### PR TITLE
storage: fix up docstring comments

### DIFF
--- a/storage/containers.go
+++ b/storage/containers.go
@@ -17,57 +17,57 @@ var (
 )
 
 // A Container is a reference to a read-write layer with a metadata string.
-// ID is either one specified at create-time or a randomly-generated value.
-// Names is an optional set of user-defined convenience values.
-// ImageID is the ID of the image which was used to create the container.
-// LayerID is the ID of the read-write layer for the container itself.
-// It is assumed that the image's top layer is the parent of the container's
-// read-write layer.
 type Container struct {
-	ID           string                 `json:"id"`
-	Names        []string               `json:"names,omitempty"`
-	ImageID      string                 `json:"image"`
-	LayerID      string                 `json:"layer"`
+	// ID is either one specified at create-time or a randomly-generated value.
+	ID string `json:"id"`
+
+	// Names is an optional set of user-defined convenience values.
+	Names []string `json:"names,omitempty"`
+
+	// ImageID is the ID of the image which was used to create the container.
+	ImageID string `json:"image"`
+
+	// LayerID is the ID of the read-write layer for the container itself.
+	// It is assumed that the image's top layer is the parent of the container's
+	// read-write layer.
+	LayerID string `json:"layer"`
+
 	Metadata     string                 `json:"metadata,omitempty"`
 	BigDataNames []string               `json:"big-data-names,omitempty"`
 	Flags        map[string]interface{} `json:"flags,omitempty"`
 }
 
 // ContainerStore provides bookkeeping for information about Containers.
-//
-// Create creates a container that has a specified ID (or a random one) and an
-// optional name, based on the specified image, using the specified layer as
-// its read-write layer.
-//
-// GetMetadata retrieves a container's metadata.
-//
-// SetMetadata replaces the metadata associated with a container with the
-// supplied value.
-//
-// Exists checks if there is a container with the given ID or name.
-//
-// Get retrieves information about a container given an ID or name.
-//
-// Delete removes the record of the container.
-//
-// Wipe removes records of all containers.
-//
-// Lookup attempts to translate a name to an ID.  Most methods do this
-// implicitly.
-//
-// Containers returns a slice enumerating the known containers.
 type ContainerStore interface {
 	FileBasedStore
 	MetadataStore
 	BigDataStore
 	FlaggableStore
+
+	// Create creates a container that has a specified ID (or a random one) and an
+	// optional name, based on the specified image, using the specified layer as
+	// its read-write layer.
 	Create(id string, names []string, image, layer, metadata string) (*Container, error)
+
 	SetNames(id string, names []string) error
+
+	// Get retrieves information about a container given an ID or name.
 	Get(id string) (*Container, error)
+
+	// Exists checks if there is a container with the given ID or name.
 	Exists(id string) bool
+
+	// Delete removes the record of the container.
 	Delete(id string) error
+
+	// Wipe removes records of all containers.
 	Wipe() error
+
+	// Lookup attempts to translate a name to an ID.  Most methods do this
+	// implicitly.
 	Lookup(name string) (string, error)
+
+	// Containers returns a slice enumerating the known containers.
 	Containers() ([]Container, error)
 }
 

--- a/storage/images.go
+++ b/storage/images.go
@@ -17,13 +17,16 @@ var (
 )
 
 // An Image is a reference to a layer and an associated metadata string.
-// ID is either one specified at import-time or a randomly-generated value.
-// Names is an optional set of user-defined convenience values.
-// TopLayer is the ID of the topmost layer of the image itself.
 type Image struct {
-	ID           string                 `json:"id"`
-	Names        []string               `json:"names,omitempty"`
-	TopLayer     string                 `json:"layer"`
+	// ID is either one specified at import-time or a randomly-generated value.
+	ID string `json:"id"`
+
+	// Names is an optional set of user-defined convenience values.
+	Names []string `json:"names,omitempty"`
+
+	// TopLayer is the ID of the topmost layer of the image itself.
+	TopLayer string `json:"layer"`
+
 	Metadata     string                 `json:"metadata,omitempty"`
 	BigDataNames []string               `json:"big-data-names,omitempty"`
 	Flags        map[string]interface{} `json:"flags,omitempty"`
@@ -31,42 +34,40 @@ type Image struct {
 
 // ImageStore provides bookkeeping for information about Images.
 //
-// Create creates an image that has a specified ID (or a random one) and an
-// optional name, using the specified layer as its topmost (hopefully
-// read-only) layer.  That layer can be referenced by multiple images.
 //
-// GetMetadata retrieves an image's metadata.
 //
-// SetMetadata replaces the metadata associated with an image with the supplied
-// value.
-//
-// SetNames replaces the list of names associated with an image with the
-// supplied values.
-//
-// Exists checks if there is an image with the given ID or name.
-//
-// Get retrieves information about an image given an ID or name.
-//
-// Delete removes the record of the image.
-//
-// Wipe removes records of all images.
-//
-// Lookup attempts to translate a name to an ID.  Most methods do this
-// implicitly.
-//
-// Images returns a slice enumerating the known images.
 type ImageStore interface {
 	FileBasedStore
 	MetadataStore
 	BigDataStore
 	FlaggableStore
+
+	// Create creates an image that has a specified ID (or a random one) and an
+	// optional name, using the specified layer as its topmost (hopefully
+	// read-only) layer.  That layer can be referenced by multiple images.
 	Create(id string, names []string, layer, metadata string) (*Image, error)
+
+	// SetNames replaces the list of names associated with an image with the
+	// supplied values.
 	SetNames(id string, names []string) error
+
+	// Exists checks if there is an image with the given ID or name.
 	Exists(id string) bool
+
+	// Get retrieves information about an image given an ID or name.
 	Get(id string) (*Image, error)
+
+	// Delete removes the record of the image.
 	Delete(id string) error
+
+	// Wipe removes records of all images.
 	Wipe() error
+
+	// Lookup attempts to translate a name to an ID.  Most methods do this
+	// implicitly.
 	Lookup(name string) (string, error)
+
+	// Images returns a slice enumerating the known images.
 	Images() ([]Image, error)
 }
 

--- a/storage/lockfile.go
+++ b/storage/lockfile.go
@@ -12,15 +12,15 @@ import (
 // A Locker represents a file lock where the file is used to cache an
 // identifier of the last party that made changes to whatever's being protected
 // by the lock.
-//
-// Touch() records, for others sharing the lock, that it was updated by the
-// caller.  It should only be called with the lock held.
-//
-// Modified() checks if the most recent writer was a party other than the
-// caller.  It should only be called with the lock held.
 type Locker interface {
 	sync.Locker
+
+	// Touch records, for others sharing the lock, that it was updated by the
+	// caller.  It should only be called with the lock held.
 	Touch() error
+
+	// Modified() checks if the most recent writer was a party other than the
+	// caller.  It should only be called with the lock held.
 	Modified() (bool, error)
 }
 


### PR DESCRIPTION
In order to make actually reading the interfaces easier (as well as
making godoc actually useful), we need to comment the interface methods
themselves rather than the whole interface.

Signed-off-by: Aleksa Sarai <asarai@suse.de>