### PR TITLE
Rename "DevmapperLogCallback" to avoid conflicts

### DIFF
--- a/pkg/devicemapper/devmapper_log.go
+++ b/pkg/devicemapper/devmapper_log.go
@@ -11,9 +11,9 @@ import (
 // Due to the way cgo works this has to be in a separate file, as devmapper.go has
 // definitions in the cgo block, which is incompatible with using "//export"
 
-// DevmapperLogCallback exports the devmapper log callback for cgo.
-//export DevmapperLogCallback
-func DevmapperLogCallback(level C.int, file *C.char, line C.int, dmErrnoOrClass C.int, message *C.char) {
+// StorageDevmapperLogCallback exports the devmapper log callback for cgo.
+//export StorageDevmapperLogCallback
+func StorageDevmapperLogCallback(level C.int, file *C.char, line C.int, dmErrnoOrClass C.int, message *C.char) {
 	msg := C.GoString(message)
 	if level < 7 {
 		if strings.Contains(msg, "busy") {

--- a/pkg/devicemapper/devmapper_wrapper.go
+++ b/pkg/devicemapper/devmapper_wrapper.go
@@ -8,7 +8,7 @@ package devicemapper
 #include <linux/fs.h>   // FIXME: present only for BLKGETSIZE64, maybe we can remove it?
 
 // FIXME: Can't we find a way to do the logging in pure Go?
-extern void DevmapperLogCallback(int level, char *file, int line, int dm_errno_or_class, char *str);
+extern void StorageDevmapperLogCallback(int level, char *file, int line, int dm_errno_or_class, char *str);
 
 static void	log_cb(int level, const char *file, int line, int dm_errno_or_class, const char *f, ...)
 {
@@ -19,7 +19,7 @@ static void	log_cb(int level, const char *file, int line, int dm_errno_or_class,
   vsnprintf(buffer, 256, f, ap);
   va_end(ap);
 
-  DevmapperLogCallback(level, (char *)file, line, dm_errno_or_class, buffer);
+  StorageDevmapperLogCallback(level, (char *)file, line, dm_errno_or_class, buffer);
 }
 
 static void	log_with_errno_init()


### PR DESCRIPTION
Rename the "DevmapperLogCallback" exported-to-C function to "StorageDevmapperLogCallback", to avoid tripping up anyone who vendors the library but already has a copy of the "pkg/devicemapper" pkg which defines the callback with its previous name.