### PR TITLE
Remove "docker" strings from container storage

### DIFF
--- a/drivers/aufs/aufs.go
+++ b/drivers/aufs/aufs.go
@@ -279,7 +279,7 @@ func (a *Driver) Remove(id string) error {
 	}
 
 	// Atomically remove each directory in turn by first moving it out of the
-	// way (so that docker doesn't find it anymore) before doing removal of
+	// way (so that container runtimes don't find it anymore) before doing removal of
 	// the whole tree.
 	tmpMntPath := path.Join(a.mntPath(), fmt.Sprintf("%s-removing", id))
 	if err := os.Rename(mountpoint, tmpMntPath); err != nil && !os.IsNotExist(err) {
@@ -559,14 +559,14 @@ func (a *Driver) aufsMount(ro []string, rw, target, mountLabel string) (err erro
 // version of aufs.
 func useDirperm() bool {
 	enableDirpermLock.Do(func() {
-		base, err := ioutil.TempDir("", "docker-aufs-base")
+		base, err := ioutil.TempDir("", "storage-aufs-base")
 		if err != nil {
 			logrus.Errorf("error checking dirperm1: %v", err)
 			return
 		}
 		defer os.RemoveAll(base)
 
-		union, err := ioutil.TempDir("", "docker-aufs-union")
+		union, err := ioutil.TempDir("", "storage-aufs-union")
 		if err != nil {
 			logrus.Errorf("error checking dirperm1: %v", err)
 			return

--- a/drivers/aufs/aufs_test.go
+++ b/drivers/aufs/aufs_test.go
@@ -311,7 +311,7 @@ func TestCreateWithInvalidParent(t *testing.T) {
 	d := newDriver(t)
 	defer os.RemoveAll(tmp)
 
-	if err := d.Create("1", "docker", "", nil); err == nil {
+	if err := d.Create("1", "storage", "", nil); err == nil {
 		t.Fatalf("Error should not be nil with parent does not exist")
 	}
 }

--- a/drivers/devmapper/deviceset.go
+++ b/drivers/devmapper/deviceset.go
@@ -1135,7 +1135,7 @@ func (devices *DeviceSet) growFS(info *devInfo) error {
 
 	defer devices.deactivateDevice(info)
 
-	fsMountPoint := "/run/docker/mnt"
+	fsMountPoint := "/run/containers/mnt"
 	if _, err := os.Stat(fsMountPoint); os.IsNotExist(err) {
 		if err := os.MkdirAll(fsMountPoint, 0700); err != nil {
 			return err
@@ -1693,7 +1693,7 @@ func (devices *DeviceSet) initDevmapper(doInit bool) error {
 		return err
 	}
 
-	// Set the device prefix from the device id and inode of the docker root dir
+	// Set the device prefix from the device id and inode of the container root dir
 
 	st, err := os.Stat(devices.root)
 	if err != nil {
@@ -1702,11 +1702,11 @@ func (devices *DeviceSet) initDevmapper(doInit bool) error {
 	sysSt := st.Sys().(*syscall.Stat_t)
 	// "reg-" stands for "regular file".
 	// In the future we might use "dev-" for "device file", etc.
-	// docker-maj,min[-inode] stands for:
-	//	- Managed by docker
+	// container-maj,min[-inode] stands for:
+	//	- Managed by container storage
 	//	- The target of this device is at major <maj> and minor <min>
 	//	- If <inode> is defined, use that file inside the device as a loopback image. Otherwise use the device itself.
-	devices.devicePrefix = fmt.Sprintf("docker-%d:%d-%d", major(sysSt.Dev), minor(sysSt.Dev), sysSt.Ino)
+	devices.devicePrefix = fmt.Sprintf("container-%d:%d-%d", major(sysSt.Dev), minor(sysSt.Dev), sysSt.Ino)
 	logrus.Debugf("devmapper: Generated prefix: %s", devices.devicePrefix)
 
 	// Check for the existence of the thin-pool device
@@ -1826,7 +1826,7 @@ func (devices *DeviceSet) initDevmapper(doInit bool) error {
 
 	if devices.thinPoolDevice == "" {
 		if devices.metadataLoopFile != "" || devices.dataLoopFile != "" {
-			logrus.Warn("devmapper: Usage of loopback devices is strongly discouraged for production use. Please use `--storage-opt dm.thinpooldev` or use `man docker` to refer to dm.thinpooldev section.")
+			logrus.Warn("devmapper: Usage of loopback devices is strongly discouraged for production use. Please use `--storage-opt dm.thinpooldev`.")
 		}
 	}
 

--- a/drivers/graphtest/graphtest_unix.go
+++ b/drivers/graphtest/graphtest_unix.go
@@ -32,7 +32,7 @@ type Driver struct {
 }
 
 func newDriver(t testing.TB, name string, options []string) *Driver {
-	root, err := ioutil.TempDir("", "docker-graphtest-")
+	root, err := ioutil.TempDir("", "storage-graphtest-")
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/drivers/overlay2/mount.go
+++ b/drivers/overlay2/mount.go
@@ -15,7 +15,7 @@ import (
 )
 
 func init() {
-	reexec.Register("docker-mountfrom", mountFromMain)
+	reexec.Register("storage-mountfrom", mountFromMain)
 }
 
 func fatal(err error) {
@@ -40,7 +40,7 @@ func mountFrom(dir, device, target, mType, label string) error {
 		Label:  label,
 	}
 
-	cmd := reexec.Command("docker-mountfrom", dir)
+	cmd := reexec.Command("storage-mountfrom", dir)
 	w, err := cmd.StdinPipe()
 	if err != nil {
 		return fmt.Errorf("mountfrom error on pipe creation: %v", err)
@@ -65,7 +65,7 @@ func mountFrom(dir, device, target, mType, label string) error {
 	return nil
 }
 
-// mountfromMain is the entry-point for docker-mountfrom on re-exec.
+// mountfromMain is the entry-point for storage-mountfrom on re-exec.
 func mountFromMain() {
 	runtime.LockOSThread()
 	flag.Parse()

--- a/drivers/windows/windows.go
+++ b/drivers/windows/windows.go
@@ -39,7 +39,7 @@ const filterDriver = 1
 // init registers the windows graph drivers to the register.
 func init() {
 	graphdriver.Register("windowsfilter", InitFilter)
-	reexec.Register("docker-windows-write-layer", writeLayer)
+	reexec.Register("storage-windows-write-layer", writeLayer)
 }
 
 type checker struct {
@@ -614,7 +614,7 @@ func addAceToSddlDacl(sddl, ace string) (string, bool) {
 
 // importLayer adds a new layer to the tag and graph store based on the given data.
 func (d *Driver) importLayer(id string, layerData archive.Reader, parentLayerPaths []string) (size int64, err error) {
-	cmd := reexec.Command(append([]string{"docker-windows-write-layer", d.info.HomeDir, id}, parentLayerPaths...)...)
+	cmd := reexec.Command(append([]string{"storage-windows-write-layer", d.info.HomeDir, id}, parentLayerPaths...)...)
 	output := bytes.NewBuffer(nil)
 	cmd.Stdin = layerData
 	cmd.Stdout = output

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -220,7 +220,7 @@ func CompressStream(dest io.Writer, compression Compression) (io.WriteCloser, er
 		return writeBufWrapper, nil
 	case Bzip2, Xz:
 		// archive/bzip2 does not support writing, and there is no xz support at all
-		// However, this is not a problem as docker only currently generates gzipped tars
+		// However, this is not a problem as we only currently generates gzipped tars
 		return nil, fmt.Errorf("Unsupported compression format %s", (&compression).Extension())
 	default:
 		return nil, fmt.Errorf("Unsupported compression format %s", (&compression).Extension())

--- a/pkg/archive/diff.go
+++ b/pkg/archive/diff.go
@@ -106,7 +106,7 @@ func UnpackLayer(dest string, layer Reader, options *TarOptions) (size int64, er
 				basename := filepath.Base(hdr.Name)
 				aufsHardlinks[basename] = hdr
 				if aufsTempdir == "" {
-					if aufsTempdir, err = ioutil.TempDir("", "dockerplnk"); err != nil {
+					if aufsTempdir, err = ioutil.TempDir("", "storageplnk"); err != nil {
 						return 0, err
 					}
 					defer os.RemoveAll(aufsTempdir)

--- a/pkg/archive/example_changes.go
+++ b/pkg/archive/example_changes.go
@@ -39,7 +39,7 @@ func main() {
 
 	if len(*flNewDir) == 0 {
 		var err error
-		newDir, err = ioutil.TempDir("", "docker-test-newDir")
+		newDir, err = ioutil.TempDir("", "storage-test-newDir")
 		if err != nil {
 			log.Fatal(err)
 		}
@@ -52,7 +52,7 @@ func main() {
 	}
 
 	if len(*flOldDir) == 0 {
-		oldDir, err := ioutil.TempDir("", "docker-test-oldDir")
+		oldDir, err := ioutil.TempDir("", "storage-test-oldDir")
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/pkg/chrootarchive/archive_unix.go
+++ b/pkg/chrootarchive/archive_unix.go
@@ -16,7 +16,7 @@ import (
 	"github.com/containers/storage/pkg/reexec"
 )
 
-// untar is the entry-point for docker-untar on re-exec. This is not used on
+// untar is the entry-point for storage-untar on re-exec. This is not used on
 // Windows as it does not support chroot, hence no point sandboxing through
 // chroot and rexec.
 func untar() {
@@ -57,7 +57,7 @@ func invokeUnpack(decompressedArchive io.Reader, dest string, options *archive.T
 		return fmt.Errorf("Untar pipe failure: %v", err)
 	}
 
-	cmd := reexec.Command("docker-untar", dest)
+	cmd := reexec.Command("storage-untar", dest)
 	cmd.Stdin = decompressedArchive
 
 	cmd.ExtraFiles = append(cmd.ExtraFiles, r)
@@ -75,7 +75,7 @@ func invokeUnpack(decompressedArchive io.Reader, dest string, options *archive.T
 	w.Close()
 
 	if err := cmd.Wait(); err != nil {
-		// when `xz -d -c -q | docker-untar ...` failed on docker-untar side,
+		// when `xz -d -c -q | storage-untar ...` failed on storage-untar side,
 		// we need to exhaust `xz`'s output, otherwise the `xz` side will be
 		// pending on write pipe forever
 		io.Copy(ioutil.Discard, decompressedArchive)

--- a/pkg/chrootarchive/diff_unix.go
+++ b/pkg/chrootarchive/diff_unix.go
@@ -21,7 +21,7 @@ type applyLayerResponse struct {
 	LayerSize int64 `json:"layerSize"`
 }
 
-// applyLayer is the entry-point for docker-applylayer on re-exec. This is not
+// applyLayer is the entry-point for storage-applylayer on re-exec. This is not
 // used on Windows as it does not support chroot, hence no point sandboxing
 // through chroot and rexec.
 func applyLayer() {
@@ -49,7 +49,7 @@ func applyLayer() {
 		fatal(err)
 	}
 
-	if tmpDir, err = ioutil.TempDir("/", "temp-docker-extract"); err != nil {
+	if tmpDir, err = ioutil.TempDir("/", "temp-storage-extract"); err != nil {
 		fatal(err)
 	}
 
@@ -98,7 +98,7 @@ func applyLayerHandler(dest string, layer archive.Reader, options *archive.TarOp
 		return 0, fmt.Errorf("ApplyLayer json encode: %v", err)
 	}
 
-	cmd := reexec.Command("docker-applyLayer", dest)
+	cmd := reexec.Command("storage-applyLayer", dest)
 	cmd.Stdin = layer
 	cmd.Env = append(cmd.Env, fmt.Sprintf("OPT=%s", data))
 

--- a/pkg/chrootarchive/diff_windows.go
+++ b/pkg/chrootarchive/diff_windows.go
@@ -29,9 +29,9 @@ func applyLayerHandler(dest string, layer archive.Reader, options *archive.TarOp
 		layer = decompressed
 	}
 
-	tmpDir, err := ioutil.TempDir(os.Getenv("temp"), "temp-docker-extract")
+	tmpDir, err := ioutil.TempDir(os.Getenv("temp"), "temp-storage-extract")
 	if err != nil {
-		return 0, fmt.Errorf("ApplyLayer failed to create temp-docker-extract under %s. %s", dest, err)
+		return 0, fmt.Errorf("ApplyLayer failed to create temp-storage-extract under %s. %s", dest, err)
 	}
 
 	s, err := archive.UnpackLayer(dest, layer, nil)

--- a/pkg/chrootarchive/init_unix.go
+++ b/pkg/chrootarchive/init_unix.go
@@ -12,8 +12,8 @@ import (
 )
 
 func init() {
-	reexec.Register("docker-applyLayer", applyLayer)
-	reexec.Register("docker-untar", untar)
+	reexec.Register("storage-applyLayer", applyLayer)
+	reexec.Register("storage-untar", untar)
 }
 
 func fatal(err error) {


### PR DESCRIPTION
We want to make sure that content created out of container storage
does not refer to docker.