### PR TITLE
Add initial Travis configuration

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,17 @@
+language: go
+go:
+    - tip
+    - 1.7
+    - 1.6
+dist: trusty
+sudo: required
+before_install:
+    - sudo apt-get -qq update
+    - sudo apt-get -qq install btrfs-tools libdevmapper-dev
+script:
+    - AUTO_GOPATH=1 make install.tools
+    - AUTO_GOPATH=1 ./hack/make.sh validate-gofmt validate-pkg validate-lint validate-test validate-toml validate-vet validate-vendor
+    - AUTO_GOPATH=1 make .gitvalidation
+    - AUTO_GOPATH=1 make build-binary
+    - sudo env AUTO_GOPATH=1 PATH="$PATH" ./hack/make.sh test-unit
+    - AUTO_GOPATH=1 make docs

--- a/hack/make/test-unit
+++ b/hack/make/test-unit
@@ -42,7 +42,7 @@ bundle_test_unit() {
 		done
 		echo $deps
 	)
-	go test $COVER $GCCGOFLAGS -ldflags "$LDFLAGS" "${BUILDFLAGS[@]}" $TESTFLAGS $pkg_list
+	go test $COVER $GCCGOFLAGS -ldflags "$LDFLAGS" "${BUILDFLAGS[@]}" ${BUILDTAGS:+-tags "${BUILDTAGS}"} $TESTFLAGS $pkg_list
 }
 
 


### PR DESCRIPTION
Add an initial Travis configuration file, and whatever fixups and tweaks we need to build in it.  This doesn't enable every test (`make lint` would fail, and integration tests are missing), but it's a start.