### PR TITLE
Prefer overlay2/overlay over devicemapper

### DIFF
--- a/drivers/driver_linux.go
+++ b/drivers/driver_linux.go
@@ -56,8 +56,9 @@ var (
 		"aufs",
 		"btrfs",
 		"zfs",
-		"devicemapper",
+		"overlay2",
 		"overlay",
+		"devicemapper",
 		"vfs",
 	}
 


### PR DESCRIPTION
It looks like overlay is going to be generally preferred over devicemapper once its SELinux support is figured out, so alter our preferences list for Linux to prefer it.