### PR TITLE
Rewrite build tags so they are no longer required

### DIFF
--- a/drivers/btrfs/version.go
+++ b/drivers/btrfs/version.go
@@ -1,4 +1,4 @@
-// +build linux,!btrfs_noversion
+// +build linux,btrfs_version
 
 package btrfs
 

--- a/drivers/btrfs/version_none.go
+++ b/drivers/btrfs/version_none.go
@@ -1,4 +1,4 @@
-// +build linux,btrfs_noversion
+// +build linux,!btrfs_version
 
 package btrfs
 

--- a/drivers/btrfs/version_test.go
+++ b/drivers/btrfs/version_test.go
@@ -1,4 +1,4 @@
-// +build linux,!btrfs_noversion
+// +build linux,btrfs_version
 
 package btrfs
 

--- a/hack/make.sh
+++ b/hack/make.sh
@@ -91,21 +91,21 @@ if [ "$EXPERIMENTAL" ]; then
 	BUILDTAGS+=" experimental"
 fi
 
-# test whether "btrfs/version.h" exists and apply btrfs_noversion appropriately
+# test whether "btrfs/version.h" exists and apply btrfs_version appropriately
 if \
 	command -v gcc &> /dev/null \
-	&& ! gcc -E - -o /dev/null &> /dev/null <<<'#include <btrfs/version.h>' \
+	&& gcc -E - -o /dev/null &> /dev/null <<<'#include <btrfs/version.h>' \
 ; then
-	BUILDTAGS+=' btrfs_noversion'
+	BUILDTAGS+=' btrfs_version'
 fi
 
 # test whether "libdevmapper.h" is new enough to support deferred remove
 # functionality.
 if \
 	command -v gcc &> /dev/null \
-	&& ! ( echo -e  '#include <libdevmapper.h>\nint main() { dm_task_deferred_remove(NULL); }'| gcc -xc - -o /dev/null -ldevmapper &> /dev/null ) \
+	&& ( echo -e  '#include <libdevmapper.h>\nint main() { dm_task_deferred_remove(NULL); }'| gcc -xc - -o /dev/null -ldevmapper &> /dev/null ) \
 ; then
-       BUILDTAGS+=' libdm_no_deferred_remove'
+       BUILDTAGS+=' libdm_deferred_remove'
 fi
 
 # Use these flags when compiling the tests and final binary

--- a/pkg/devicemapper/devmapper_wrapper_deferred_remove.go
+++ b/pkg/devicemapper/devmapper_wrapper_deferred_remove.go
@@ -1,4 +1,4 @@
-// +build linux,!libdm_no_deferred_remove
+// +build linux,libdm_deferred_remove
 
 package devicemapper
 

--- a/pkg/devicemapper/devmapper_wrapper_no_deferred_remove.go
+++ b/pkg/devicemapper/devmapper_wrapper_no_deferred_remove.go
@@ -1,8 +1,8 @@
-// +build linux,libdm_no_deferred_remove
+// +build linux,!libdm_deferred_remove
 
 package devicemapper
 
-// LibraryDeferredRemovalsupport is not supported when statically linked.
+// LibraryDeferredRemovalSupport is not supported when statically linked.
 const LibraryDeferredRemovalSupport = false
 
 func dmTaskDeferredRemoveFct(task *cdmTask) int {


### PR DESCRIPTION
This rewrites btrfs_noversion to btrfs_version and
libdm_no_deferred_remove to libdm_deferred_remove. This allows many
systems to compile without build tags; the current situation is that
most hosts require the build tags and very few do not.

This eliminates the dependency in containers/image and my own project (erikh/box). These tools should be able to `go build` now without specifying tags and get no compile errors on platforms that have the dependencies installed, even if they are outdated.