### PR TITLE
Modify default directories for storage to /var/lib/containers/storage

### DIFF
--- a/storage/store.go
+++ b/storage/store.go
@@ -2171,8 +2171,8 @@ func makeBigDataBaseName(key string) string {
 }
 
 func init() {
-	DefaultStoreOptions.RunRoot = "/var/run/containers"
-	DefaultStoreOptions.GraphRoot = "/var/lib/containers"
+	DefaultStoreOptions.RunRoot = "/var/run/containers/storage"
+	DefaultStoreOptions.GraphRoot = "/var/lib/containers/storage"
 	DefaultStoreOptions.GraphDriverName = os.Getenv("STORAGE_DRIVER")
 	DefaultStoreOptions.GraphDriverOptions = strings.Split(os.Getenv("STORAGE_OPTS"), ",")
 	if len(DefaultStoreOptions.GraphDriverOptions) == 1 && DefaultStoreOptions.GraphDriverOptions[0] == "" {


### PR DESCRIPTION
Also modify work directory to /var/run/containers/storage to be consistent.
/var/lib/containers/atomic is currently being used by other tools including the
atomic cli for storing OSTree based containers.  Running tools like CRI-O
ends up dropping lots of files in /var/lib/containers directory causing an
admin to get perhaps confused.  Since this tool is containers/storage, I think
it is best we store it in this subdir, and cleaner for administrators.