### PR TITLE
Ensure directories are there before saving stores

### DIFF
--- a/storage/containers.go
+++ b/storage/containers.go
@@ -151,6 +151,9 @@ func (r *containerStore) Load() error {
 
 func (r *containerStore) Save() error {
 	rpath := r.containerspath()
+	if err := os.MkdirAll(filepath.Dir(rpath), 0700); err != nil {
+		return err
+	}
 	jdata, err := json.Marshal(&r.containers)
 	if err != nil {
 		return err

--- a/storage/images.go
+++ b/storage/images.go
@@ -142,6 +142,9 @@ func (r *imageStore) Load() error {
 
 func (r *imageStore) Save() error {
 	rpath := r.imagespath()
+	if err := os.MkdirAll(filepath.Dir(rpath), 0700); err != nil {
+		return err
+	}
 	jdata, err := json.Marshal(&r.images)
 	if err != nil {
 		return err

--- a/storage/layers.go
+++ b/storage/layers.go
@@ -252,11 +252,17 @@ func (r *layerStore) Load() error {
 
 func (r *layerStore) Save() error {
 	rpath := r.layerspath()
+	if err := os.MkdirAll(filepath.Dir(rpath), 0700); err != nil {
+		return err
+	}
 	jldata, err := json.Marshal(&r.layers)
 	if err != nil {
 		return err
 	}
 	mpath := r.mountspath()
+	if err := os.MkdirAll(filepath.Dir(mpath), 0700); err != nil {
+		return err
+	}
 	mounts := []layerMountPoint{}
 	for _, layer := range r.layers {
 		if layer.MountPoint != "" && layer.MountCount > 0 {
@@ -846,6 +852,9 @@ func (r *layerStore) ApplyDiff(to string, diff archive.Reader) (size int64, err 
 	size, err = r.driver.ApplyDiff(layer.ID, layer.Parent, payload)
 	compressor.Close()
 	if err == nil {
+		if err := os.MkdirAll(filepath.Dir(r.tspath(layer.ID)), 0700); err != nil {
+			return -1, err
+		}
 		if err := ioutils.AtomicWriteFile(r.tspath(layer.ID), tsdata.Bytes(), 0600); err != nil {
 			return -1, err
 		}


### PR DESCRIPTION
Ensure that the containing directories are there before we call `AtomicWriteFile` to save the lists of containers, images, or layers, each time we go to do so.  Samuel Ortiz noticed that we weren't making sure of this everywhere, and that this can trip up long-running processes.