### PR TITLE
Switch to using opencontainers/selinux

### DIFF
--- a/drivers/aufs/aufs.go
+++ b/drivers/aufs/aufs.go
@@ -45,8 +45,8 @@ import (
 	mountpk "github.com/containers/storage/pkg/mount"
 	"github.com/containers/storage/pkg/stringid"
 
-	"github.com/opencontainers/runc/libcontainer/label"
 	rsystem "github.com/opencontainers/runc/libcontainer/system"
+	"github.com/opencontainers/selinux/go-selinux/label"
 )
 
 var (

--- a/drivers/btrfs/btrfs.go
+++ b/drivers/btrfs/btrfs.go
@@ -28,7 +28,7 @@ import (
 	"github.com/containers/storage/pkg/mount"
 	"github.com/containers/storage/pkg/parsers"
 	"github.com/docker/go-units"
-	"github.com/opencontainers/runc/libcontainer/label"
+	"github.com/opencontainers/selinux/go-selinux/label"
 )
 
 func init() {

--- a/drivers/devmapper/deviceset.go
+++ b/drivers/devmapper/deviceset.go
@@ -2569,7 +2569,7 @@ func NewDeviceSet(root string, doInit bool, options []string, uidMaps, gidMaps [
 			devices.metaDataLoopbackSize = size
 		case "dm.fs":
 			if val != "ext4" && val != "xfs" {
-				return nil, fmt.Errorf("devmapper: Unsupported filesystem %s\n", val)
+				return nil, fmt.Errorf("devmapper: Unsupported filesystem %s", val)
 			}
 			devices.filesystem = val
 		case "dm.mkfsarg":
@@ -2631,9 +2631,9 @@ func NewDeviceSet(root string, doInit bool, options []string, uidMaps, gidMaps [
 			devices.minFreeSpacePercent = uint32(minFreeSpacePercent)
 		default:
 			if nthOption > len(defaults) {
-				return nil, fmt.Errorf("devmapper: Unknown option %s\n", key)
+				return nil, fmt.Errorf("devmapper: Unknown option %s", key)
 			}
-			logrus.Errorf("devmapper: Unknown option %s, ignoring\n", key)
+			logrus.Errorf("devmapper: Unknown option %s, ignoring", key)
 		}
 		settings[key] = val
 	}

--- a/drivers/devmapper/deviceset.go
+++ b/drivers/devmapper/deviceset.go
@@ -31,7 +31,7 @@ import (
 	"github.com/containers/storage/storageversion"
 	"github.com/docker/go-units"
 
-	"github.com/opencontainers/runc/libcontainer/label"
+	"github.com/opencontainers/selinux/go-selinux/label"
 )
 
 var (

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -18,7 +18,7 @@ import (
 	"github.com/containers/storage/pkg/idtools"
 
 	"github.com/containers/storage/pkg/mount"
-	"github.com/opencontainers/runc/libcontainer/label"
+	"github.com/opencontainers/selinux/go-selinux/label"
 )
 
 // This is a small wrapper over the NaiveDiffWriter that lets us have a custom

--- a/drivers/overlay2/overlay.go
+++ b/drivers/overlay2/overlay.go
@@ -172,7 +172,7 @@ func parseOptions(options []string) (*overlayOptions, error) {
 				return nil, err
 			}
 		default:
-			return nil, fmt.Errorf("overlay2: Unknown option %s\n", key)
+			return nil, fmt.Errorf("overlay2: Unknown option %s", key)
 		}
 	}
 	return o, nil

--- a/drivers/overlay2/overlay.go
+++ b/drivers/overlay2/overlay.go
@@ -25,7 +25,7 @@ import (
 	"github.com/containers/storage/pkg/parsers"
 	"github.com/containers/storage/pkg/parsers/kernel"
 
-	"github.com/opencontainers/runc/libcontainer/label"
+	"github.com/opencontainers/selinux/go-selinux/label"
 )
 
 var (

--- a/drivers/vfs/driver.go
+++ b/drivers/vfs/driver.go
@@ -9,7 +9,7 @@ import (
 	"github.com/containers/storage/pkg/chrootarchive"
 	"github.com/containers/storage/pkg/idtools"
 
-	"github.com/opencontainers/runc/libcontainer/label"
+	"github.com/opencontainers/selinux/go-selinux/label"
 )
 
 var (

--- a/drivers/zfs/zfs.go
+++ b/drivers/zfs/zfs.go
@@ -19,7 +19,7 @@ import (
 	"github.com/containers/storage/pkg/mount"
 	"github.com/containers/storage/pkg/parsers"
 	zfs "github.com/mistifyio/go-zfs"
-	"github.com/opencontainers/runc/libcontainer/label"
+	"github.com/opencontainers/selinux/go-selinux/label"
 )
 
 type zfsOptions struct {

--- a/vendor.conf
+++ b/vendor.conf
@@ -8,6 +8,7 @@ github.com/go-check/check 20d25e2804050c1cd24a7eea1e7a6447dd0e74ec
 github.com/mattn/go-shellwords 753a2322a99f87c0eff284980e77f53041555bc6
 github.com/mistifyio/go-zfs c0224de804d438efd11ea6e52ada8014537d6062
 github.com/opencontainers/runc 6c22e77604689db8725fa866f0f2ec0b3e8c3a07
+github.com/opencontainers/selinux ba1aefe8057f1d0cfb8e88d0ec1dc85925ef987d
 github.com/pborman/uuid 1b00554d822231195d1babd97ff4a781231955c9
 github.com/vbatts/tar-split bd4c5d64c3e9297f410025a3b1bd0c58f659e721
 github.com/vdemeester/shakers 24d7f1d6a71aa5d9cbe7390e4afb66b7eef9e1b3

--- a/vendor/github.com/opencontainers/selinux/LICENSE
+++ b/vendor/github.com/opencontainers/selinux/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "{}"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright {yyyy} {name of copyright owner}
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/opencontainers/selinux/README.md
+++ b/vendor/github.com/opencontainers/selinux/README.md
@@ -1,0 +1,7 @@
+# selinux
+
+[![GoDoc](https://godoc.org/github.com/opencontainers/selinux?status.svg)](https://godoc.org/github.com/opencontainers/selinux) [![Go Report Card](https://goreportcard.com/badge/github.com/opencontainers/selinux)](https://goreportcard.com/report/github.com/opencontainers/selinux) [![Build Status](https://travis-ci.org/opencontainers/selinux.svg?branch=master)](https://travis-ci.org/opencontainers/selinux)
+
+Common SELinux package used across the container ecosystem.
+
+Please see the [godoc](https://godoc.org/github.com/opencontainers/selinux) for more information.

--- a/vendor/github.com/opencontainers/selinux/go-selinux/label/label.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/label/label.go
@@ -52,7 +52,7 @@ func ReserveLabel(label string) error {
 	return nil
 }
 
-func UnreserveLabel(label string) error {
+func ReleaseLabel(label string) error {
 	return nil
 }
 

--- a/vendor/github.com/opencontainers/selinux/go-selinux/selinux.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/selinux.go
@@ -15,13 +15,14 @@ import (
 	"strings"
 	"sync"
 	"syscall"
-
-	"github.com/opencontainers/runc/libcontainer/system"
 )
 
 const (
-	Enforcing        = 1
-	Permissive       = 0
+	// Enforcing constant indicate SELinux is in enforcing mode
+	Enforcing = 1
+	// Permissive constant to indicate SELinux is in permissive mode
+	Permissive = 0
+	// Disabled constant to indicate SELinux is disabled
 	Disabled         = -1
 	selinuxDir       = "/etc/selinux/"
 	selinuxConfig    = selinuxDir + "config"
@@ -48,7 +49,8 @@ var (
 	}
 )
 
-type SELinuxContext map[string]string
+// Context is a representation of the SELinux label broken into 4 parts
+type Context map[string]string
 
 func (s *selinuxState) setEnable(enabled bool) bool {
 	s.Lock()
@@ -69,7 +71,7 @@ func (s *selinuxState) getEnabled() bool {
 
 	enabled = false
 	if fs := getSelinuxMountPoint(); fs != "" {
-		if con, _ := Getcon(); con != "kernel" {
+		if con, _ := CurrentLabel(); con != "kernel" {
 			enabled = true
 		}
 	}
@@ -143,8 +145,8 @@ func getSelinuxMountPoint() string {
 	return state.getSELinuxfs()
 }
 
-// SelinuxEnabled returns whether selinux is currently enabled.
-func SelinuxEnabled() bool {
+// GetEnabled returns whether selinux is currently enabled.
+func GetEnabled() bool {
 	return state.getEnabled()
 }
 
@@ -206,43 +208,55 @@ func readCon(name string) (string, error) {
 	return val, err
 }
 
-// Setfilecon sets the SELinux label for this path or returns an error.
-func Setfilecon(path string, scon string) error {
-	return system.Lsetxattr(path, xattrNameSelinux, []byte(scon), 0)
+// SetFileLabel sets the SELinux label for this path or returns an error.
+func SetFileLabel(path string, label string) error {
+	return lsetxattr(path, xattrNameSelinux, []byte(label), 0)
 }
 
-// Getfilecon returns the SELinux label for this path or returns an error.
-func Getfilecon(path string) (string, error) {
-	con, err := system.Lgetxattr(path, xattrNameSelinux)
+// Filecon returns the SELinux label for this path or returns an error.
+func FileLabel(path string) (string, error) {
+	label, err := lgetxattr(path, xattrNameSelinux)
 	if err != nil {
 		return "", err
 	}
 	// Trim the NUL byte at the end of the byte buffer, if present.
-	if len(con) > 0 && con[len(con)-1] == '\x00' {
-		con = con[:len(con)-1]
+	if len(label) > 0 && label[len(label)-1] == '\x00' {
+		label = label[:len(label)-1]
 	}
-	return string(con), nil
+	return string(label), nil
 }
 
-func Setfscreatecon(scon string) error {
-	return writeCon(fmt.Sprintf("/proc/self/task/%d/attr/fscreate", syscall.Gettid()), scon)
+/*
+SetFSCreateLabel tells kernel the label to create all file system objects
+created by this task. Setting label="" to return to default.
+*/
+func SetFSCreateLabel(label string) error {
+	return writeCon(fmt.Sprintf("/proc/self/task/%d/attr/fscreate", syscall.Gettid()), label)
 }
 
-func Getfscreatecon() (string, error) {
+/*
+FSCreateLabel returns the default label the kernel which the kernel is using
+for file system objects created by this task. "" indicates default.
+*/
+func FSCreateLabel() (string, error) {
 	return readCon(fmt.Sprintf("/proc/self/task/%d/attr/fscreate", syscall.Gettid()))
 }
 
-// Getcon returns the SELinux label of the current process thread, or an error.
-func Getcon() (string, error) {
+// CurrentLabel returns the SELinux label of the current process thread, or an error.
+func CurrentLabel() (string, error) {
 	return readCon(fmt.Sprintf("/proc/self/task/%d/attr/current", syscall.Gettid()))
 }
 
-// Getpidcon returns the SELinux label of the given pid, or an error.
-func Getpidcon(pid int) (string, error) {
+// PidLabel returns the SELinux label of the given pid, or an error.
+func PidLabel(pid int) (string, error) {
 	return readCon(fmt.Sprintf("/proc/%d/attr/current", pid))
 }
 
-func Getexeccon() (string, error) {
+/*
+ExecLabel returns the SELinux label that the kernel will use for any programs
+that are executed by the current process thread, or an error.
+*/
+func ExecLabel() (string, error) {
 	return readCon(fmt.Sprintf("/proc/self/task/%d/attr/exec", syscall.Gettid()))
 }
 
@@ -261,19 +275,25 @@ func writeCon(name string, val string) error {
 	return err
 }
 
-func Setexeccon(scon string) error {
-	return writeCon(fmt.Sprintf("/proc/self/task/%d/attr/exec", syscall.Gettid()), scon)
+/*
+SetExecLabel sets the SELinux label that the kernel will use for any programs
+that are executed by the current process thread, or an error.
+*/
+func SetExecLabel(label string) error {
+	return writeCon(fmt.Sprintf("/proc/self/task/%d/attr/exec", syscall.Gettid()), label)
 }
 
-func (c SELinuxContext) Get() string {
+// Get returns the Context as a string
+func (c Context) Get() string {
 	return fmt.Sprintf("%s:%s:%s:%s", c["user"], c["role"], c["type"], c["level"])
 }
 
-func NewContext(scon string) SELinuxContext {
-	c := make(SELinuxContext)
+// NewContext creates a new Context struct from the specified label
+func NewContext(label string) Context {
+	c := make(Context)
 
-	if len(scon) != 0 {
-		con := strings.SplitN(scon, ":", 4)
+	if len(label) != 0 {
+		con := strings.SplitN(label, ":", 4)
 		c["user"] = con[0]
 		c["role"] = con[1]
 		c["type"] = con[2]
@@ -282,9 +302,10 @@ func NewContext(scon string) SELinuxContext {
 	return c
 }
 
-func ReserveLabel(scon string) {
-	if len(scon) != 0 {
-		con := strings.SplitN(scon, ":", 4)
+// ReserveLabel reserves the MLS/MCS level component of the specified label
+func ReserveLabel(label string) {
+	if len(label) != 0 {
+		con := strings.SplitN(label, ":", 4)
 		mcsAdd(con[3])
 	}
 }
@@ -293,7 +314,8 @@ func selinuxEnforcePath() string {
 	return fmt.Sprintf("%s/enforce", selinuxPath)
 }
 
-func SelinuxGetEnforce() int {
+// EnforceMode returns the current SELinux mode Enforcing, Permissive, Disabled
+func EnforceMode() int {
 	var enforce int
 
 	enforceS, err := readCon(selinuxEnforcePath())
@@ -308,11 +330,20 @@ func SelinuxGetEnforce() int {
 	return enforce
 }
 
-func SelinuxSetEnforce(mode int) error {
+/*
+SetEnforce sets the current SELinux mode Enforcing, Permissive.
+Disabled is not valid, since this needs to be set at boot time.
+*/
+func SetEnforceMode(mode int) error {
 	return writeCon(selinuxEnforcePath(), fmt.Sprintf("%d", mode))
 }
 
-func SelinuxGetEnforceMode() int {
+/*
+DefaultEnforceMode returns the systems default SELinux mode Enforcing,
+Permissive or Disabled. Note this is is just the default at boot time.
+EnforceMode tells you the systems current mode.
+*/
+func DefaultEnforceMode() int {
 	switch readConfig(selinuxTag) {
 	case "enforcing":
 		return Enforcing
@@ -338,7 +369,7 @@ func mcsDelete(mcs string) {
 	state.mcsList[mcs] = false
 }
 
-func IntToMcs(id int, catRange uint32) string {
+func intToMcs(id int, catRange uint32) string {
 	var (
 		SETSIZE = int(catRange)
 		TIER    = SETSIZE
@@ -386,26 +417,35 @@ func uniqMcs(catRange uint32) string {
 	return mcs
 }
 
-func FreeLxcContexts(scon string) {
-	if len(scon) != 0 {
-		con := strings.SplitN(scon, ":", 4)
+/*
+ReleaseLabel will unreserve the MLS/MCS Level field of the specified label.
+Allowing it to be used by another process.
+*/
+func ReleaseLabel(label string) {
+	if len(label) != 0 {
+		con := strings.SplitN(label, ":", 4)
 		mcsDelete(con[3])
 	}
 }
 
 var roFileLabel string
 
-func GetROFileLabel() (fileLabel string) {
+// ROFileLabel returns the specified SELinux readonly file label
+func ROFileLabel() (fileLabel string) {
 	return roFileLabel
 }
 
-func GetLxcContexts() (processLabel string, fileLabel string) {
+/*
+ContainerLabels returns an allocated processLabel and fileLabel to be used for
+container labeling by the calling process.
+*/
+func ContainerLabels() (processLabel string, fileLabel string) {
 	var (
 		val, key string
 		bufin    *bufio.Reader
 	)
 
-	if !SelinuxEnabled() {
+	if !GetEnabled() {
 		return "", ""
 	}
 	lxcPath := fmt.Sprintf("%s/contexts/lxc_contexts", getSELinuxPolicyRoot())
@@ -457,7 +497,6 @@ func GetLxcContexts() (processLabel string, fileLabel string) {
 		roFileLabel = fileLabel
 	}
 exit:
-	//	mcs := IntToMcs(os.Getpid(), 1024)
 	mcs := uniqMcs(1024)
 	scon := NewContext(processLabel)
 	scon["level"] = mcs
@@ -468,10 +507,15 @@ exit:
 	return processLabel, fileLabel
 }
 
+// SecurityCheckContext validates that the SELinux label is understood by the kernel
 func SecurityCheckContext(val string) error {
 	return writeCon(fmt.Sprintf("%s.context", selinuxPath), val)
 }
 
+/*
+CopyLevel returns a label with the MLS/MCS level from src label replaces on
+the dest label.
+*/
 func CopyLevel(src, dest string) (string, error) {
 	if src == "" {
 		return "", nil
@@ -502,25 +546,25 @@ func badPrefix(fpath string) error {
 	return nil
 }
 
-// Chcon changes the fpath file object to the SELinux label scon.
+// Chcon changes the fpath file object to the SELinux label label.
 // If the fpath is a directory and recurse is true Chcon will walk the
 // directory tree setting the label
-func Chcon(fpath string, scon string, recurse bool) error {
-	if scon == "" {
+func Chcon(fpath string, label string, recurse bool) error {
+	if label == "" {
 		return nil
 	}
 	if err := badPrefix(fpath); err != nil {
 		return err
 	}
 	callback := func(p string, info os.FileInfo, err error) error {
-		return Setfilecon(p, scon)
+		return SetFileLabel(p, label)
 	}
 
 	if recurse {
 		return filepath.Walk(fpath, callback)
 	}
 
-	return Setfilecon(fpath, scon)
+	return SetFileLabel(fpath, label)
 }
 
 // DupSecOpt takes an SELinux process label and returns security options that
@@ -536,14 +580,14 @@ func DupSecOpt(src string) []string {
 		con["level"] == "" {
 		return nil
 	}
-	return []string{"label=user:" + con["user"],
-		"label=role:" + con["role"],
-		"label=type:" + con["type"],
-		"label=level:" + con["level"]}
+	return []string{"user:" + con["user"],
+		"role:" + con["role"],
+		"type:" + con["type"],
+		"level:" + con["level"]}
 }
 
 // DisableSecOpt returns a security opt that can be used to disabling SELinux
 // labeling support for future container processes
 func DisableSecOpt() []string {
-	return []string{"label=disable"}
+	return []string{"disable"}
 }

--- a/vendor/github.com/opencontainers/selinux/go-selinux/xattrs.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/xattrs.go
@@ -1,0 +1,78 @@
+// +build linux
+
+package selinux
+
+import (
+	"syscall"
+	"unsafe"
+)
+
+var _zero uintptr
+
+// Returns a []byte slice if the xattr is set and nil otherwise
+// Requires path and its attribute as arguments
+func lgetxattr(path string, attr string) ([]byte, error) {
+	var sz int
+	pathBytes, err := syscall.BytePtrFromString(path)
+	if err != nil {
+		return nil, err
+	}
+	attrBytes, err := syscall.BytePtrFromString(attr)
+	if err != nil {
+		return nil, err
+	}
+
+	// Start with a 128 length byte array
+	sz = 128
+	dest := make([]byte, sz)
+	destBytes := unsafe.Pointer(&dest[0])
+	_sz, _, errno := syscall.Syscall6(syscall.SYS_LGETXATTR, uintptr(unsafe.Pointer(pathBytes)), uintptr(unsafe.Pointer(attrBytes)), uintptr(destBytes), uintptr(len(dest)), 0, 0)
+
+	switch {
+	case errno == syscall.ENODATA:
+		return nil, errno
+	case errno == syscall.ENOTSUP:
+		return nil, errno
+	case errno == syscall.ERANGE:
+		// 128 byte array might just not be good enough,
+		// A dummy buffer is used ``uintptr(0)`` to get real size
+		// of the xattrs on disk
+		_sz, _, errno = syscall.Syscall6(syscall.SYS_LGETXATTR, uintptr(unsafe.Pointer(pathBytes)), uintptr(unsafe.Pointer(attrBytes)), uintptr(unsafe.Pointer(nil)), uintptr(0), 0, 0)
+		sz = int(_sz)
+		if sz < 0 {
+			return nil, errno
+		}
+		dest = make([]byte, sz)
+		destBytes := unsafe.Pointer(&dest[0])
+		_sz, _, errno = syscall.Syscall6(syscall.SYS_LGETXATTR, uintptr(unsafe.Pointer(pathBytes)), uintptr(unsafe.Pointer(attrBytes)), uintptr(destBytes), uintptr(len(dest)), 0, 0)
+		if errno != 0 {
+			return nil, errno
+		}
+	case errno != 0:
+		return nil, errno
+	}
+	sz = int(_sz)
+	return dest[:sz], nil
+}
+
+func lsetxattr(path string, attr string, data []byte, flags int) error {
+	pathBytes, err := syscall.BytePtrFromString(path)
+	if err != nil {
+		return err
+	}
+	attrBytes, err := syscall.BytePtrFromString(attr)
+	if err != nil {
+		return err
+	}
+	var dataBytes unsafe.Pointer
+	if len(data) > 0 {
+		dataBytes = unsafe.Pointer(&data[0])
+	} else {
+		dataBytes = unsafe.Pointer(&_zero)
+	}
+	_, _, errno := syscall.Syscall6(syscall.SYS_LSETXATTR, uintptr(unsafe.Pointer(pathBytes)), uintptr(unsafe.Pointer(attrBytes)), uintptr(dataBytes), uintptr(len(data)), uintptr(flags), 0)
+	if errno != 0 {
+		return errno
+	}
+	return nil
+}


### PR DESCRIPTION
We have moved runc/libcontainers selinux support out of libcontainer
into opencontainers/selinux.  Switching containers/storage to use
new interfaces.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>