### PR TITLE
Fix {container,image}Store.Lookup()

### DIFF
--- a/storage/containers.go
+++ b/storage/containers.go
@@ -336,7 +336,7 @@ func (r *containerStore) Get(id string) (*Container, error) {
 }
 
 func (r *containerStore) Lookup(name string) (id string, err error) {
-	if container, ok := r.lookup(id); ok {
+	if container, ok := r.lookup(name); ok {
 		return container.ID, nil
 	}
 	return "", ErrContainerUnknown

--- a/storage/images.go
+++ b/storage/images.go
@@ -320,7 +320,7 @@ func (r *imageStore) Get(id string) (*Image, error) {
 }
 
 func (r *imageStore) Lookup(name string) (id string, err error) {
-	if image, ok := r.lookup(id); ok {
+	if image, ok := r.lookup(name); ok {
 		return image.ID, nil
 	}
 	return "", ErrImageUnknown


### PR DESCRIPTION
Fix the Lookup methods in container and image stores, which broke due to a bug in #6.