### PR TITLE
Rename 'overlay2' to 'overlay'

### DIFF
--- a/drivers/overlay/mount.go
+++ b/drivers/overlay/mount.go
@@ -1,6 +1,6 @@
 // +build linux
 
-package overlay2
+package overlay
 
 import (
 	"bytes"

--- a/drivers/overlay/overlay_test.go
+++ b/drivers/overlay/overlay_test.go
@@ -1,6 +1,6 @@
 // +build linux
 
-package overlay2
+package overlay
 
 import (
 	"os"
@@ -12,6 +12,8 @@ import (
 	"github.com/containers/storage/pkg/archive"
 	"github.com/containers/storage/pkg/reexec"
 )
+
+const driverName = "overlay"
 
 func init() {
 	// Do not sure chroot to speed run time and allow archive

--- a/drivers/overlay/overlay_unsupported.go
+++ b/drivers/overlay/overlay_unsupported.go
@@ -1,3 +1,3 @@
 // +build !linux
 
-package overlay2
+package overlay

--- a/drivers/overlay/randomid.go
+++ b/drivers/overlay/randomid.go
@@ -1,6 +1,6 @@
 // +build linux
 
-package overlay2
+package overlay
 
 import (
 	"crypto/rand"

--- a/drivers/register/register_overlay.go
+++ b/drivers/register/register_overlay.go
@@ -3,6 +3,6 @@
 package register
 
 import (
-	// register the overlay2 graphdriver
-	_ "github.com/containers/storage/drivers/overlay2"
+	// register the overlay graphdriver
+	_ "github.com/containers/storage/drivers/overlay"
 )


### PR DESCRIPTION
Finish the overlay->overlay2 changeover by:
* renaming overlay2 to overlay
  * teaching the driver to accept the overlay.override_kernel_check and
    overlay2.override_kernel_check options as having the same meaning
* registering the driver init function using both names