### PR TITLE
Support additional image stores 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ GIT_BRANCH_CLEAN := $(shell echo $(GIT_BRANCH) | sed -e "s/[^[:alnum:]]/-/g")
 EPOCH_TEST_COMMIT := 0418ebf59f9e1f564831c0ba9378b7f8e40a1c73
 SYSTEM_GOPATH := ${GOPATH}
 
-RUNINVM := vagrant/runinvm.sh
+RUNINVM := /usr/bin/true
 
 default all: build ## validate all checks, build linux binaries, run all tests\ncross build non-linux binaries and generate archives\nusing VMs
 	$(RUNINVM) hack/make.sh

--- a/containers.go
+++ b/containers.go
@@ -170,7 +170,7 @@ func newContainerStore(dir string) (ContainerStore, error) {
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return nil, err
 	}
-	lockfile, err := GetLockfile(filepath.Join(dir, "containers.lock"))
+	lockfile, err := GetLockfile(filepath.Join(DefaultStoreOptions.LockDir, dir, "containers.lock"))
 	if err != nil {
 		return nil, err
 	}

--- a/images.go
+++ b/images.go
@@ -161,7 +161,7 @@ func newImageStore(dir string) (ImageStore, error) {
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return nil, err
 	}
-	lockfile, err := GetLockfile(filepath.Join(dir, "images.lock"))
+	lockfile, err := GetLockfile(filepath.Join(DefaultStoreOptions.LockDir, dir, "images.lock"))
 	if err != nil {
 		return nil, err
 	}

--- a/layers.go
+++ b/layers.go
@@ -527,7 +527,7 @@ func (r *layerStore) SetMetadata(id, metadata string) error {
 }
 
 func (r *layerStore) tspath(id string) string {
-	return filepath.Join(r.layerdir, id+tarSplitSuffix)
+	return filepath.Join(DefaultStoreOptions.GraphRoot, DefaultStoreOptions.GraphDriverName+"-layers", id+tarSplitSuffix)
 }
 
 func (r *layerStore) Delete(id string) error {

--- a/layers.go
+++ b/layers.go
@@ -293,7 +293,7 @@ func newLayerStore(rundir string, layerdir string, driver drivers.Driver) (Layer
 	if err := os.MkdirAll(layerdir, 0700); err != nil {
 		return nil, err
 	}
-	lockfile, err := GetLockfile(filepath.Join(layerdir, "layers.lock"))
+	lockfile, err := GetLockfile(filepath.Join(DefaultStoreOptions.LockDir, layerdir, "layers.lock"))
 	if err != nil {
 		return nil, err
 	}

--- a/lockfile.go
+++ b/lockfile.go
@@ -49,10 +49,14 @@ func GetLockfile(path string) (Locker, error) {
 	if lockfiles == nil {
 		lockfiles = make(map[string]*lockfile)
 	}
-	if locker, ok := lockfiles[filepath.Clean(path)]; ok {
+	cleanPath := filepath.Clean(path)
+	if locker, ok := lockfiles[cleanPath]; ok {
 		return locker, nil
 	}
-	fd, err := unix.Open(filepath.Clean(path), os.O_RDWR|os.O_CREATE, unix.S_IRUSR|unix.S_IWUSR)
+	if err := os.MkdirAll(filepath.Dir(cleanPath), 0700); err != nil {
+		return nil, err
+	}
+	fd, err := unix.Open(cleanPath, os.O_RDWR|os.O_CREATE, unix.S_IRUSR|unix.S_IWUSR)
 	if err != nil {
 		return nil, err
 	}

--- a/storage.conf
+++ b/storage.conf
@@ -10,6 +10,9 @@ runroot = "/var/run/containers/storage"
 # Primary Read/Write location of container storage
 graphroot = "/var/lib/containers/storage"
 
+# Local Directory to store lock files
+LockDir = "/run/storage/locks"
+
 [storage.options]
 # AdditionalImageStores is used to pass paths to additional Read/Only image stores
 # Must be comma separated list.

--- a/store.go
+++ b/store.go
@@ -128,6 +128,9 @@ type StoreOptions struct {
 	GraphDriverName string `json:"driver,omitempty"`
 	// GraphDriverOptions are driver-specific options.
 	GraphDriverOptions []string `json:"driver-options,omitempty"`
+	// LockDir alternative directory to store locks,  if you are useing additional read/only shares
+	// you will have to store the lock files in a local writable directory. ("/run/storage/locks")
+	LockDir string `json:"lockdir,omitempty"`
 	// UIDMap and GIDMap are used mainly for deciding on the ownership of
 	// files in layers as they're stored on disk, which is often necessary
 	// when user namespaces are being used.
@@ -449,8 +452,7 @@ func GetStore(options StoreOptions) (Store, error) {
 			return nil, err
 		}
 	}
-
-	graphLock, err := GetLockfile(filepath.Join(options.GraphRoot, "storage.lock"))
+	graphLock, err := GetLockfile(filepath.Join(options.LockDir, options.GraphRoot, "storage.lock"))
 	if err != nil {
 		return nil, err
 	}
@@ -1976,6 +1978,7 @@ type tomlConfig struct {
 		Driver    string                  `toml:"driver"`
 		RunRoot   string                  `toml:"runroot"`
 		GraphRoot string                  `toml:"graphroot"`
+		LockDir   string                  `toml:"lockdir"`
 		Options   struct{ OptionsConfig } `toml:"options"`
 	} `toml:"storage"`
 }
@@ -2007,6 +2010,9 @@ func init() {
 	}
 	if config.Storage.GraphRoot != "" {
 		DefaultStoreOptions.GraphRoot = config.Storage.GraphRoot
+	}
+	if config.Storage.LockDir != "" {
+		DefaultStoreOptions.LockDir = config.Storage.LockDir
 	}
 	for _, s := range config.Storage.Options.AdditionalImageStores {
 		DefaultStoreOptions.GraphDriverOptions = append(DefaultStoreOptions.GraphDriverOptions, fmt.Sprintf("%s.imagestore=%s", config.Storage.Driver, s))

--- a/store.go
+++ b/store.go
@@ -152,13 +152,21 @@ type Store interface {
 	// by the Store.
 	GraphDriver() (drivers.Driver, error)
 
-	// LayerStore obtains and returns a handle to the layer store object used by
+	// LayerStore obtains and returns a handle to the writeable layer store object used by
 	// the Store.
 	LayerStore() (LayerStore, error)
 
-	// ImageStore obtains and returns a handle to the image store object used by
+	// ROLayerStore obtains additional read/only layer store objects used by
+	// the Store.
+	ROLayerStores() ([]LayerStore, error)
+
+	// ImageStore obtains and returns a handle to the writable image store object used by
 	// the Store.
 	ImageStore() (ImageStore, error)
+
+	// ROImageStores obtains additional read/only image store objects used by
+	// the Store.
+	ROImageStores() ([]ImageStore, error)
 
 	// ContainerStore obtains and returns a handle to the container store object
 	// used by the Store.
@@ -401,7 +409,9 @@ type store struct {
 	gidMap          []idtools.IDMap
 	graphDriver     drivers.Driver
 	layerStore      LayerStore
+	roLayerStores   []LayerStore
 	imageStore      ImageStore
+	roImageStores   []ImageStore
 	containerStore  ContainerStore
 }
 
@@ -517,6 +527,12 @@ func (s *store) load() error {
 	}
 	s.layerStore = rls
 
+	rols, err := s.ROLayerStores()
+	if err != nil {
+		return err
+	}
+	s.roLayerStores = rols
+
 	gipath := filepath.Join(s.graphRoot, driverPrefix+"images")
 	if err := os.MkdirAll(gipath, 0700); err != nil {
 		return err
@@ -525,6 +541,12 @@ func (s *store) load() error {
 	if err != nil {
 		return err
 	}
+	rois, err := s.ROImageStores()
+	if err != nil {
+		return err
+	}
+	s.roImageStores = rois
+
 	s.imageStore = ris
 	gcpath := filepath.Join(s.graphRoot, driverPrefix+"containers")
 	if err := os.MkdirAll(gcpath, 0700); err != nil {
@@ -598,11 +620,62 @@ func (s *store) LayerStore() (LayerStore, error) {
 	return s.layerStore, nil
 }
 
+func (s *store) ROLayerStores() ([]LayerStore, error) {
+	s.graphLock.Lock()
+	defer s.graphLock.Unlock()
+	if s.graphLock.TouchedSince(s.lastLoaded) {
+		s.graphDriver = nil
+		s.layerStore = nil
+		s.lastLoaded = time.Now()
+	}
+	if s.roLayerStores != nil {
+		return s.roLayerStores, nil
+	}
+	driver, err := s.getGraphDriver()
+	if err != nil {
+		return nil, err
+	}
+	driverPrefix := s.graphDriverName + "-"
+	rlpath := filepath.Join(s.runRoot, driverPrefix+"layers")
+	if err := os.MkdirAll(rlpath, 0700); err != nil {
+		return nil, err
+	}
+	for _, store := range driver.AdditionalImageStores() {
+		glpath := filepath.Join(store, driverPrefix+"layers")
+		rls, err := newLayerStore(rlpath, glpath, driver)
+		if err != nil {
+			return nil, err
+		}
+		s.roLayerStores = append(s.roLayerStores, rls)
+	}
+	return s.roLayerStores, nil
+}
+
 func (s *store) ImageStore() (ImageStore, error) {
 	if s.imageStore != nil {
 		return s.imageStore, nil
 	}
 	return nil, ErrLoadError
+}
+
+func (s *store) ROImageStores() ([]ImageStore, error) {
+	if len(s.roImageStores) != 0 {
+		return s.roImageStores, nil
+	}
+	driver, err := s.getGraphDriver()
+	if err != nil {
+		return nil, err
+	}
+	driverPrefix := s.graphDriverName + "-"
+	for _, store := range driver.AdditionalImageStores() {
+		gipath := filepath.Join(store, driverPrefix+"images")
+		ris, err := newImageStore(gipath)
+		if err != nil {
+			return nil, err
+		}
+		s.roImageStores = append(s.roImageStores, ris)
+	}
+	return s.roImageStores, nil
 }
 
 func (s *store) ContainerStore() (ContainerStore, error) {
@@ -662,18 +735,9 @@ func (s *store) CreateLayer(id, parent string, names []string, mountLabel string
 }
 
 func (s *store) CreateImage(id string, names []string, layer, metadata string, options *ImageOptions) (*Image, error) {
-	rlstore, err := s.LayerStore()
-	if err != nil {
-		return nil, err
-	}
 	ristore, err := s.ImageStore()
 	if err != nil {
 		return nil, err
-	}
-	rlstore.Lock()
-	defer rlstore.Unlock()
-	if modified, err := rlstore.Modified(); modified || err != nil {
-		rlstore.Load()
 	}
 	ristore.Lock()
 	defer ristore.Unlock()
@@ -685,9 +749,26 @@ func (s *store) CreateImage(id string, names []string, layer, metadata string, o
 		id = stringid.GenerateRandomID()
 	}
 
-	ilayer, err := rlstore.Get(layer)
+	rlstore, err := s.LayerStore()
 	if err != nil {
 		return nil, err
+	}
+	stores, err := s.ROLayerStores()
+	if err != nil {
+		return nil, err
+	}
+	stores = append([]LayerStore{rlstore}, stores...)
+	var ilayer *Layer
+	for _, rlstore := range stores {
+		rlstore.Lock()
+		defer rlstore.Unlock()
+		if modified, err := rlstore.Modified(); modified || err != nil {
+			rlstore.Load()
+		}
+		ilayer, err = rlstore.Get(layer)
+		if err == nil {
+			break
+		}
 	}
 	if ilayer == nil {
 		return nil, ErrLayerUnknown
@@ -697,37 +778,6 @@ func (s *store) CreateImage(id string, names []string, layer, metadata string, o
 }
 
 func (s *store) CreateContainer(id string, names []string, image, layer, metadata string, options *ContainerOptions) (*Container, error) {
-	rlstore, err := s.LayerStore()
-	if err != nil {
-		return nil, err
-	}
-	ristore, err := s.ImageStore()
-	if err != nil {
-		return nil, err
-	}
-	rcstore, err := s.ContainerStore()
-	if err != nil {
-		return nil, err
-	}
-
-	rlstore.Lock()
-	defer rlstore.Unlock()
-	defer rlstore.Touch()
-	if modified, err := rlstore.Modified(); modified || err != nil {
-		rlstore.Load()
-	}
-	ristore.Lock()
-	defer ristore.Unlock()
-	if modified, err := ristore.Modified(); modified || err != nil {
-		ristore.Load()
-	}
-	rcstore.Lock()
-	defer rcstore.Unlock()
-	defer rcstore.Touch()
-	if modified, err := rcstore.Modified(); modified || err != nil {
-		rcstore.Load()
-	}
-
 	if id == "" {
 		id = stringid.GenerateRandomID()
 	}
@@ -735,9 +785,26 @@ func (s *store) CreateContainer(id string, names []string, image, layer, metadat
 	imageTopLayer := ""
 	imageID := ""
 	if image != "" {
-		cimage, err := ristore.Get(image)
+		ristore, err := s.ImageStore()
 		if err != nil {
 			return nil, err
+		}
+		stores, err := s.ROImageStores()
+		if err != nil {
+			return nil, err
+		}
+		stores = append([]ImageStore{ristore}, stores...)
+		var cimage *Image
+		for _, ristore := range stores {
+			ristore.Lock()
+			defer ristore.Unlock()
+			if modified, err := ristore.Modified(); modified || err != nil {
+				ristore.Load()
+			}
+			cimage, err = ristore.Get(image)
+			if err == nil {
+				break
+			}
 		}
 		if cimage == nil {
 			return nil, ErrImageUnknown
@@ -745,11 +812,31 @@ func (s *store) CreateContainer(id string, names []string, image, layer, metadat
 		imageTopLayer = cimage.TopLayer
 		imageID = cimage.ID
 	}
+	rlstore, err := s.LayerStore()
+	if err != nil {
+		return nil, err
+	}
+	rlstore.Lock()
+	defer rlstore.Unlock()
+	defer rlstore.Touch()
+	if modified, err := rlstore.Modified(); modified || err != nil {
+		rlstore.Load()
+	}
 	clayer, err := rlstore.Create(layer, imageTopLayer, nil, "", nil, true)
 	if err != nil {
 		return nil, err
 	}
 	layer = clayer.ID
+	rcstore, err := s.ContainerStore()
+	if err != nil {
+		return nil, err
+	}
+	rcstore.Lock()
+	defer rcstore.Unlock()
+	defer rcstore.Touch()
+	if modified, err := rcstore.Modified(); modified || err != nil {
+		rcstore.Load()
+	}
 	container, err := rcstore.Create(id, names, imageID, layer, metadata)
 	if err != nil || container == nil {
 		rlstore.Delete(layer)
@@ -807,36 +894,50 @@ func (s *store) Metadata(id string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	ristore, err := s.ImageStore()
+	stores, err := s.ROLayerStores()
 	if err != nil {
 		return "", err
 	}
+	stores = append([]LayerStore{rlstore}, stores...)
+	for _, rlstore := range stores {
+		rlstore.Lock()
+		defer rlstore.Unlock()
+		if modified, err := rlstore.Modified(); modified || err != nil {
+			rlstore.Load()
+		}
+		if rlstore.Exists(id) {
+			return rlstore.Metadata(id)
+		}
+	}
+
+	istore, err := s.ImageStore()
+	if err != nil {
+		return "", err
+	}
+	istores, err := s.ROImageStores()
+	if err != nil {
+		return "", err
+	}
+	istores = append([]ImageStore{istore}, istores...)
+	for _, ristore := range istores {
+		ristore.Lock()
+		defer ristore.Unlock()
+		if modified, err := ristore.Modified(); modified || err != nil {
+			ristore.Load()
+		}
+		if ristore.Exists(id) {
+			return ristore.Metadata(id)
+		}
+	}
+
 	rcstore, err := s.ContainerStore()
 	if err != nil {
 		return "", err
-	}
-
-	rlstore.Lock()
-	defer rlstore.Unlock()
-	if modified, err := rlstore.Modified(); modified || err != nil {
-		rlstore.Load()
-	}
-	ristore.Lock()
-	defer ristore.Unlock()
-	if modified, err := ristore.Modified(); modified || err != nil {
-		ristore.Load()
 	}
 	rcstore.Lock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
 		rcstore.Load()
-	}
-
-	if rlstore.Exists(id) {
-		return rlstore.Metadata(id)
-	}
-	if ristore.Exists(id) {
-		return ristore.Metadata(id)
 	}
 	if rcstore.Exists(id) {
 		return rcstore.Metadata(id)
@@ -849,13 +950,23 @@ func (s *store) ListImageBigData(id string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	ristore.Lock()
-	defer ristore.Unlock()
-	if modified, err := ristore.Modified(); modified || err != nil {
-		ristore.Load()
+	stores, err := s.ROImageStores()
+	if err != nil {
+		return nil, err
 	}
-
-	return ristore.BigDataNames(id)
+	stores = append([]ImageStore{ristore}, stores...)
+	for _, ristore := range stores {
+		ristore.Lock()
+		defer ristore.Unlock()
+		if modified, err := ristore.Modified(); modified || err != nil {
+			ristore.Load()
+		}
+		bigDataNames, err := ristore.BigDataNames(id)
+		if err == nil {
+			return bigDataNames, err
+		}
+	}
+	return nil, ErrNotAnImage
 }
 
 func (s *store) ImageBigDataSize(id, key string) (int64, error) {
@@ -863,13 +974,23 @@ func (s *store) ImageBigDataSize(id, key string) (int64, error) {
 	if err != nil {
 		return -1, err
 	}
-	ristore.Lock()
-	defer ristore.Unlock()
-	if modified, err := ristore.Modified(); modified || err != nil {
-		ristore.Load()
+	stores, err := s.ROImageStores()
+	if err != nil {
+		return -1, err
 	}
-
-	return ristore.BigDataSize(id, key)
+	stores = append([]ImageStore{ristore}, stores...)
+	for _, ristore := range stores {
+		ristore.Lock()
+		defer ristore.Unlock()
+		if modified, err := ristore.Modified(); modified || err != nil {
+			ristore.Load()
+		}
+		size, err := ristore.BigDataSize(id, key)
+		if err == nil {
+			return size, nil
+		}
+	}
+	return -1, ErrSizeUnknown
 }
 
 func (s *store) ImageBigData(id, key string) ([]byte, error) {
@@ -877,13 +998,24 @@ func (s *store) ImageBigData(id, key string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	ristore.Lock()
-	defer ristore.Unlock()
-	if modified, err := ristore.Modified(); modified || err != nil {
-		ristore.Load()
+	stores, err := s.ROImageStores()
+	if err != nil {
+		return nil, err
+	}
+	stores = append([]ImageStore{ristore}, stores...)
+	for _, ristore := range stores {
+		ristore.Lock()
+		defer ristore.Unlock()
+		if modified, err := ristore.Modified(); modified || err != nil {
+			ristore.Load()
+		}
+		data, err := ristore.BigData(id, key)
+		if err == nil {
+			return data, nil
+		}
 	}
 
-	return ristore.BigData(id, key)
+	return nil, ErrNotAnImage
 }
 
 func (s *store) SetImageBigData(id, key string, data []byte) error {
@@ -972,70 +1104,58 @@ func (s *store) Exists(id string) bool {
 	if err != nil {
 		return false
 	}
-	ristore, err := s.ImageStore()
-	if err != nil {
-		return false
-	}
-	rlstore, err := s.LayerStore()
-	if err != nil {
-		return false
-	}
-
-	rlstore.Lock()
-	defer rlstore.Unlock()
-	if modified, err := rlstore.Modified(); modified || err != nil {
-		rlstore.Load()
-	}
-	ristore.Lock()
-	defer ristore.Unlock()
-	if modified, err := ristore.Modified(); modified || err != nil {
-		ristore.Load()
-	}
 	rcstore.Lock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
 		rcstore.Load()
 	}
-
 	if rcstore.Exists(id) {
 		return true
 	}
-	if ristore.Exists(id) {
-		return true
+
+	ristore, err := s.ImageStore()
+	if err != nil {
+		return false
 	}
-	return rlstore.Exists(id)
+	stores, err := s.ROImageStores()
+	if err != nil {
+		return false
+	}
+	stores = append([]ImageStore{ristore}, stores...)
+	for _, ristore := range stores {
+		ristore.Lock()
+		defer ristore.Unlock()
+		if modified, err := ristore.Modified(); modified || err != nil {
+			ristore.Load()
+		}
+		if ristore.Exists(id) {
+			return true
+		}
+	}
+
+	lstore, err := s.LayerStore()
+	if err != nil {
+		return false
+	}
+	lstores, err := s.ROLayerStores()
+	if err != nil {
+		return false
+	}
+	lstores = append([]LayerStore{lstore}, lstores...)
+	for _, rlstore := range lstores {
+		rlstore.Lock()
+		defer rlstore.Unlock()
+		if modified, err := rlstore.Modified(); modified || err != nil {
+			rlstore.Load()
+		}
+		if rlstore.Exists(id) {
+			return true
+		}
+	}
+	return false
 }
 
 func (s *store) SetNames(id string, names []string) error {
-	rcstore, err := s.ContainerStore()
-	if err != nil {
-		return err
-	}
-	ristore, err := s.ImageStore()
-	if err != nil {
-		return err
-	}
-	rlstore, err := s.LayerStore()
-	if err != nil {
-		return err
-	}
-
-	rlstore.Lock()
-	defer rlstore.Unlock()
-	if modified, err := rlstore.Modified(); modified || err != nil {
-		rlstore.Load()
-	}
-	ristore.Lock()
-	defer ristore.Unlock()
-	if modified, err := ristore.Modified(); modified || err != nil {
-		ristore.Load()
-	}
-	rcstore.Lock()
-	defer rcstore.Unlock()
-	if modified, err := rcstore.Modified(); modified || err != nil {
-		rcstore.Load()
-	}
-
 	deduped := []string{}
 	seen := make(map[string]bool)
 	for _, name := range names {
@@ -1044,12 +1164,40 @@ func (s *store) SetNames(id string, names []string) error {
 			deduped = append(deduped, name)
 		}
 	}
-
+	rlstore, err := s.LayerStore()
+	if err != nil {
+		return err
+	}
+	rlstore.Lock()
+	defer rlstore.Unlock()
+	if modified, err := rlstore.Modified(); modified || err != nil {
+		rlstore.Load()
+	}
 	if rlstore.Exists(id) {
 		return rlstore.SetNames(id, deduped)
 	}
+
+	ristore, err := s.ImageStore()
+	if err != nil {
+		return err
+	}
+	ristore.Lock()
+	defer ristore.Unlock()
+	if modified, err := ristore.Modified(); modified || err != nil {
+		ristore.Load()
+	}
 	if ristore.Exists(id) {
 		return ristore.SetNames(id, deduped)
+	}
+
+	rcstore, err := s.ContainerStore()
+	if err != nil {
+		return err
+	}
+	rcstore.Lock()
+	defer rcstore.Unlock()
+	if modified, err := rcstore.Modified(); modified || err != nil {
+		rcstore.Load()
 	}
 	if rcstore.Exists(id) {
 		return rcstore.SetNames(id, deduped)
@@ -1058,40 +1206,54 @@ func (s *store) SetNames(id string, names []string) error {
 }
 
 func (s *store) Names(id string) ([]string, error) {
-	rcstore, err := s.ContainerStore()
-	if err != nil {
-		return nil, err
-	}
-	ristore, err := s.ImageStore()
-	if err != nil {
-		return nil, err
-	}
 	rlstore, err := s.LayerStore()
 	if err != nil {
 		return nil, err
 	}
-
-	rlstore.Lock()
-	defer rlstore.Unlock()
-	if modified, err := rlstore.Modified(); modified || err != nil {
-		rlstore.Load()
+	stores, err := s.ROLayerStores()
+	if err != nil {
+		return nil, err
 	}
-	ristore.Lock()
-	defer ristore.Unlock()
-	if modified, err := ristore.Modified(); modified || err != nil {
-		ristore.Load()
+	stores = append([]LayerStore{rlstore}, stores...)
+	for _, rlstore := range stores {
+		rlstore.Lock()
+		defer rlstore.Unlock()
+		if modified, err := rlstore.Modified(); modified || err != nil {
+			rlstore.Load()
+		}
+		if l, err := rlstore.Get(id); l != nil && err == nil {
+			return l.Names, nil
+		}
+	}
+
+	ristore, err := s.ImageStore()
+	if err != nil {
+		return nil, err
+	}
+	ristores, err := s.ROImageStores()
+	if err != nil {
+		return nil, err
+	}
+	ristores = append([]ImageStore{ristore}, ristores...)
+	for _, ristore := range stores {
+		ristore.Lock()
+		defer ristore.Unlock()
+		if modified, err := ristore.Modified(); modified || err != nil {
+			ristore.Load()
+		}
+		if i, err := ristore.Get(id); i != nil && err == nil {
+			return i.Names, nil
+		}
+	}
+
+	rcstore, err := s.ContainerStore()
+	if err != nil {
+		return nil, err
 	}
 	rcstore.Lock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
 		rcstore.Load()
-	}
-
-	if l, err := rlstore.Get(id); l != nil && err == nil {
-		return l.Names, nil
-	}
-	if i, err := ristore.Get(id); i != nil && err == nil {
-		return i.Names, nil
 	}
 	if c, err := rcstore.Get(id); c != nil && err == nil {
 		return c.Names, nil
@@ -1516,17 +1678,6 @@ func (s *store) Mount(id, mountLabel string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	rlstore, err := s.LayerStore()
-	if err != nil {
-		return "", err
-	}
-
-	rlstore.Lock()
-	defer rlstore.Unlock()
-	defer rlstore.Touch()
-	if modified, err := rlstore.Modified(); modified || err != nil {
-		rlstore.Load()
-	}
 	rcstore.Lock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
@@ -1536,7 +1687,26 @@ func (s *store) Mount(id, mountLabel string) (string, error) {
 	if c, err := rcstore.Get(id); c != nil && err == nil {
 		id = c.LayerID
 	}
-	return rlstore.Mount(id, mountLabel)
+	rlstore, err := s.LayerStore()
+	if err != nil {
+		return "", err
+	}
+	stores, err := s.ROLayerStores()
+	if err != nil {
+		return "", err
+	}
+	stores = append([]LayerStore{rlstore}, stores...)
+	for _, rlstore := range stores {
+		rlstore.Lock()
+		defer rlstore.Unlock()
+		if modified, err := rlstore.Modified(); modified || err != nil {
+			rlstore.Load()
+		}
+		if rlstore.Exists(id) {
+			return rlstore.Mount(id, mountLabel)
+		}
+	}
+	return "", ErrNotALayer
 }
 
 func (s *store) Unmount(id string) error {
@@ -1544,27 +1714,35 @@ func (s *store) Unmount(id string) error {
 	if err != nil {
 		return err
 	}
-	rlstore, err := s.LayerStore()
-	if err != nil {
-		return err
-	}
-
-	rlstore.Lock()
-	defer rlstore.Unlock()
-	defer rlstore.Touch()
-	if modified, err := rlstore.Modified(); modified || err != nil {
-		rlstore.Load()
-	}
 	rcstore.Lock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
 		rcstore.Load()
 	}
-
 	if c, err := rcstore.Get(id); c != nil && err == nil {
 		id = c.LayerID
 	}
-	return rlstore.Unmount(id)
+
+	rlstore, err := s.LayerStore()
+	if err != nil {
+		return err
+	}
+	stores, err := s.ROLayerStores()
+	if err != nil {
+		return err
+	}
+	stores = append([]LayerStore{rlstore}, stores...)
+	for _, rlstore := range stores {
+		rlstore.Lock()
+		defer rlstore.Unlock()
+		if modified, err := rlstore.Modified(); modified || err != nil {
+			rlstore.Load()
+		}
+		if rlstore.Exists(id) {
+			return rlstore.Unmount(id)
+		}
+	}
+	return ErrNotALayer
 }
 
 func (s *store) Changes(from, to string) ([]archive.Change, error) {
@@ -1572,14 +1750,22 @@ func (s *store) Changes(from, to string) ([]archive.Change, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	rlstore.Lock()
-	defer rlstore.Unlock()
-	if modified, err := rlstore.Modified(); modified || err != nil {
-		rlstore.Load()
+	stores, err := s.ROLayerStores()
+	if err != nil {
+		return nil, err
 	}
-
-	return rlstore.Changes(from, to)
+	stores = append([]LayerStore{rlstore}, stores...)
+	for _, rlstore := range stores {
+		rlstore.Lock()
+		defer rlstore.Unlock()
+		if modified, err := rlstore.Modified(); modified || err != nil {
+			rlstore.Load()
+		}
+		if rlstore.Exists(to) {
+			return rlstore.Changes(from, to)
+		}
+	}
+	return nil, ErrNotALayer
 }
 
 func (s *store) DiffSize(from, to string) (int64, error) {
@@ -1587,29 +1773,46 @@ func (s *store) DiffSize(from, to string) (int64, error) {
 	if err != nil {
 		return -1, err
 	}
-
-	rlstore.Lock()
-	defer rlstore.Unlock()
-	if modified, err := rlstore.Modified(); modified || err != nil {
-		rlstore.Load()
+	stores, err := s.ROLayerStores()
+	if err != nil {
+		return -1, err
 	}
-
-	return rlstore.DiffSize(from, to)
+	stores = append([]LayerStore{rlstore}, stores...)
+	for _, rlstore := range stores {
+		rlstore.Lock()
+		defer rlstore.Unlock()
+		if modified, err := rlstore.Modified(); modified || err != nil {
+			rlstore.Load()
+		}
+		if rlstore.Exists(to) {
+			return rlstore.DiffSize(from, to)
+		}
+	}
+	return -1, ErrNotALayer
 }
 
 func (s *store) Diff(from, to string) (io.ReadCloser, error) {
+
 	rlstore, err := s.LayerStore()
 	if err != nil {
 		return nil, err
 	}
-
-	rlstore.Lock()
-	defer rlstore.Unlock()
-	if modified, err := rlstore.Modified(); modified || err != nil {
-		rlstore.Load()
+	stores, err := s.ROLayerStores()
+	if err != nil {
+		return nil, err
 	}
-
-	return rlstore.Diff(from, to)
+	stores = append([]LayerStore{rlstore}, stores...)
+	for _, rlstore := range stores {
+		rlstore.Lock()
+		defer rlstore.Unlock()
+		if modified, err := rlstore.Modified(); modified || err != nil {
+			rlstore.Load()
+		}
+		if rlstore.Exists(to) {
+			return rlstore.Diff(from, to)
+		}
+	}
+	return nil, ErrNotALayer
 }
 
 func (s *store) ApplyDiff(to string, diff archive.Reader) (int64, error) {
@@ -1617,43 +1820,77 @@ func (s *store) ApplyDiff(to string, diff archive.Reader) (int64, error) {
 	if err != nil {
 		return -1, err
 	}
-
-	rlstore.Lock()
-	defer rlstore.Unlock()
-	if modified, err := rlstore.Modified(); modified || err != nil {
-		rlstore.Load()
+	stores, err := s.ROLayerStores()
+	if err != nil {
+		return -1, err
 	}
-
-	return rlstore.ApplyDiff(to, diff)
+	stores = append([]LayerStore{rlstore}, stores...)
+	for _, rlstore := range stores {
+		rlstore.Lock()
+		defer rlstore.Unlock()
+		if modified, err := rlstore.Modified(); modified || err != nil {
+			rlstore.Load()
+		}
+		if rlstore.Exists(to) {
+			return rlstore.ApplyDiff(to, diff)
+		}
+	}
+	return -1, ErrNotALayer
 }
 
 func (s *store) Layers() ([]Layer, error) {
+	var layers []Layer
 	rlstore, err := s.LayerStore()
 	if err != nil {
 		return nil, err
 	}
 
-	rlstore.Lock()
-	defer rlstore.Unlock()
-	if modified, err := rlstore.Modified(); modified || err != nil {
-		rlstore.Load()
+	stores, err := s.ROLayerStores()
+	if err != nil {
+		return nil, err
 	}
+	stores = append([]LayerStore{rlstore}, stores...)
 
-	return rlstore.Layers()
+	for _, rlstore := range stores {
+		rlstore.Lock()
+		defer rlstore.Unlock()
+		if modified, err := rlstore.Modified(); modified || err != nil {
+			rlstore.Load()
+		}
+		slayers, err := rlstore.Layers()
+		if err != nil {
+			return nil, err
+		}
+		layers = append(layers, slayers...)
+	}
+	return layers, nil
 }
 
 func (s *store) Images() ([]Image, error) {
+	var images []Image
 	ristore, err := s.ImageStore()
 	if err != nil {
 		return nil, err
 	}
-	ristore.Lock()
-	defer ristore.Unlock()
-	if modified, err := ristore.Modified(); modified || err != nil {
-		ristore.Load()
-	}
 
-	return ristore.Images()
+	stores, err := s.ROImageStores()
+	if err != nil {
+		return nil, err
+	}
+	stores = append([]ImageStore{ristore}, stores...)
+	for _, ristore := range stores {
+		ristore.Lock()
+		defer ristore.Unlock()
+		if modified, err := ristore.Modified(); modified || err != nil {
+			ristore.Load()
+		}
+		simages, err := ristore.Images()
+		if err != nil {
+			return nil, err
+		}
+		images = append(images, simages...)
+	}
+	return images, nil
 }
 
 func (s *store) Containers() ([]Container, error) {
@@ -1677,13 +1914,24 @@ func (s *store) Layer(id string) (*Layer, error) {
 		return nil, err
 	}
 
-	rlstore.Lock()
-	defer rlstore.Unlock()
-	if modified, err := rlstore.Modified(); modified || err != nil {
-		rlstore.Load()
+	stores, err := s.ROLayerStores()
+	if err != nil {
+		return nil, err
 	}
+	stores = append([]LayerStore{rlstore}, stores...)
 
-	return rlstore.Get(id)
+	for _, rlstore := range stores {
+		rlstore.Lock()
+		defer rlstore.Unlock()
+		if modified, err := rlstore.Modified(); modified || err != nil {
+			rlstore.Load()
+		}
+		layer, err := rlstore.Get(id)
+		if err == nil {
+			return layer, nil
+		}
+	}
+	return nil, ErrNotALayer
 }
 
 func (s *store) Image(id string) (*Image, error) {
@@ -1691,51 +1939,58 @@ func (s *store) Image(id string) (*Image, error) {
 	if err != nil {
 		return nil, err
 	}
-	ristore.Lock()
-	defer ristore.Unlock()
-	if modified, err := ristore.Modified(); modified || err != nil {
-		ristore.Load()
+	stores, err := s.ROImageStores()
+	if err != nil {
+		return nil, err
 	}
-
-	return ristore.Get(id)
+	stores = append([]ImageStore{ristore}, stores...)
+	for _, ristore := range stores {
+		ristore.Lock()
+		defer ristore.Unlock()
+		if modified, err := ristore.Modified(); modified || err != nil {
+			ristore.Load()
+		}
+		image, err := ristore.Get(id)
+		if err == nil {
+			return image, nil
+		}
+	}
+	return nil, ErrNotAnImage
 }
 
 func (s *store) ImagesByTopLayer(id string) ([]*Image, error) {
+	images := []*Image{}
+	layer, err := s.Layer(id)
+	if err != nil {
+		return nil, err
+	}
+
 	ristore, err := s.ImageStore()
 	if err != nil {
 		return nil, err
 	}
-	rlstore, err := s.LayerStore()
-	if err != nil {
-		return nil, err
-	}
 
-	rlstore.Lock()
-	defer rlstore.Unlock()
-	if modified, err := rlstore.Modified(); modified || err != nil {
-		rlstore.Load()
-	}
-	ristore.Lock()
-	defer ristore.Unlock()
-	if modified, err := ristore.Modified(); modified || err != nil {
-		ristore.Load()
-	}
-
-	layer, err := rlstore.Get(id)
+	stores, err := s.ROImageStores()
 	if err != nil {
 		return nil, err
 	}
-	images := []*Image{}
-	imageList, err := ristore.Images()
-	if err != nil {
-		return nil, err
-	}
-	for _, image := range imageList {
-		if image.TopLayer == layer.ID {
-			images = append(images, &image)
+	stores = append([]ImageStore{ristore}, stores...)
+	for _, ristore := range stores {
+		ristore.Lock()
+		defer ristore.Unlock()
+		if modified, err := ristore.Modified(); modified || err != nil {
+			ristore.Load()
+		}
+		imageList, err := ristore.Images()
+		if err != nil {
+			return nil, err
+		}
+		for _, image := range imageList {
+			if image.TopLayer == layer.ID {
+				images = append(images, &image)
+			}
 		}
 	}
-
 	return images, nil
 }
 
@@ -1754,7 +2009,7 @@ func (s *store) Container(id string) (*Container, error) {
 }
 
 func (s *store) ContainerByLayer(id string) (*Container, error) {
-	rlstore, err := s.LayerStore()
+	layer, err := s.Layer(id)
 	if err != nil {
 		return nil, err
 	}
@@ -1762,21 +2017,10 @@ func (s *store) ContainerByLayer(id string) (*Container, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	rlstore.Lock()
-	defer rlstore.Unlock()
-	if modified, err := rlstore.Modified(); modified || err != nil {
-		rlstore.Load()
-	}
 	rcstore.Lock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
 		rcstore.Load()
-	}
-
-	layer, err := rlstore.Get(id)
-	if err != nil {
-		return nil, err
 	}
 	containerList, err := rcstore.Containers()
 	if err != nil {


### PR DESCRIPTION
We want to support additional read/only image stores available on
file systems.  Usually these images stores would be on network shares.
Currently the only driver that will support additional images is the
overlay file system.