### PR TITLE
Fix container storage to support additional image stores

### DIFF
--- a/drivers/aufs/aufs.go
+++ b/drivers/aufs/aufs.go
@@ -372,6 +372,12 @@ func (a *Driver) Diff(id, parent string) (archive.Archive, error) {
 	})
 }
 
+// AdditionalImageStores returns additional image stores supported by the driver
+func (a *Driver) AdditionalImageStores() []string {
+	var imageStores []string
+	return imageStores
+}
+
 type fileGetNilCloser struct {
 	storage.FileGetter
 }

--- a/drivers/btrfs/btrfs.go
+++ b/drivers/btrfs/btrfs.go
@@ -518,3 +518,9 @@ func (d *Driver) Exists(id string) bool {
 	_, err := os.Stat(dir)
 	return err == nil
 }
+
+// AdditionalImageStores returns additional image stores supported by the driver
+func (d *Driver) AdditionalImageStores() []string {
+	var imageStores []string
+	return imageStores
+}

--- a/drivers/devmapper/driver.go
+++ b/drivers/devmapper/driver.go
@@ -224,3 +224,9 @@ func (d *Driver) Put(id string) error {
 func (d *Driver) Exists(id string) bool {
 	return d.DeviceSet.HasDevice(id)
 }
+
+// AdditionalImageStores returns additional image stores supported by the driver
+func (d *Driver) AdditionalImageStores() []string {
+	var imageStores []string
+	return imageStores
+}

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -74,6 +74,8 @@ type ProtoDriver interface {
 	// held by the driver, e.g., unmounting all layered filesystems
 	// known to this driver.
 	Cleanup() error
+	// AdditionalImageStores returns additional image stores supported by the driver
+	AdditionalImageStores() []string
 }
 
 // Driver is the interface for layered/snapshot file system drivers.

--- a/drivers/vfs/driver.go
+++ b/drivers/vfs/driver.go
@@ -143,3 +143,9 @@ func (d *Driver) Exists(id string) bool {
 	_, err := os.Stat(d.dir(id))
 	return err == nil
 }
+
+// AdditionalImageStores returns additional image stores supported by the driver
+func (d *Driver) AdditionalImageStores() []string {
+	var imageStores []string
+	return imageStores
+}

--- a/drivers/zfs/zfs.go
+++ b/drivers/zfs/zfs.go
@@ -403,3 +403,9 @@ func (d *Driver) Exists(id string) bool {
 	defer d.Unlock()
 	return d.filesystemsCache[d.zfsPath(id)] == true
 }
+
+// AdditionalImageStores returns additional image stores supported by the driver
+func (d *Driver) AdditionalImageStores() []string {
+	var imageStores []string
+	return imageStores
+}


### PR DESCRIPTION
We want to support additional read/only image stores available on
file systems.  Usually these images stores would be on network shares.
Currently the only driver that will support additional images is the
overlay file system.

Signed-off-by: Dan Walsh <dwalsh@redhat.com>