### PR TITLE
If a lockfile is on a readonly directory then create a read lock

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -152,7 +152,6 @@ func (r *containerStore) Load() error {
 	r.bylayer = layers
 	r.byname = names
 	if needSave {
-		r.Touch()
 		return r.Save()
 	}
 	return nil

--- a/containers.go
+++ b/containers.go
@@ -158,6 +158,9 @@ func (r *containerStore) Load() error {
 }
 
 func (r *containerStore) Save() error {
+	if !r.lockfile.RWLock() {
+		return ErrLockReadOnly
+	}
 	rpath := r.containerspath()
 	if err := os.MkdirAll(filepath.Dir(rpath), 0700); err != nil {
 		return err
@@ -438,6 +441,10 @@ func (r *containerStore) Touch() error {
 
 func (r *containerStore) Modified() (bool, error) {
 	return r.lockfile.Modified()
+}
+
+func (r *containerStore) RWLock() bool {
+	return r.lockfile.RWLock()
 }
 
 func (r *containerStore) TouchedSince(when time.Time) bool {

--- a/images.go
+++ b/images.go
@@ -143,7 +143,6 @@ func (r *imageStore) Load() error {
 	r.byid = ids
 	r.byname = names
 	if needSave {
-		r.Touch()
 		return r.Save()
 	}
 	return nil

--- a/layers.go
+++ b/layers.go
@@ -251,7 +251,6 @@ func (r *layerStore) Load() error {
 		}
 	}
 	if needSave {
-		r.Touch()
 		return r.Save()
 	}
 	return err

--- a/lockfile.go
+++ b/lockfile.go
@@ -1,14 +1,16 @@
 package storage
 
 import (
+	"fmt"
 	"os"
 	"path/filepath"
 	"sync"
 	"time"
 
-	"golang.org/x/sys/unix"
-
 	"github.com/containers/storage/pkg/stringid"
+	"github.com/pkg/errors"
+
+	"golang.org/x/sys/unix"
 )
 
 // A Locker represents a file lock where the file is used to cache an
@@ -27,21 +29,27 @@ type Locker interface {
 
 	// TouchedSince() checks if the most recent writer modified the file (likely using Touch()) after the specified time.
 	TouchedSince(when time.Time) bool
+
+	// RWLock() checks if the lock file is read/write
+	RWLock() bool
 }
 
 type lockfile struct {
-	mu   sync.Mutex
-	file string
-	fd   uintptr
-	lw   string
+	mu       sync.Mutex
+	file     string
+	fd       uintptr
+	lw       string
+	locktype int16
 }
 
 var (
 	lockfiles     map[string]*lockfile
 	lockfilesLock sync.Mutex
+	// ErrLockReadOnly indicates that the caller only took a read/only lock, and is not allowed to write
+	ErrLockReadOnly = errors.New("lock is not a read/write lock")
 )
 
-// GetLockfile opens a lock file, creating it if necessary.  The Locker object
+// GetLockfile opens a read/write lock file, creating it if necessary.  The Locker object
 // return will be returned unlocked.
 func GetLockfile(path string) (Locker, error) {
 	lockfilesLock.Lock()
@@ -49,22 +57,52 @@ func GetLockfile(path string) (Locker, error) {
 	if lockfiles == nil {
 		lockfiles = make(map[string]*lockfile)
 	}
-	if locker, ok := lockfiles[filepath.Clean(path)]; ok {
+	cleanPath := filepath.Clean(path)
+	if locker, ok := lockfiles[cleanPath]; ok {
+		if !locker.RWLock() {
+			return nil, fmt.Errorf("Lock %q is a Read/Only lock", cleanPath)
+		}
 		return locker, nil
 	}
-	fd, err := unix.Open(filepath.Clean(path), os.O_RDWR|os.O_CREATE, unix.S_IRUSR|unix.S_IWUSR)
+	fd, err := unix.Open(cleanPath, os.O_RDWR|os.O_CREATE, unix.S_IRUSR|unix.S_IWUSR)
 	if err != nil {
-		return nil, err
+		return nil, errors.Wrapf(err, "Error opening %q", cleanPath)
 	}
 	unix.CloseOnExec(fd)
-	locker := &lockfile{file: path, fd: uintptr(fd), lw: stringid.GenerateRandomID()}
+	locker := &lockfile{file: path, fd: uintptr(fd), lw: stringid.GenerateRandomID(), locktype: unix.F_WRLCK}
 	lockfiles[filepath.Clean(path)] = locker
 	return locker, nil
 }
 
+// GetROLockfile opens a read/only lock file.  The Locker object
+// return will be returned unlocked.
+func GetROLockfile(path string) (Locker, error) {
+	lockfilesLock.Lock()
+	defer lockfilesLock.Unlock()
+	if lockfiles == nil {
+		lockfiles = make(map[string]*lockfile)
+	}
+	cleanPath := filepath.Clean(path)
+	if locker, ok := lockfiles[cleanPath]; ok {
+		if locker.RWLock() {
+			return nil, fmt.Errorf("Lock %q is a Read/Write lock", cleanPath)
+		}
+		return locker, nil
+	}
+	fd, err := unix.Open(cleanPath, os.O_RDONLY, 0)
+	if err != nil {
+		return nil, errors.Wrapf(err, "Error opening %q", cleanPath)
+	}
+	unix.CloseOnExec(fd)
+	locker := &lockfile{file: path, fd: uintptr(fd), lw: stringid.GenerateRandomID(), locktype: unix.F_RDLCK}
+	lockfiles[filepath.Clean(path)] = locker
+	return locker, nil
+}
+
+// Lock locks the lock file
 func (l *lockfile) Lock() {
 	lk := unix.Flock_t{
-		Type:   unix.F_WRLCK,
+		Type:   l.locktype,
 		Whence: int16(os.SEEK_SET),
 		Start:  0,
 		Len:    0,
@@ -76,6 +114,7 @@ func (l *lockfile) Lock() {
 	}
 }
 
+// Unlock unlocks the lock file
 func (l *lockfile) Unlock() {
 	lk := unix.Flock_t{
 		Type:   unix.F_UNLCK,
@@ -90,6 +129,7 @@ func (l *lockfile) Unlock() {
 	l.mu.Unlock()
 }
 
+// Touch updates the lock file with the UID of the user
 func (l *lockfile) Touch() error {
 	l.lw = stringid.GenerateRandomID()
 	id := []byte(l.lw)
@@ -111,6 +151,7 @@ func (l *lockfile) Touch() error {
 	return nil
 }
 
+// Modified indicates if the lock file has been updated since the last time it was loaded
 func (l *lockfile) Modified() (bool, error) {
 	id := []byte(l.lw)
 	_, err := unix.Seek(int(l.fd), 0, os.SEEK_SET)
@@ -129,6 +170,7 @@ func (l *lockfile) Modified() (bool, error) {
 	return l.lw != lw, nil
 }
 
+// TouchedSince indicates if the lock file has been touched since the specified time
 func (l *lockfile) TouchedSince(when time.Time) bool {
 	st := unix.Stat_t{}
 	err := unix.Fstat(int(l.fd), &st)
@@ -137,4 +179,9 @@ func (l *lockfile) TouchedSince(when time.Time) bool {
 	}
 	touched := time.Unix(statTMtimeUnix(st))
 	return when.Before(touched)
+}
+
+// RWLock indicates if the lock file is a read/write lock
+func (l *lockfile) RWLock() bool {
+	return (l.locktype == unix.F_WRLCK)
 }


### PR DESCRIPTION
We need to handle the situation where lockfiles are stored on readonly
image stores.  We will first attempt a read/write lock and then fall
back on a read/only lock.