### PR TITLE
Fix consistency errors after adding/removing items

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -93,7 +93,7 @@ type ContainerStore interface {
 type containerStore struct {
 	lockfile   Locker
 	dir        string
-	containers []Container
+	containers []*Container
 	idindex    *truncindex.TruncIndex
 	byid       map[string]*Container
 	bylayer    map[string]*Container
@@ -101,7 +101,11 @@ type containerStore struct {
 }
 
 func (r *containerStore) Containers() ([]Container, error) {
-	return r.containers, nil
+	containers := make([]Container, len(r.containers))
+	for i := range r.containers {
+		containers[i] = *(r.containers[i])
+	}
+	return containers, nil
 }
 
 func (r *containerStore) containerspath() string {
@@ -123,7 +127,7 @@ func (r *containerStore) Load() error {
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
-	containers := []Container{}
+	containers := []*Container{}
 	layers := make(map[string]*Container)
 	idlist := []string{}
 	ids := make(map[string]*Container)
@@ -131,14 +135,14 @@ func (r *containerStore) Load() error {
 	if err = json.Unmarshal(data, &containers); len(data) == 0 || err == nil {
 		for n, container := range containers {
 			idlist = append(idlist, container.ID)
-			ids[container.ID] = &containers[n]
-			layers[container.LayerID] = &containers[n]
+			ids[container.ID] = containers[n]
+			layers[container.LayerID] = containers[n]
 			for _, name := range container.Names {
 				if conflict, ok := names[name]; ok {
 					r.removeName(conflict, name)
 					needSave = true
 				}
-				names[name] = &containers[n]
+				names[name] = containers[n]
 			}
 		}
 	}
@@ -179,7 +183,7 @@ func newContainerStore(dir string) (ContainerStore, error) {
 	cstore := containerStore{
 		lockfile:   lockfile,
 		dir:        dir,
-		containers: []Container{},
+		containers: []*Container{},
 		byid:       make(map[string]*Container),
 		bylayer:    make(map[string]*Container),
 		byname:     make(map[string]*Container),
@@ -241,7 +245,7 @@ func (r *containerStore) Create(id string, names []string, image, layer, metadat
 		}
 	}
 	if err == nil {
-		newContainer := Container{
+		container = &Container{
 			ID:           id,
 			Names:        names,
 			ImageID:      image,
@@ -251,8 +255,7 @@ func (r *containerStore) Create(id string, names []string, image, layer, metadat
 			BigDataSizes: make(map[string]int64),
 			Flags:        make(map[string]interface{}),
 		}
-		r.containers = append(r.containers, newContainer)
-		container = &r.containers[len(r.containers)-1]
+		r.containers = append(r.containers, container)
 		r.byid[id] = container
 		r.idindex.Add(id)
 		r.bylayer[layer] = container
@@ -306,7 +309,7 @@ func (r *containerStore) Delete(id string) error {
 		return ErrContainerUnknown
 	}
 	id = container.ID
-	newContainers := []Container{}
+	newContainers := []*Container{}
 	for _, candidate := range r.containers {
 		if candidate.ID != id {
 			newContainers = append(newContainers, candidate)

--- a/images.go
+++ b/images.go
@@ -88,14 +88,18 @@ type ImageStore interface {
 type imageStore struct {
 	lockfile Locker
 	dir      string
-	images   []Image
+	images   []*Image
 	idindex  *truncindex.TruncIndex
 	byid     map[string]*Image
 	byname   map[string]*Image
 }
 
 func (r *imageStore) Images() ([]Image, error) {
-	return r.images, nil
+	images := make([]Image, len(r.images))
+	for i := range r.images {
+		images[i] = *(r.images[i])
+	}
+	return images, nil
 }
 
 func (r *imageStore) imagespath() string {
@@ -117,20 +121,20 @@ func (r *imageStore) Load() error {
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
-	images := []Image{}
+	images := []*Image{}
 	idlist := []string{}
 	ids := make(map[string]*Image)
 	names := make(map[string]*Image)
 	if err = json.Unmarshal(data, &images); len(data) == 0 || err == nil {
 		for n, image := range images {
-			ids[image.ID] = &images[n]
+			ids[image.ID] = images[n]
 			idlist = append(idlist, image.ID)
 			for _, name := range image.Names {
 				if conflict, ok := names[name]; ok {
 					r.removeName(conflict, name)
 					needSave = true
 				}
-				names[name] = &images[n]
+				names[name] = images[n]
 			}
 		}
 	}
@@ -170,7 +174,7 @@ func newImageStore(dir string) (ImageStore, error) {
 	istore := imageStore{
 		lockfile: lockfile,
 		dir:      dir,
-		images:   []Image{},
+		images:   []*Image{},
 		byid:     make(map[string]*Image),
 		byname:   make(map[string]*Image),
 	}
@@ -228,7 +232,7 @@ func (r *imageStore) Create(id string, names []string, layer, metadata string) (
 		}
 	}
 	if err == nil {
-		newImage := Image{
+		image = &Image{
 			ID:           id,
 			Names:        names,
 			TopLayer:     layer,
@@ -237,8 +241,7 @@ func (r *imageStore) Create(id string, names []string, layer, metadata string) (
 			BigDataSizes: make(map[string]int64),
 			Flags:        make(map[string]interface{}),
 		}
-		r.images = append(r.images, newImage)
-		image = &r.images[len(r.images)-1]
+		r.images = append(r.images, image)
 		r.idindex.Add(id)
 		r.byid[id] = image
 		for _, name := range names {
@@ -291,7 +294,7 @@ func (r *imageStore) Delete(id string) error {
 		return ErrImageUnknown
 	}
 	id = image.ID
-	newImages := []Image{}
+	newImages := []*Image{}
 	for _, candidate := range r.images {
 		if candidate.ID != id {
 			newImages = append(newImages, candidate)

--- a/layers.go
+++ b/layers.go
@@ -159,7 +159,7 @@ type layerStore struct {
 	rundir   string
 	driver   drivers.Driver
 	layerdir string
-	layers   []Layer
+	layers   []*Layer
 	idindex  *truncindex.TruncIndex
 	byid     map[string]*Layer
 	byname   map[string]*Layer
@@ -167,7 +167,11 @@ type layerStore struct {
 }
 
 func (r *layerStore) Layers() ([]Layer, error) {
-	return r.layers, nil
+	layers := make([]Layer, len(r.layers))
+	for i := range r.layers {
+		layers[i] = *(r.layers[i])
+	}
+	return layers, nil
 }
 
 func (r *layerStore) mountspath() string {
@@ -185,7 +189,7 @@ func (r *layerStore) Load() error {
 	if err != nil && !os.IsNotExist(err) {
 		return err
 	}
-	layers := []Layer{}
+	layers := []*Layer{}
 	idlist := []string{}
 	ids := make(map[string]*Layer)
 	names := make(map[string]*Layer)
@@ -193,19 +197,19 @@ func (r *layerStore) Load() error {
 	parents := make(map[string][]*Layer)
 	if err = json.Unmarshal(data, &layers); len(data) == 0 || err == nil {
 		for n, layer := range layers {
-			ids[layer.ID] = &layers[n]
+			ids[layer.ID] = layers[n]
 			idlist = append(idlist, layer.ID)
 			for _, name := range layer.Names {
 				if conflict, ok := names[name]; ok {
 					r.removeName(conflict, name)
 					needSave = true
 				}
-				names[name] = &layers[n]
+				names[name] = layers[n]
 			}
 			if pslice, ok := parents[layer.Parent]; ok {
-				parents[layer.Parent] = append(pslice, &layers[n])
+				parents[layer.Parent] = append(pslice, layers[n])
 			} else {
-				parents[layer.Parent] = []*Layer{&layers[n]}
+				parents[layer.Parent] = []*Layer{layers[n]}
 			}
 		}
 	}
@@ -383,15 +387,14 @@ func (r *layerStore) Put(id, parent string, names []string, mountLabel string, o
 		err = r.driver.Create(id, parent, mountLabel, options)
 	}
 	if err == nil {
-		newLayer := Layer{
+		layer = &Layer{
 			ID:         id,
 			Parent:     parent,
 			Names:      names,
 			MountLabel: mountLabel,
 			Flags:      make(map[string]interface{}),
 		}
-		r.layers = append(r.layers, newLayer)
-		layer = &r.layers[len(r.layers)-1]
+		r.layers = append(r.layers, layer)
 		r.idindex.Add(id)
 		r.byid[id] = layer
 		for _, name := range names {
@@ -549,7 +552,7 @@ func (r *layerStore) Delete(id string) error {
 		if layer.MountPoint != "" {
 			delete(r.bymount, layer.MountPoint)
 		}
-		newLayers := []Layer{}
+		newLayers := []*Layer{}
 		for _, candidate := range r.layers {
 			if candidate.ID != id {
 				newLayers = append(newLayers, candidate)


### PR DESCRIPTION
Fix consistency errors we'd hit after creating or deleting a layer, image, or container, by replacing the slice of items in their respective stores with a slice of pointers to items, so that pointers in name- and ID-based indexes don't become invalid when the slice is resized. 