### PR TITLE
Lockfile is leaking file descriptors,  Needs to closexec

### DIFF
--- a/lockfile.go
+++ b/lockfile.go
@@ -56,6 +56,7 @@ func GetLockfile(path string) (Locker, error) {
 	if err != nil {
 		return nil, err
 	}
+	unix.CloseOnExec(fd)
 	locker := &lockfile{file: path, fd: uintptr(fd), lw: stringid.GenerateRandomID()}
 	lockfiles[filepath.Clean(path)] = locker
 	return locker, nil


### PR DESCRIPTION
SELinux is complaining about the leaked file descriptors.

Signed-off-by: Dan Walsh <dwalsh@redhat.com>