### PR TITLE
Implement read-only layer and image stores

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -440,6 +440,10 @@ func (r *containerStore) Modified() (bool, error) {
 	return r.lockfile.Modified()
 }
 
+func (r *containerStore) IsReadWrite() bool {
+	return r.lockfile.IsReadWrite()
+}
+
 func (r *containerStore) TouchedSince(when time.Time) bool {
 	return r.lockfile.TouchedSince(when)
 }

--- a/images.go
+++ b/images.go
@@ -49,11 +49,32 @@ type Image struct {
 	Flags map[string]interface{} `json:"flags,omitempty"`
 }
 
+// ROImageStore provides bookkeeping for information about Images.
+type ROImageStore interface {
+	ROFileBasedStore
+	ROMetadataStore
+	ROBigDataStore
+
+	// Exists checks if there is an image with the given ID or name.
+	Exists(id string) bool
+
+	// Get retrieves information about an image given an ID or name.
+	Get(id string) (*Image, error)
+
+	// Lookup attempts to translate a name to an ID.  Most methods do this
+	// implicitly.
+	Lookup(name string) (string, error)
+
+	// Images returns a slice enumerating the known images.
+	Images() ([]Image, error)
+}
+
 // ImageStore provides bookkeeping for information about Images.
 type ImageStore interface {
-	FileBasedStore
-	MetadataStore
-	BigDataStore
+	ROImageStore
+	RWFileBasedStore
+	RWMetadataStore
+	RWBigDataStore
 	FlaggableStore
 
 	// Create creates an image that has a specified ID (or a random one) and
@@ -65,24 +86,11 @@ type ImageStore interface {
 	// supplied values.
 	SetNames(id string, names []string) error
 
-	// Exists checks if there is an image with the given ID or name.
-	Exists(id string) bool
-
-	// Get retrieves information about an image given an ID or name.
-	Get(id string) (*Image, error)
-
 	// Delete removes the record of the image.
 	Delete(id string) error
 
 	// Wipe removes records of all images.
 	Wipe() error
-
-	// Lookup attempts to translate a name to an ID.  Most methods do this
-	// implicitly.
-	Lookup(name string) (string, error)
-
-	// Images returns a slice enumerating the known images.
-	Images() ([]Image, error)
 }
 
 type imageStore struct {

--- a/images.go
+++ b/images.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"encoding/json"
-	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -11,6 +10,7 @@ import (
 	"github.com/containers/storage/pkg/ioutils"
 	"github.com/containers/storage/pkg/stringid"
 	"github.com/containers/storage/pkg/truncindex"
+	"github.com/pkg/errors"
 )
 
 var (
@@ -123,7 +123,7 @@ func (r *imageStore) datapath(id, key string) string {
 }
 
 func (r *imageStore) Load() error {
-	needSave := false
+	shouldSave := false
 	rpath := r.imagespath()
 	data, err := ioutil.ReadFile(rpath)
 	if err != nil && !os.IsNotExist(err) {
@@ -140,23 +140,29 @@ func (r *imageStore) Load() error {
 			for _, name := range image.Names {
 				if conflict, ok := names[name]; ok {
 					r.removeName(conflict, name)
-					needSave = true
+					shouldSave = true
 				}
 				names[name] = images[n]
 			}
 		}
 	}
+	if shouldSave && !r.IsReadWrite() {
+		return errors.New("image store assigns the same name to multiple images")
+	}
 	r.images = images
 	r.idindex = truncindex.NewTruncIndex(idlist)
 	r.byid = ids
 	r.byname = names
-	if needSave {
+	if shouldSave {
 		return r.Save()
 	}
 	return nil
 }
 
 func (r *imageStore) Save() error {
+	if !r.IsReadWrite() {
+		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to modify the image store at %q", r.imagespath())
+	}
 	rpath := r.imagespath()
 	if err := os.MkdirAll(filepath.Dir(rpath), 0700); err != nil {
 		return err
@@ -192,6 +198,26 @@ func newImageStore(dir string) (ImageStore, error) {
 	return &istore, nil
 }
 
+func newROImageStore(dir string) (ROImageStore, error) {
+	lockfile, err := GetROLockfile(filepath.Join(dir, "images.lock"))
+	if err != nil {
+		return nil, err
+	}
+	lockfile.Lock()
+	defer lockfile.Unlock()
+	istore := imageStore{
+		lockfile: lockfile,
+		dir:      dir,
+		images:   []*Image{},
+		byid:     make(map[string]*Image),
+		byname:   make(map[string]*Image),
+	}
+	if err := istore.Load(); err != nil {
+		return nil, err
+	}
+	return &istore, nil
+}
+
 func (r *imageStore) lookup(id string) (*Image, bool) {
 	if image, ok := r.byid[id]; ok {
 		return image, ok
@@ -205,6 +231,9 @@ func (r *imageStore) lookup(id string) (*Image, bool) {
 }
 
 func (r *imageStore) ClearFlag(id string, flag string) error {
+	if !r.IsReadWrite() {
+		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to clear flags on images at %q", r.imagespath())
+	}
 	image, ok := r.lookup(id)
 	if !ok {
 		return ErrImageUnknown
@@ -214,6 +243,9 @@ func (r *imageStore) ClearFlag(id string, flag string) error {
 }
 
 func (r *imageStore) SetFlag(id string, flag string, value interface{}) error {
+	if !r.IsReadWrite() {
+		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to set flags on images at %q", r.imagespath())
+	}
 	image, ok := r.lookup(id)
 	if !ok {
 		return ErrImageUnknown
@@ -223,6 +255,9 @@ func (r *imageStore) SetFlag(id string, flag string, value interface{}) error {
 }
 
 func (r *imageStore) Create(id string, names []string, layer, metadata string) (image *Image, err error) {
+	if !r.IsReadWrite() {
+		return nil, errors.Wrapf(ErrStoreIsReadOnly, "not allowed to create new images at %q", r.imagespath())
+	}
 	if id == "" {
 		id = stringid.GenerateRandomID()
 		_, idInUse := r.byid[id]
@@ -268,6 +303,9 @@ func (r *imageStore) Metadata(id string) (string, error) {
 }
 
 func (r *imageStore) SetMetadata(id, metadata string) error {
+	if !r.IsReadWrite() {
+		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to modify image metadata at %q", r.imagespath())
+	}
 	if image, ok := r.lookup(id); ok {
 		image.Metadata = metadata
 		return r.Save()
@@ -280,6 +318,9 @@ func (r *imageStore) removeName(image *Image, name string) {
 }
 
 func (r *imageStore) SetNames(id string, names []string) error {
+	if !r.IsReadWrite() {
+		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to change image name assignments at %q", r.imagespath())
+	}
 	if image, ok := r.lookup(id); ok {
 		for _, name := range image.Names {
 			delete(r.byname, name)
@@ -297,6 +338,9 @@ func (r *imageStore) SetNames(id string, names []string) error {
 }
 
 func (r *imageStore) Delete(id string) error {
+	if !r.IsReadWrite() {
+		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to delete images at %q", r.imagespath())
+	}
 	image, ok := r.lookup(id)
 	if !ok {
 		return ErrImageUnknown
@@ -370,6 +414,9 @@ func (r *imageStore) BigDataNames(id string) ([]string, error) {
 }
 
 func (r *imageStore) SetBigData(id, key string, data []byte) error {
+	if !r.IsReadWrite() {
+		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to save data items associated with images at %q", r.imagespath())
+	}
 	image, ok := r.lookup(id)
 	if !ok {
 		return ErrImageUnknown
@@ -404,6 +451,9 @@ func (r *imageStore) SetBigData(id, key string, data []byte) error {
 }
 
 func (r *imageStore) Wipe() error {
+	if !r.IsReadWrite() {
+		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to delete images at %q", r.imagespath())
+	}
 	ids := []string{}
 	for id := range r.byid {
 		ids = append(ids, id)

--- a/images.go
+++ b/images.go
@@ -424,6 +424,10 @@ func (r *imageStore) Modified() (bool, error) {
 	return r.lockfile.Modified()
 }
 
+func (r *imageStore) IsReadWrite() bool {
+	return r.lockfile.IsReadWrite()
+}
+
 func (r *imageStore) TouchedSince(when time.Time) bool {
 	return r.lockfile.TouchedSince(when)
 }

--- a/layers.go
+++ b/layers.go
@@ -825,6 +825,10 @@ func (r *layerStore) Modified() (bool, error) {
 	return r.lockfile.Modified()
 }
 
+func (r *layerStore) IsReadWrite() bool {
+	return r.lockfile.IsReadWrite()
+}
+
 func (r *layerStore) TouchedSince(when time.Time) bool {
 	return r.lockfile.TouchedSince(when)
 }

--- a/store.go
+++ b/store.go
@@ -52,6 +52,8 @@ var (
 	ErrIncompleteOptions = errors.New("missing necessary StoreOptions")
 	// ErrSizeUnknown is returned when the caller asks for the size of a big data item, but the Store couldn't determine the answer.
 	ErrSizeUnknown = errors.New("size is not known")
+	// ErrStoreIsReadOnly is returned when the caller makes a call to a read-only store that would require modifying its contents.
+	ErrStoreIsReadOnly = errors.New("called a write method on a read-only store")
 	// DefaultStoreOptions is a reasonable default set of options.
 	DefaultStoreOptions StoreOptions
 	stores              []*store

--- a/store.go
+++ b/store.go
@@ -58,37 +58,54 @@ var (
 	storesLock          sync.Mutex
 )
 
-// FileBasedStore wraps up the most common methods of the various types of file-based
-// data stores that we implement.
-type FileBasedStore interface {
+// ROFileBasedStore wraps up the methods of the various types of file-based
+// data stores that we implement which are needed for both read-only and
+// read-write files.
+type ROFileBasedStore interface {
 	Locker
 
 	// Load reloads the contents of the store from disk.  It should be called
 	// with the lock held.
 	Load() error
+}
 
+// RWFileBasedStore wraps up the methods of various types of file-based data
+// stores that we implement using read-write files.
+type RWFileBasedStore interface {
 	// Save saves the contents of the store to disk.  It should be called with
 	// the lock held, and Touch() should be called afterward before releasing the
 	// lock.
 	Save() error
 }
 
-// MetadataStore wraps up methods for getting and setting metadata associated with IDs.
-type MetadataStore interface {
+// FileBasedStore wraps up the common methods of various types of file-based
+// data stores that we implement.
+type FileBasedStore interface {
+	ROFileBasedStore
+	RWFileBasedStore
+}
+
+// ROMetadataStore wraps a method for reading metadata associated with an ID.
+type ROMetadataStore interface {
 	// Metadata reads metadata associated with an item with the specified ID.
 	Metadata(id string) (string, error)
+}
 
+// RWMetadataStore wraps a method for setting metadata associated with an ID.
+type RWMetadataStore interface {
 	// SetMetadata updates the metadata associated with the item with the specified ID.
 	SetMetadata(id, metadata string) error
 }
 
-// A BigDataStore wraps up the most common methods of the various types of
-// file-based lookaside stores that we implement.
-type BigDataStore interface {
-	// SetBigData stores a (potentially large) piece of data associated with this
-	// ID.
-	SetBigData(id, key string, data []byte) error
+// MetadataStore wraps up methods for getting and setting metadata associated with IDs.
+type MetadataStore interface {
+	ROMetadataStore
+	RWMetadataStore
+}
 
+// An ROBigDataStore wraps up the read-only big-data related methods of the
+// various types of file-based lookaside stores that we implement.
+type ROBigDataStore interface {
 	// BigData retrieves a (potentially large) piece of data associated with
 	// this ID, if it has previously been set.
 	BigData(id, key string) ([]byte, error)
@@ -100,6 +117,21 @@ type BigDataStore interface {
 	// BigDataNames() returns a list of the names of previously-stored pieces of
 	// data.
 	BigDataNames(id string) ([]string, error)
+}
+
+// A RWBigDataStore wraps up the read-write big-data related methods of the
+// various types of file-based lookaside stores that we implement.
+type RWBigDataStore interface {
+	// SetBigData stores a (potentially large) piece of data associated with this
+	// ID.
+	SetBigData(id, key string, data []byte) error
+}
+
+// A BigDataStore wraps up the most common big-data related methods of the
+// various types of file-based lookaside stores that we implement.
+type BigDataStore interface {
+	ROBigDataStore
+	RWBigDataStore
 }
 
 // A FlaggableStore can have flags set and cleared on items which it manages.


### PR DESCRIPTION
Building off of #50 and subsuming the changes from #52, this patch set refactors the existing LayerStore and ImageStore interfaces and introduces subsets of them that aren't expected to modify the underlying data.  It also implements versions of the implementations that take read-only locks instead of read-write locks, and uses those to handle additional storage locations.