### PR TITLE
Make Diff() methods take an optional *DiffOptions

### DIFF
--- a/docs/containers-storage-diff.md
+++ b/docs/containers-storage-diff.md
@@ -19,9 +19,14 @@ Write the diff to the specified file instead of stdout.
 
 **-c | --gzip**
 
-Compress the diff using gzip compression.  If the layer was populated by a
-layer diff, and that layer diff was compressed, this will be done
-automatically.
+Force the diff to be compressed using gzip compression.  If the layer was
+populated by a layer diff, and that layer diff was compressed, this will be
+done automatically.
+
+**-u | --uncompressed**
+
+Force the diff to be uncompressed.  If the layer was populated by a layer diff,
+and that layer diff was compressed, it will be decompressed for output.
 
 ## EXAMPLE
 **oci-storage diff my-base-layer**

--- a/store.go
+++ b/store.go
@@ -298,8 +298,8 @@ type Store interface {
 	DiffSize(from, to string) (int64, error)
 
 	// Diff returns the tarstream which would specify the changes returned by
-	// Changes.
-	Diff(from, to string) (io.ReadCloser, error)
+	// Changes.  If options are passed in, they can override default behaviors.
+	Diff(from, to string, options *DiffOptions) (io.ReadCloser, error)
 
 	// ApplyDiff applies a tarstream to a layer.  Information about the tarstream
 	// is cached with the layer.  Typically, a layer which is populated using a
@@ -1747,7 +1747,7 @@ func (s *store) DiffSize(from, to string) (int64, error) {
 	return -1, ErrLayerUnknown
 }
 
-func (s *store) Diff(from, to string) (io.ReadCloser, error) {
+func (s *store) Diff(from, to string, options *DiffOptions) (io.ReadCloser, error) {
 	rlstore, err := s.LayerStore()
 	if err != nil {
 		return nil, err
@@ -1764,7 +1764,7 @@ func (s *store) Diff(from, to string) (io.ReadCloser, error) {
 			rlstore.Load()
 		}
 		if rlstore.Exists(to) {
-			return rlstore.Diff(from, to)
+			return rlstore.Diff(from, to, options)
 		}
 	}
 	return nil, ErrLayerUnknown


### PR DESCRIPTION
Add an optional *DiffOptions parameter to Diff() methods (which can be nil), to allow overriding of default behaviors.

At this time, that's just what type of compression is applied, if we want something other than what was recorded when the diff was applied, but we can add more later if needed.