### PR TITLE
layers|containers: do not allocate slices at every delete

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -309,10 +309,11 @@ func (r *containerStore) Delete(id string) error {
 		return ErrContainerUnknown
 	}
 	id = container.ID
-	newContainers := []*Container{}
-	for _, candidate := range r.containers {
-		if candidate.ID != id {
-			newContainers = append(newContainers, candidate)
+	toDeleteIndex := -1
+	for i, candidate := range r.containers {
+		if candidate.ID == id {
+			toDeleteIndex = i
+			break
 		}
 	}
 	delete(r.byid, id)
@@ -321,7 +322,14 @@ func (r *containerStore) Delete(id string) error {
 	for _, name := range container.Names {
 		delete(r.byname, name)
 	}
-	r.containers = newContainers
+	if toDeleteIndex != -1 {
+		// delete the container at toDeleteIndex
+		if toDeleteIndex == len(r.containers)-1 {
+			r.containers = r.containers[:len(r.containers)-1]
+		} else {
+			r.containers = append(r.containers[:toDeleteIndex], r.containers[toDeleteIndex+1:]...)
+		}
+	}
 	if err := r.Save(); err != nil {
 		return err
 	}

--- a/images.go
+++ b/images.go
@@ -346,10 +346,10 @@ func (r *imageStore) Delete(id string) error {
 		return ErrImageUnknown
 	}
 	id = image.ID
-	newImages := []*Image{}
-	for _, candidate := range r.images {
-		if candidate.ID != id {
-			newImages = append(newImages, candidate)
+	toDeleteIndex := -1
+	for i, candidate := range r.images {
+		if candidate.ID == id {
+			toDeleteIndex = i
 		}
 	}
 	delete(r.byid, id)
@@ -357,7 +357,14 @@ func (r *imageStore) Delete(id string) error {
 	for _, name := range image.Names {
 		delete(r.byname, name)
 	}
-	r.images = newImages
+	if toDeleteIndex != -1 {
+		// delete the image at toDeleteIndex
+		if toDeleteIndex == len(r.images)-1 {
+			r.images = r.images[:len(r.images)-1]
+		} else {
+			r.images = append(r.images[:toDeleteIndex], r.images[toDeleteIndex+1:]...)
+		}
+	}
 	if err := r.Save(); err != nil {
 		return err
 	}

--- a/layers.go
+++ b/layers.go
@@ -615,13 +615,21 @@ func (r *layerStore) Delete(id string) error {
 		if layer.MountPoint != "" {
 			delete(r.bymount, layer.MountPoint)
 		}
-		newLayers := []*Layer{}
-		for _, candidate := range r.layers {
-			if candidate.ID != id {
-				newLayers = append(newLayers, candidate)
+		toDeleteIndex := -1
+		for i, candidate := range r.layers {
+			if candidate.ID == id {
+				toDeleteIndex = i
+				break
 			}
 		}
-		r.layers = newLayers
+		if toDeleteIndex != -1 {
+			// delete the layer at toDeleteIndex
+			if toDeleteIndex == len(r.layers)-1 {
+				r.layers = r.layers[:len(r.layers)-1]
+			} else {
+				r.layers = append(r.layers[:toDeleteIndex], r.layers[toDeleteIndex+1:]...)
+			}
+		}
 		if err = r.Save(); err != nil {
 			return err
 		}


### PR DESCRIPTION
Was playing around with CRI-O profiler (https://github.com/kubernetes-incubator/cri-o/pull/612) and ran into this:

When Delete:ing a layer or a container the code was always allocating a
new slice just to remove an element from the original slice.
Profiling cri-o with c/storage showed that doing it at every delete is
pretty expensive:

```
         .          .    309:   newContainers := []Container{}
         .          .    310:   for _, candidate := range r.containers
{
         .          .    311:           if candidate.ID != id {
  528.17kB   528.17kB    312:                   newContainers =
append(newContainers, candidate)
         .          .    313:           }
         .          .    314:   }

         .          .    552:           newLayers := []Layer{}
         .          .    553:           for _, candidate := range
r.layers {
         .          .    554:                   if candidate.ID != id {
    1.03MB     1.03MB    555:                           newLayers =
append(newLayers, candidate)
         .          .    556:                   }
         .          .    557:           }
         .          .    558:           r.layers = newLayers
```

This patch just filters out the element to remove from the original
slice w/o allocating a new slice. After this patch, no memory overhead
anymore is shown in the profiler.

@mrunalp @rhatdan @nalind PTAL

Signed-off-by: Antonio Murdaca <runcom@redhat.com>