### PR TITLE
When creating images, options are optional

### DIFF
--- a/store.go
+++ b/store.go
@@ -809,7 +809,13 @@ func (s *store) CreateImage(id string, names []string, layer, metadata string, o
 	if modified, err := ristore.Modified(); modified || err != nil {
 		ristore.Load()
 	}
-	return ristore.Create(id, names, layer, metadata, options.CreationDate)
+
+	creationDate := time.Now().UTC()
+	if options != nil {
+		creationDate = options.CreationDate
+	}
+
+	return ristore.Create(id, names, layer, metadata, creationDate)
 }
 
 func (s *store) CreateContainer(id string, names []string, image, layer, metadata string, options *ContainerOptions) (*Container, error) {


### PR DESCRIPTION
Since ImageOptions are optional when calling a store's CreateImage() method, we can't assume that there's a value there.