### PR TITLE
Fix compression of Diff() results for parent/child diffs with no tarsplit data

### DIFF
--- a/drivers/aufs/aufs_test.go
+++ b/drivers/aufs/aufs_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/containers/storage/pkg/archive"
 	"github.com/containers/storage/pkg/reexec"
 	"github.com/containers/storage/pkg/stringid"
+
+	"github.com/pkg/errors"
 )
 
 var (
@@ -30,7 +32,7 @@ func init() {
 func testInit(dir string, t testing.TB) graphdriver.Driver {
 	d, err := Init(dir, nil, nil, nil)
 	if err != nil {
-		if err == graphdriver.ErrNotSupported {
+		if errors.Cause(err) == graphdriver.ErrNotSupported {
 			t.Skip(err)
 		} else {
 			t.Fatal(err)

--- a/drivers/aufs/mount_unsupported.go
+++ b/drivers/aufs/mount_unsupported.go
@@ -2,7 +2,7 @@
 
 package aufs
 
-import "errors"
+import "github.com/pkg/errors"
 
 // MsRemount declared to specify a non-linux system mount.
 const MsRemount = 0

--- a/drivers/btrfs/btrfs.go
+++ b/drivers/btrfs/btrfs.go
@@ -27,8 +27,10 @@ import (
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/mount"
 	"github.com/containers/storage/pkg/parsers"
+
 	"github.com/docker/go-units"
 	"github.com/opencontainers/selinux/go-selinux/label"
+	"github.com/pkg/errors"
 )
 
 func init() {
@@ -55,7 +57,7 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 	}
 
 	if fsMagic != graphdriver.FsMagicBtrfs {
-		return nil, graphdriver.ErrPrerequisites
+		return nil, errors.Wrapf(graphdriver.ErrPrerequisites, "%q is not on a btrfs filesystem", home)
 	}
 
 	rootUID, rootGID, err := idtools.GetRootUIDGID(uidMaps, gidMaps)

--- a/drivers/driver_solaris.go
+++ b/drivers/driver_solaris.go
@@ -20,6 +20,7 @@ import (
 	"unsafe"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -56,7 +57,7 @@ func Mounted(fsType FsMagic, mountPath string) (bool, error) {
 		(buf.f_basetype[3] != 0) {
 		log.Debugf("[zfs] no zfs dataset found for rootdir '%s'", mountPath)
 		C.free(unsafe.Pointer(buf))
-		return false, ErrPrerequisites
+		return false, errors.Wrapf(graphdriver.ErrPrerequisites, "%q is not on a zfs filesystem", mountPath)
 	}
 
 	C.free(unsafe.Pointer(buf))

--- a/drivers/graphtest/graphtest_unix.go
+++ b/drivers/graphtest/graphtest_unix.go
@@ -16,6 +16,7 @@ import (
 	"github.com/containers/storage/drivers"
 	"github.com/containers/storage/pkg/stringid"
 	"github.com/docker/go-units"
+	"github.com/pkg/errors"
 )
 
 var (
@@ -41,9 +42,10 @@ func newDriver(t testing.TB, name string, options []string) *Driver {
 		t.Fatal(err)
 	}
 
-	d, err := graphdriver.GetDriver(name, root, options, nil, nil)
-	if err != nil {
+	d, werr := graphdriver.GetDriver(name, root, options, nil, nil)
+	if werr != nil {
 		t.Logf("graphdriver: %v\n", err)
+		err = errors.Cause(werr)
 		if err == graphdriver.ErrNotSupported || err == graphdriver.ErrPrerequisites || err == graphdriver.ErrIncompatibleFS {
 			t.Skipf("Driver %s not supported", name)
 		}

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -4,7 +4,6 @@ package overlay
 
 import (
 	"bufio"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -15,8 +14,6 @@ import (
 	"strings"
 	"syscall"
 
-	"github.com/Sirupsen/logrus"
-
 	"github.com/containers/storage/drivers"
 	"github.com/containers/storage/pkg/archive"
 	"github.com/containers/storage/pkg/chrootarchive"
@@ -26,7 +23,9 @@ import (
 	"github.com/containers/storage/pkg/parsers"
 	"github.com/containers/storage/pkg/parsers/kernel"
 
+	"github.com/Sirupsen/logrus"
 	"github.com/opencontainers/selinux/go-selinux/label"
+	"github.com/pkg/errors"
 )
 
 var (
@@ -102,7 +101,7 @@ func InitWithName(name, home string, options []string, uidMaps, gidMaps []idtool
 	}
 
 	if err := supportsOverlay(); err != nil {
-		return nil, graphdriver.ErrNotSupported
+		return nil, errors.Wrap(graphdriver.ErrNotSupported, "overlay not supported")
 	}
 
 	// require kernel 4.0.0 to ensure multiple lower dirs are supported
@@ -112,7 +111,7 @@ func InitWithName(name, home string, options []string, uidMaps, gidMaps []idtool
 	}
 	if kernel.CompareKernelVersion(*v, kernel.VersionInfo{Kernel: 4, Major: 0, Minor: 0}) < 0 {
 		if !opts.overrideKernelCheck {
-			return nil, graphdriver.ErrNotSupported
+			return nil, errors.Wrap(graphdriver.ErrNotSupported, "kernel too old to provide multiple lowers feature for overlay")
 		}
 		logrus.Warnf("Using pre-4.0.0 kernel for overlay, mount failures may require kernel update")
 	}
@@ -129,7 +128,7 @@ func InitWithName(name, home string, options []string, uidMaps, gidMaps []idtool
 	switch fsMagic {
 	case graphdriver.FsMagicBtrfs, graphdriver.FsMagicAufs, graphdriver.FsMagicZfs, graphdriver.FsMagicOverlay, graphdriver.FsMagicEcryptfs:
 		logrus.Errorf("'overlay' is not supported over %s", backingFs)
-		return nil, graphdriver.ErrIncompatibleFS
+		return nil, errors.Wrapf(graphdriver.ErrIncompatibleFS, "'overlay' is not supported over %s", backingFs)
 	}
 
 	rootUID, rootGID, err := idtools.GetRootUIDGID(uidMaps, gidMaps)
@@ -231,7 +230,7 @@ func supportsOverlay() error {
 		}
 	}
 	logrus.Error("'overlay' not found as a supported filesystem on this host. Please ensure kernel is new enough and has overlay support loaded.")
-	return graphdriver.ErrNotSupported
+	return errors.Wrapf(graphdriver.ErrNotSupported, "overlay filesystem was not and could not be loaded")
 }
 
 func (d *Driver) String() string {

--- a/drivers/proxy.go
+++ b/drivers/proxy.go
@@ -3,8 +3,9 @@
 package graphdriver
 
 import (
-	"errors"
 	"fmt"
+
+	"github.com/pkg/errors"
 
 	"github.com/containers/storage/pkg/archive"
 )

--- a/drivers/windows/windows.go
+++ b/drivers/windows/windows.go
@@ -23,6 +23,8 @@ import (
 	"github.com/Microsoft/go-winio/backuptar"
 	"github.com/Microsoft/hcsshim"
 	"github.com/Sirupsen/logrus"
+	"github.com/vbatts/tar-split/tar/storage"
+
 	"github.com/containers/storage/drivers"
 	"github.com/containers/storage/pkg/archive"
 	"github.com/containers/storage/pkg/idtools"
@@ -30,7 +32,6 @@ import (
 	"github.com/containers/storage/pkg/longpath"
 	"github.com/containers/storage/pkg/reexec"
 	"github.com/containers/storage/pkg/system"
-	"github.com/vbatts/tar-split/tar/storage"
 )
 
 // filterDriver is an HCSShim driver type for the Windows Filter driver.

--- a/drivers/zfs/zfs.go
+++ b/drivers/zfs/zfs.go
@@ -13,13 +13,15 @@ import (
 	"syscall"
 	"time"
 
-	"github.com/Sirupsen/logrus"
 	"github.com/containers/storage/drivers"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/mount"
 	"github.com/containers/storage/pkg/parsers"
+
+	"github.com/Sirupsen/logrus"
 	zfs "github.com/mistifyio/go-zfs"
 	"github.com/opencontainers/selinux/go-selinux/label"
+	"github.com/pkg/errors"
 )
 
 type zfsOptions struct {
@@ -47,13 +49,13 @@ func Init(base string, opt []string, uidMaps, gidMaps []idtools.IDMap) (graphdri
 
 	if _, err := exec.LookPath("zfs"); err != nil {
 		logrus.Debugf("[zfs] zfs command is not available: %v", err)
-		return nil, graphdriver.ErrPrerequisites
+		return nil, errors.Wrap(graphdriver.ErrPrerequisites, "the 'zfs' command was not found")
 	}
 
 	file, err := os.OpenFile("/dev/zfs", os.O_RDWR, 600)
 	if err != nil {
 		logrus.Debugf("[zfs] cannot open /dev/zfs: %v", err)
-		return nil, graphdriver.ErrPrerequisites
+		return nil, errors.Wrapf(graphdriver.ErrPrerequisites, "could not open /dev/zfs: %v", err)
 	}
 	defer file.Close()
 

--- a/drivers/zfs/zfs_freebsd.go
+++ b/drivers/zfs/zfs_freebsd.go
@@ -6,6 +6,8 @@ import (
 	"syscall"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/pkg/errors"
+
 	"github.com/containers/storage/drivers"
 )
 
@@ -18,7 +20,7 @@ func checkRootdirFs(rootdir string) error {
 	// on FreeBSD buf.Fstypename contains ['z', 'f', 's', 0 ... ]
 	if (buf.Fstypename[0] != 122) || (buf.Fstypename[1] != 102) || (buf.Fstypename[2] != 115) || (buf.Fstypename[3] != 0) {
 		logrus.Debugf("[zfs] no zfs dataset found for rootdir '%s'", rootdir)
-		return graphdriver.ErrPrerequisites
+		return errors.Wrapf(graphdriver.ErrPrerequisites, "%q is not on a zfs filesystem", rootdir)
 	}
 
 	return nil

--- a/drivers/zfs/zfs_linux.go
+++ b/drivers/zfs/zfs_linux.go
@@ -5,6 +5,8 @@ import (
 	"syscall"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/pkg/errors"
+
 	"github.com/containers/storage/drivers"
 )
 
@@ -16,7 +18,7 @@ func checkRootdirFs(rootdir string) error {
 
 	if graphdriver.FsMagic(buf.Type) != graphdriver.FsMagicZfs {
 		logrus.Debugf("[zfs] no zfs dataset found for rootdir '%s'", rootdir)
-		return graphdriver.ErrPrerequisites
+		return errors.Wrapf(graphdriver.ErrPrerequisites, "%q is not on a zfs filesystem", rootdir)
 	}
 
 	return nil

--- a/drivers/zfs/zfs_solaris.go
+++ b/drivers/zfs/zfs_solaris.go
@@ -21,6 +21,8 @@ import (
 	"unsafe"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/pkg/errors"
+
 	"github.com/containers/storage/drivers"
 )
 
@@ -34,7 +36,7 @@ func checkRootdirFs(rootdir string) error {
 		(buf.f_basetype[3] != 0) {
 		log.Debugf("[zfs] no zfs dataset found for rootdir '%s'", rootdir)
 		C.free(unsafe.Pointer(buf))
-		return graphdriver.ErrPrerequisites
+		return errors.Wrapf(graphdriver.ErrPrerequisites, "%q is not on a zfs filesystem", rootdir)
 	}
 
 	C.free(unsafe.Pointer(buf))

--- a/layers.go
+++ b/layers.go
@@ -815,7 +815,7 @@ func (r *layerStore) Diff(from, to string, options *DiffOptions) (io.ReadCloser,
 	if err != nil {
 		return nil, ErrLayerUnknown
 	}
-	// Default to applying the type of encryption that we noted was used
+	// Default to applying the type of compression that we noted was used
 	// for the layerdiff when it was applied.
 	compression := toLayer.CompressionType
 	// If a particular compression type (or no compression) was selected,


### PR DESCRIPTION
The `Diff()` method didn't handle recompression correctly when generating a diff between a layer and its parent when there was no tar-split data present.

We also wrap a couple of `ErrNotSupported` errors with context info, and update some godoc comments.