### PR TITLE
Wrap some driver-level errors

### DIFF
--- a/drivers/aufs/aufs.go
+++ b/drivers/aufs/aufs.go
@@ -47,6 +47,7 @@ import (
 
 	rsystem "github.com/opencontainers/runc/libcontainer/system"
 	"github.com/opencontainers/selinux/go-selinux/label"
+	"github.com/pkg/errors"
 )
 
 var (
@@ -81,7 +82,7 @@ func Init(root string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 
 	// Try to load the aufs kernel module
 	if err := supportsAufs(); err != nil {
-		return nil, graphdriver.ErrNotSupported
+		return nil, errors.Wrap(graphdriver.ErrNotSupported, "kernel does not support aufs")
 	}
 
 	fsMagic, err := graphdriver.GetFSMagic(root)
@@ -95,7 +96,7 @@ func Init(root string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 	switch fsMagic {
 	case graphdriver.FsMagicAufs, graphdriver.FsMagicBtrfs, graphdriver.FsMagicEcryptfs:
 		logrus.Errorf("AUFS is not supported over %s", backingFs)
-		return nil, graphdriver.ErrIncompatibleFS
+		return nil, errors.Wrapf(graphdriver.ErrIncompatibleFS, "AUFS is not supported over %q", backingFs)
 	}
 
 	paths := []string{

--- a/drivers/aufs/aufs_test.go
+++ b/drivers/aufs/aufs_test.go
@@ -16,6 +16,7 @@ import (
 	"github.com/containers/storage/pkg/archive"
 	"github.com/containers/storage/pkg/reexec"
 	"github.com/containers/storage/pkg/stringid"
+	"github.com/pkg/errors"
 )
 
 var (
@@ -30,7 +31,7 @@ func init() {
 func testInit(dir string, t testing.TB) graphdriver.Driver {
 	d, err := Init(dir, nil, nil, nil)
 	if err != nil {
-		if err == graphdriver.ErrNotSupported {
+		if errors.Cause(err) == graphdriver.ErrNotSupported {
 			t.Skip(err)
 		} else {
 			t.Fatal(err)

--- a/drivers/aufs/mount_unsupported.go
+++ b/drivers/aufs/mount_unsupported.go
@@ -2,7 +2,7 @@
 
 package aufs
 
-import "errors"
+import "github.com/pkg/errors"
 
 // MsRemount declared to specify a non-linux system mount.
 const MsRemount = 0

--- a/drivers/btrfs/btrfs.go
+++ b/drivers/btrfs/btrfs.go
@@ -29,6 +29,7 @@ import (
 	"github.com/containers/storage/pkg/parsers"
 	"github.com/docker/go-units"
 	"github.com/opencontainers/selinux/go-selinux/label"
+	"github.com/pkg/errors"
 )
 
 func init() {
@@ -55,7 +56,7 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 	}
 
 	if fsMagic != graphdriver.FsMagicBtrfs {
-		return nil, graphdriver.ErrPrerequisites
+		return nil, errors.Wrapf(graphdriver.ErrPrerequisites, "%q is not on a btrfs filesystem", home)
 	}
 
 	rootUID, rootGID, err := idtools.GetRootUIDGID(uidMaps, gidMaps)

--- a/drivers/devmapper/deviceset.go
+++ b/drivers/devmapper/deviceset.go
@@ -5,7 +5,6 @@ package devmapper
 import (
 	"bufio"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -31,6 +30,7 @@ import (
 	"github.com/docker/go-units"
 
 	"github.com/opencontainers/selinux/go-selinux/label"
+	"github.com/pkg/errors"
 )
 
 var (
@@ -1474,7 +1474,7 @@ func determineDriverCapabilities(version string) error {
 	versionSplit := strings.Split(version, ".")
 	major, err := strconv.Atoi(versionSplit[0])
 	if err != nil {
-		return graphdriver.ErrNotSupported
+		return errors.Wrapf(graphdriver.ErrNotSupported, "unable to parse driver major version %q as a number", versionSplit[0])
 	}
 
 	if major > 4 {
@@ -1488,7 +1488,7 @@ func determineDriverCapabilities(version string) error {
 
 	minor, err := strconv.Atoi(versionSplit[1])
 	if err != nil {
-		return graphdriver.ErrNotSupported
+		return errors.Wrapf(graphdriver.ErrNotSupported, "unable to parse driver minor version %q as a number", versionSplit[1])
 	}
 
 	/*
@@ -1655,11 +1655,11 @@ func (devices *DeviceSet) initDevmapper(doInit bool) error {
 	version, err := devicemapper.GetDriverVersion()
 	if err != nil {
 		// Can't even get driver version, assume not supported
-		return graphdriver.ErrNotSupported
+		return errors.Wrap(graphdriver.ErrNotSupported, "unable to determine version of device mapper")
 	}
 
 	if err := determineDriverCapabilities(version); err != nil {
-		return graphdriver.ErrNotSupported
+		return errors.Wrap(graphdriver.ErrNotSupported, "unable to determine device mapper driver capabilities")
 	}
 
 	if err := devices.enableDeferredRemovalDeletion(); err != nil {
@@ -1959,7 +1959,7 @@ func (devices *DeviceSet) deleteTransaction(info *devInfo, syncDelete bool) erro
 		// If syncDelete is true, we want to return error. If deferred
 		// deletion is not enabled, we return an error. If error is
 		// something other then EBUSY, return an error.
-		if syncDelete || !devices.deferredDelete || err != devicemapper.ErrBusy {
+		if syncDelete || !devices.deferredDelete || errors.Cause(err) != devicemapper.ErrBusy {
 			logrus.Debugf("devmapper: Error deleting device: %s", err)
 			return err
 		}
@@ -2114,7 +2114,7 @@ func (devices *DeviceSet) removeDevice(devname string) error {
 		if err == nil {
 			break
 		}
-		if err != devicemapper.ErrBusy {
+		if errors.Cause(err) != devicemapper.ErrBusy {
 			return err
 		}
 
@@ -2149,12 +2149,12 @@ func (devices *DeviceSet) cancelDeferredRemoval(info *devInfo) error {
 			break
 		}
 
-		if err == devicemapper.ErrEnxio {
+		if errors.Cause(err) == devicemapper.ErrEnxio {
 			// Device is probably already gone. Return success.
 			return nil
 		}
 
-		if err != devicemapper.ErrBusy {
+		if errors.Cause(err) != devicemapper.ErrBusy {
 			return err
 		}
 

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -1,13 +1,13 @@
 package graphdriver
 
 import (
-	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
 
 	"github.com/Sirupsen/logrus"
+	"github.com/pkg/errors"
 	"github.com/vbatts/tar-split/tar/storage"
 
 	"github.com/containers/storage/pkg/archive"
@@ -144,7 +144,7 @@ func GetDriver(name, home string, options []string, uidMaps, gidMaps []idtools.I
 		return pluginDriver, nil
 	}
 	logrus.Errorf("Failed to GetDriver graph %s %s", name, home)
-	return nil, ErrNotSupported
+	return nil, errors.Wrapf(ErrNotSupported, "failed to GetDriver graph %s %s", name, home)
 }
 
 // getBuiltinDriver initializes and returns the registered driver, but does not try to load from plugins
@@ -153,7 +153,7 @@ func getBuiltinDriver(name, home string, options []string, uidMaps, gidMaps []id
 		return initFunc(filepath.Join(home, name), options, uidMaps, gidMaps)
 	}
 	logrus.Errorf("Failed to built-in GetDriver graph %s %s", name, home)
-	return nil, ErrNotSupported
+	return nil, errors.Wrapf(ErrNotSupported, "failed to built-in GetDriver graph %s %s", name, home)
 }
 
 // New creates the driver and initializes it at the specified root.
@@ -228,7 +228,8 @@ func New(root string, name string, options []string, uidMaps, gidMaps []idtools.
 // isDriverNotSupported returns true if the error initializing
 // the graph driver is a non-supported error.
 func isDriverNotSupported(err error) bool {
-	return err == ErrNotSupported || err == ErrPrerequisites || err == ErrIncompatibleFS
+	cause := errors.Cause(err)
+	return cause == ErrNotSupported || cause == ErrPrerequisites || cause == ErrIncompatibleFS
 }
 
 // scanPriorDrivers returns an un-ordered scan of directories of prior storage drivers

--- a/drivers/driver_solaris.go
+++ b/drivers/driver_solaris.go
@@ -20,6 +20,7 @@ import (
 	"unsafe"
 
 	log "github.com/Sirupsen/logrus"
+	"github.com/pkg/errors"
 )
 
 const (
@@ -56,7 +57,7 @@ func Mounted(fsType FsMagic, mountPath string) (bool, error) {
 		(buf.f_basetype[3] != 0) {
 		log.Debugf("[zfs] no zfs dataset found for rootdir '%s'", mountPath)
 		C.free(unsafe.Pointer(buf))
-		return false, ErrPrerequisites
+		return false, errors.Wrapf(graphdriver.ErrPrerequisites, "no zfs dataset found for rootdir '%s'", mountPath)
 	}
 
 	C.free(unsafe.Pointer(buf))

--- a/drivers/graphtest/graphtest_unix.go
+++ b/drivers/graphtest/graphtest_unix.go
@@ -16,6 +16,7 @@ import (
 	"github.com/containers/storage/drivers"
 	"github.com/containers/storage/pkg/stringid"
 	"github.com/docker/go-units"
+	"github.com/pkg/errors"
 )
 
 var (
@@ -44,7 +45,8 @@ func newDriver(t testing.TB, name string, options []string) *Driver {
 	d, err := graphdriver.GetDriver(name, root, options, nil, nil)
 	if err != nil {
 		t.Logf("graphdriver: %v\n", err)
-		if err == graphdriver.ErrNotSupported || err == graphdriver.ErrPrerequisites || err == graphdriver.ErrIncompatibleFS {
+		cause := errors.Cause(err)
+		if cause == graphdriver.ErrNotSupported || cause == graphdriver.ErrPrerequisites || cause == graphdriver.ErrIncompatibleFS {
 			t.Skipf("Driver %s not supported", name)
 		}
 		t.Fatal(err)

--- a/drivers/proxy.go
+++ b/drivers/proxy.go
@@ -3,10 +3,10 @@
 package graphdriver
 
 import (
-	"errors"
 	"fmt"
 
 	"github.com/containers/storage/pkg/archive"
+	"github.com/pkg/errors"
 )
 
 type graphDriverProxy struct {

--- a/drivers/zfs/zfs.go
+++ b/drivers/zfs/zfs.go
@@ -20,6 +20,7 @@ import (
 	"github.com/containers/storage/pkg/parsers"
 	zfs "github.com/mistifyio/go-zfs"
 	"github.com/opencontainers/selinux/go-selinux/label"
+	"github.com/pkg/errors"
 )
 
 type zfsOptions struct {
@@ -47,13 +48,13 @@ func Init(base string, opt []string, uidMaps, gidMaps []idtools.IDMap) (graphdri
 
 	if _, err := exec.LookPath("zfs"); err != nil {
 		logrus.Debugf("[zfs] zfs command is not available: %v", err)
-		return nil, graphdriver.ErrPrerequisites
+		return nil, errors.Wrap(graphdriver.ErrPrerequisites, "the 'zfs' command is not available")
 	}
 
 	file, err := os.OpenFile("/dev/zfs", os.O_RDWR, 600)
 	if err != nil {
 		logrus.Debugf("[zfs] cannot open /dev/zfs: %v", err)
-		return nil, graphdriver.ErrPrerequisites
+		return nil, errors.Wrapf(graphdriver.ErrPrerequisites, "could not open /dev/zfs: %v", err)
 	}
 	defer file.Close()
 

--- a/drivers/zfs/zfs_freebsd.go
+++ b/drivers/zfs/zfs_freebsd.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/containers/storage/drivers"
+	"github.com/pkg/errors"
 )
 
 func checkRootdirFs(rootdir string) error {
@@ -18,7 +19,7 @@ func checkRootdirFs(rootdir string) error {
 	// on FreeBSD buf.Fstypename contains ['z', 'f', 's', 0 ... ]
 	if (buf.Fstypename[0] != 122) || (buf.Fstypename[1] != 102) || (buf.Fstypename[2] != 115) || (buf.Fstypename[3] != 0) {
 		logrus.Debugf("[zfs] no zfs dataset found for rootdir '%s'", rootdir)
-		return graphdriver.ErrPrerequisites
+		return errors.Wrapf(graphdriver.ErrPrerequisites, "no zfs dataset found for rootdir '%s'", rootdir)
 	}
 
 	return nil

--- a/drivers/zfs/zfs_linux.go
+++ b/drivers/zfs/zfs_linux.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Sirupsen/logrus"
 	"github.com/containers/storage/drivers"
+	"github.com/pkg/errors"
 )
 
 func checkRootdirFs(rootdir string) error {
@@ -16,7 +17,7 @@ func checkRootdirFs(rootdir string) error {
 
 	if graphdriver.FsMagic(buf.Type) != graphdriver.FsMagicZfs {
 		logrus.Debugf("[zfs] no zfs dataset found for rootdir '%s'", rootdir)
-		return graphdriver.ErrPrerequisites
+		return errors.Wrapf(graphdriver.ErrPrerequisites, "no zfs dataset found for rootdir '%s'", rootdir)
 	}
 
 	return nil

--- a/drivers/zfs/zfs_solaris.go
+++ b/drivers/zfs/zfs_solaris.go
@@ -22,6 +22,7 @@ import (
 
 	log "github.com/Sirupsen/logrus"
 	"github.com/containers/storage/drivers"
+	"github.com/pkg/errors"
 )
 
 func checkRootdirFs(rootdir string) error {
@@ -34,7 +35,7 @@ func checkRootdirFs(rootdir string) error {
 		(buf.f_basetype[3] != 0) {
 		log.Debugf("[zfs] no zfs dataset found for rootdir '%s'", rootdir)
 		C.free(unsafe.Pointer(buf))
-		return graphdriver.ErrPrerequisites
+		return errors.Wrapf(graphdriver.ErrPrerequisites, "no zfs dataset found for rootdir '%s'", rootdir)
 	}
 
 	C.free(unsafe.Pointer(buf))


### PR DESCRIPTION
Wrap `graphdriver.{ErrNotSupported,ErrPrerequisites,ErrIncompatibleFS}` errors in contexts using `github.com/pkg/errors`, and dig them out for comparison using `errors.Cause()`.