### PR TITLE
Default to overlay as "overlay"

### DIFF
--- a/drivers/driver_linux.go
+++ b/drivers/driver_linux.go
@@ -53,7 +53,7 @@ const (
 var (
 	// Slice of drivers that should be used in an order
 	priority = []string{
-		"overlay2",
+		"overlay",
 		"devicemapper",
 		"aufs",
 		"btrfs",


### PR DESCRIPTION
When selecting overlay as a possible use-by-default driver, use it under the name "overlay".