### PR TITLE
Refuse to start loopback devicemapper on AUFS

### DIFF
--- a/drivers/devmapper/deviceset.go
+++ b/drivers/devmapper/deviceset.go
@@ -1733,6 +1733,15 @@ func (devices *DeviceSet) initDevmapper(doInit bool) error {
 			metadataFile *os.File
 		)
 
+		fsMagic, err := graphdriver.GetFSMagic(devices.loopbackDir())
+		if err != nil {
+			return err
+		}
+		switch fsMagic {
+		case graphdriver.FsMagicAufs:
+			return errors.Errorf("devmapper: Loopback devices can not be created on AUFS filesystems")
+		}
+
 		if devices.dataDevice == "" {
 			// Make sure the sparse images exist in <root>/devicemapper/data
 


### PR DESCRIPTION
An AUFS filesystem doesn't give us the "real" device and inode numbers of an underlying file when we stat() it, so we'll hit errors trying to resume use of a pool when that pool is built on loopback devices using
files that live on an AUFS filesystem.  Refuse to let ourselves be put into that situation.