### PR TITLE
Do not default to overlay

### DIFF
--- a/store.go
+++ b/store.go
@@ -2309,7 +2309,7 @@ type tomlConfig struct {
 func init() {
 	DefaultStoreOptions.RunRoot = "/var/run/containers/storage"
 	DefaultStoreOptions.GraphRoot = "/var/lib/containers/storage"
-	DefaultStoreOptions.GraphDriverName = "overlay"
+	DefaultStoreOptions.GraphDriverName = ""
 
 	data, err := ioutil.ReadFile(configFile)
 	if err != nil {


### PR DESCRIPTION
We should default to "" and then allow the library to pick the
best driver for the particular distribution.  Picking overlay is
currently breaking cri-o on Centos and RHEL, since they don't
support overlay driver until 7.4 release.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>