### PR TITLE
RunRoot directory should be mounted private

### DIFF
--- a/pkg/mount/sharedsubtree_notlinux.go
+++ b/pkg/mount/sharedsubtree_notlinux.go
@@ -1,0 +1,9 @@
+// +build !linux
+
+package mount
+
+// MakePrivate ensures a mounted filesystem has the PRIVATE mount option enabled.
+// See the supported options in flags.go for further reference.
+func MakePrivate(mountPoint string) error {
+	return nil
+}


### PR DESCRIPTION
We are leaking files into other mount namespaces, making the
runroot private might also improve performance.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>