### PR TITLE
Switch all calls to MakePrivate to MakeUnbindable

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 go:
     - tip
+    - 1.8
     - 1.7
-    - 1.6
 dist: trusty
 sudo: required
 before_install:

--- a/drivers/aufs/aufs.go
+++ b/drivers/aufs/aufs.go
@@ -127,7 +127,7 @@ func Init(root string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 		return nil, err
 	}
 
-	if err := mountpk.MakePrivate(root); err != nil {
+	if err := mountpk.MakeUnbindable(root); err != nil {
 		return nil, err
 	}
 

--- a/drivers/btrfs/btrfs.go
+++ b/drivers/btrfs/btrfs.go
@@ -67,7 +67,7 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 		return nil, err
 	}
 
-	if err := mount.MakePrivate(home); err != nil {
+	if err := mount.MakeUnbindable(home); err != nil {
 		return nil, err
 	}
 

--- a/drivers/devmapper/driver.go
+++ b/drivers/devmapper/driver.go
@@ -38,7 +38,7 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 		return nil, err
 	}
 
-	if err := mount.MakePrivate(home); err != nil {
+	if err := mount.MakeUnbindable(home); err != nil {
 		return nil, err
 	}
 

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -141,7 +141,7 @@ func InitWithName(name, home string, options []string, uidMaps, gidMaps []idtool
 		return nil, err
 	}
 
-	if err := mount.MakePrivate(home); err != nil {
+	if err := mount.MakeUnbindable(home); err != nil {
 		return nil, err
 	}
 

--- a/drivers/zfs/zfs.go
+++ b/drivers/zfs/zfs.go
@@ -100,7 +100,7 @@ func Init(base string, opt []string, uidMaps, gidMaps []idtools.IDMap) (graphdri
 		return nil, fmt.Errorf("BUG: zfs get all -t filesystem -rHp '%s' should contain '%s'", options.fsName, options.fsName)
 	}
 
-	if err := mount.MakePrivate(base); err != nil {
+	if err := mount.MakeUnbindable(base); err != nil {
 		return nil, err
 	}
 	d := &Driver{

--- a/pkg/mount/sharedsubtree_notlinux.go
+++ b/pkg/mount/sharedsubtree_notlinux.go
@@ -7,3 +7,9 @@ package mount
 func MakePrivate(mountPoint string) error {
 	return nil
 }
+
+// MakeUnbindable ensures a mounted filesystem has the UNBINDABLE mount option
+// enabled. See the supported options in flags.go for further reference.
+func MakeUnbindable(mountPoint string) error {
+	return ensureMountedAs(mountPoint, "unbindable")
+}

--- a/store.go
+++ b/store.go
@@ -531,7 +531,7 @@ func GetStore(options StoreOptions) (Store, error) {
 		return nil, err
 	}
 
-	if err := mount.MakePrivate(options.RunRoot); err != nil {
+	if err := mount.MakeUnbindable(options.RunRoot); err != nil {
 		return nil, err
 	}
 


### PR DESCRIPTION
This should eliminate the need for oci-umount, and stop leaking of file paths.
According to the man pages Unbindable meaks the same as Private except that
the mount point will not be bound on a rbind mount.

Running containers with -v /:/host has caused issues with this for a long time.
Only issue with this, is if you attempt to mount the mount point like /run/containers/storage
into a container it will fail.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>