### PR TITLE
We should not force a default storage driver

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 language: go
 go:
     - tip
+    - 1.8
     - 1.7
-    - 1.6
 dist: trusty
 sudo: required
 before_install:

--- a/storage.conf
+++ b/storage.conf
@@ -2,7 +2,7 @@
 [storage]
 
 # Default Storage Driver
-driver = "overlay"
+driver = ""
 
 # Temporary storage location
 runroot = "/var/run/containers/storage"


### PR DESCRIPTION
This is causing cri-o to break in RHEL7.3 environments.

Changing to "" allows the containers/storage to pick a storage
driver that will work on a particular platform.  It will still
default to overlay by default, if the platform supports it.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>