### PR TITLE
Create errors using "errors"

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"encoding/json"
-	"errors"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -11,11 +10,6 @@ import (
 	"github.com/containers/storage/pkg/ioutils"
 	"github.com/containers/storage/pkg/stringid"
 	"github.com/containers/storage/pkg/truncindex"
-)
-
-var (
-	// ErrContainerUnknown indicates that there was no container with the specified name or ID
-	ErrContainerUnknown = errors.New("container not known")
 )
 
 // A Container is a reference to a read-write layer with metadata.

--- a/errors.go
+++ b/errors.go
@@ -1,0 +1,52 @@
+package storage
+
+import (
+	"errors"
+)
+
+var (
+	// ErrContainerUnknown indicates that there was no container with the specified name or ID.
+	ErrContainerUnknown = errors.New("container not known")
+	// ErrImageUnknown indicates that there was no image with the specified name or ID.
+	ErrImageUnknown = errors.New("image not known")
+	// ErrParentUnknown indicates that we didn't record the ID of the parent of the specified layer.
+	ErrParentUnknown = errors.New("parent of layer not known")
+	// ErrLayerUnknown indicates that there was no layer with the specified name or ID.
+	ErrLayerUnknown = errors.New("layer not known")
+	// ErrLoadError indicates that there was an initialization error.
+	ErrLoadError = errors.New("error loading storage metadata")
+	// ErrDuplicateID indicates that an ID which is to be assigned to a new item is already being used.
+	ErrDuplicateID = errors.New("that ID is already in use")
+	// ErrDuplicateName indicates that a name which is to be assigned to a new item is already being used.
+	ErrDuplicateName = errors.New("that name is already in use")
+	// ErrParentIsContainer is returned when a caller attempts to create a layer as a child of a container's layer.
+	ErrParentIsContainer = errors.New("would-be parent layer is a container")
+	// ErrNotAContainer is returned when the caller attempts to delete a container that isn't a container.
+	ErrNotAContainer = errors.New("identifier is not a container")
+	// ErrNotAnImage is returned when the caller attempts to delete an image that isn't an image.
+	ErrNotAnImage = errors.New("identifier is not an image")
+	// ErrNotALayer is returned when the caller attempts to delete a layer that isn't a layer.
+	ErrNotALayer = errors.New("identifier is not a layer")
+	// ErrNotAnID is returned when the caller attempts to read or write metadata from an item that doesn't exist.
+	ErrNotAnID = errors.New("identifier is not a layer, image, or container")
+	// ErrLayerHasChildren is returned when the caller attempts to delete a layer that has children.
+	ErrLayerHasChildren = errors.New("layer has children")
+	// ErrLayerUsedByImage is returned when the caller attempts to delete a layer that is an image's top layer.
+	ErrLayerUsedByImage = errors.New("layer is in use by an image")
+	// ErrLayerUsedByContainer is returned when the caller attempts to delete a layer that is a container's layer.
+	ErrLayerUsedByContainer = errors.New("layer is in use by a container")
+	// ErrImageUsedByContainer is returned when the caller attempts to delete an image that is a container's image.
+	ErrImageUsedByContainer = errors.New("image is in use by a container")
+	// ErrIncompleteOptions is returned when the caller attempts to initialize a Store without providing required information.
+	ErrIncompleteOptions = errors.New("missing necessary StoreOptions")
+	// ErrSizeUnknown is returned when the caller asks for the size of a big data item, but the Store couldn't determine the answer.
+	ErrSizeUnknown = errors.New("size is not known")
+	// ErrStoreIsReadOnly is returned when the caller makes a call to a read-only store that would require modifying its contents.
+	ErrStoreIsReadOnly = errors.New("called a write method on a read-only store")
+	// ErrLockReadOnly indicates that the caller only took a read-only lock, and is not allowed to write.
+	ErrLockReadOnly = errors.New("lock is not a read-write lock")
+	// ErrDuplicateImageNames indicates that the read-only store uses the same name for multiple images.
+	ErrDuplicateImageNames = errors.New("read-only image store assigns the same name to multiple images")
+	// ErrDuplicateLayerNames indicates that the read-only store uses the same name for multiple layers.
+	ErrDuplicateLayerNames = errors.New("read-only layer store assigns the same name to multiple layers")
+)

--- a/images.go
+++ b/images.go
@@ -13,11 +13,6 @@ import (
 	"github.com/pkg/errors"
 )
 
-var (
-	// ErrImageUnknown indicates that there was no image with the specified name or ID
-	ErrImageUnknown = errors.New("image not known")
-)
-
 // An Image is a reference to a layer and an associated metadata string.
 type Image struct {
 	// ID is either one which was specified at create-time, or a random
@@ -153,7 +148,7 @@ func (r *imageStore) Load() error {
 		}
 	}
 	if shouldSave && !r.IsReadWrite() {
-		return errors.New("image store assigns the same name to multiple images")
+		return ErrDuplicateImageNames
 	}
 	r.images = images
 	r.idindex = truncindex.NewTruncIndex(idlist)

--- a/layers.go
+++ b/layers.go
@@ -27,13 +27,6 @@ const (
 	compressionFlag = "diff-compression"
 )
 
-var (
-	// ErrParentUnknown indicates that we didn't record the ID of the parent of the specified layer
-	ErrParentUnknown = errors.New("parent of layer not known")
-	// ErrLayerUnknown indicates that there was no layer with the specified name or ID
-	ErrLayerUnknown = errors.New("layer not known")
-)
-
 // A Layer is a record of a copy-on-write layer that's stored by the lower
 // level graph driver.
 type Layer struct {
@@ -280,7 +273,7 @@ func (r *layerStore) Load() error {
 		}
 	}
 	if shouldSave && !r.IsReadWrite() {
-		return errors.New("layer store assigns the same name to multiple layers")
+		return ErrDuplicateLayerNames
 	}
 	mpath := r.mountspath()
 	data, err = ioutil.ReadFile(mpath)

--- a/lockfile.go
+++ b/lockfile.go
@@ -44,8 +44,6 @@ type lockfile struct {
 var (
 	lockfiles     map[string]*lockfile
 	lockfilesLock sync.Mutex
-	// ErrLockReadOnly indicates that the caller only took a read-only lock, and is not allowed to write
-	ErrLockReadOnly = errors.New("lock is not a read-write lock")
 )
 
 // GetLockfile opens a read-write lock file, creating it if necessary.  The

--- a/store.go
+++ b/store.go
@@ -26,36 +26,6 @@ import (
 )
 
 var (
-	// ErrLoadError indicates that there was an initialization error.
-	ErrLoadError = errors.New("error loading storage metadata")
-	// ErrDuplicateID indicates that an ID which is to be assigned to a new item is already being used.
-	ErrDuplicateID = errors.New("that ID is already in use")
-	// ErrDuplicateName indicates that a name which is to be assigned to a new item is already being used.
-	ErrDuplicateName = errors.New("that name is already in use")
-	// ErrParentIsContainer is returned when a caller attempts to create a layer as a child of a container's layer.
-	ErrParentIsContainer = errors.New("would-be parent layer is a container")
-	// ErrNotAContainer is returned when the caller attempts to delete a container that isn't a container.
-	ErrNotAContainer = errors.New("identifier is not a container")
-	// ErrNotAnImage is returned when the caller attempts to delete an image that isn't an image.
-	ErrNotAnImage = errors.New("identifier is not an image")
-	// ErrNotALayer is returned when the caller attempts to delete a layer that isn't a layer.
-	ErrNotALayer = errors.New("identifier is not a layer")
-	// ErrNotAnID is returned when the caller attempts to read or write metadata from an item that doesn't exist.
-	ErrNotAnID = errors.New("identifier is not a layer, image, or container")
-	// ErrLayerHasChildren is returned when the caller attempts to delete a layer that has children.
-	ErrLayerHasChildren = errors.New("layer has children")
-	// ErrLayerUsedByImage is returned when the caller attempts to delete a layer that is an image's top layer.
-	ErrLayerUsedByImage = errors.New("layer is in use by an image")
-	// ErrLayerUsedByContainer is returned when the caller attempts to delete a layer that is a container's layer.
-	ErrLayerUsedByContainer = errors.New("layer is in use by a container")
-	// ErrImageUsedByContainer is returned when the caller attempts to delete an image that is a container's image.
-	ErrImageUsedByContainer = errors.New("image is in use by a container")
-	// ErrIncompleteOptions is returned when the caller attempts to initialize a Store without providing required information.
-	ErrIncompleteOptions = errors.New("missing necessary StoreOptions")
-	// ErrSizeUnknown is returned when the caller asks for the size of a big data item, but the Store couldn't determine the answer.
-	ErrSizeUnknown = errors.New("size is not known")
-	// ErrStoreIsReadOnly is returned when the caller makes a call to a read-only store that would require modifying its contents.
-	ErrStoreIsReadOnly = errors.New("called a write method on a read-only store")
 	// DefaultStoreOptions is a reasonable default set of options.
 	DefaultStoreOptions StoreOptions
 	stores              []*store


### PR DESCRIPTION
Use the standard library's "errors" package to create errors so that backtraces in wrapped errors terminate at the point where the error was first wrapped, and not at the line where we created the error, which isn't as useful for troubleshooting.