### PR TITLE
Make sure you get the realpath when checking Mounted

### DIFF
--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -2,6 +2,8 @@ package mount
 
 import (
 	"time"
+
+	"github.com/containers/storage/pkg/fileutils"
 )
 
 // GetMounts retrieves a list of mounts for the current running process.
@@ -17,6 +19,10 @@ func Mounted(mountpoint string) (bool, error) {
 		return false, err
 	}
 
+	mountpoint, err = fileutils.ReadSymlinkedDirectory(mountpoint)
+	if err != nil {
+		return false, err
+	}
 	// Search the table for the mountpoint
 	for _, e := range entries {
 		if e.Mountpoint == mountpoint {


### PR DESCRIPTION
Do not umount when exiting, because you are not sure if you mounted
in the first place and you could accidently umount other peoples mounts.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>