### PR TITLE
     Revert "RunRoot directory should be mounted private"

### DIFF
--- a/pkg/mount/sharedsubtree_notlinux.go
+++ b/pkg/mount/sharedsubtree_notlinux.go
@@ -1,9 +1,0 @@
-// +build !linux
-
-package mount
-
-// MakePrivate ensures a mounted filesystem has the PRIVATE mount option enabled.
-// See the supported options in flags.go for further reference.
-func MakePrivate(mountPoint string) error {
-	return nil
-}

--- a/store.go
+++ b/store.go
@@ -19,7 +19,6 @@ import (
 	"github.com/containers/storage/pkg/archive"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/ioutils"
-	"github.com/containers/storage/pkg/mount"
 	"github.com/containers/storage/pkg/stringid"
 	"github.com/opencontainers/go-digest"
 	"github.com/pkg/errors"
@@ -475,11 +474,6 @@ func GetStore(options StoreOptions) (Store, error) {
 	if err := os.MkdirAll(options.RunRoot, 0700); err != nil && !os.IsExist(err) {
 		return nil, err
 	}
-
-	if err := mount.MakePrivate(options.RunRoot); err != nil {
-		return nil, err
-	}
-
 	for _, subdir := range []string{} {
 		if err := os.MkdirAll(filepath.Join(options.RunRoot, subdir), 0700); err != nil && !os.IsExist(err) {
 			return nil, err
@@ -2214,10 +2208,6 @@ func (s *store) Shutdown(force bool) ([]string, error) {
 	}
 	if err == nil {
 		err = s.graphDriver.Cleanup()
-		if err2 := mount.Unmount(s.runRoot); err2 != nil && err == nil {
-			err = err2
-		}
-
 		s.graphLock.Touch()
 		modified = true
 	}


### PR DESCRIPTION
We instead need to move the shm content into a different directory.
This patch basically reverts 05e45e0b084152a4eff88db0d4ea308fd326a3d4.
The reason we need this patch is to allow oci-umount to remove leaked
mount points into the container.  We are going to attempt to move the
shm mount point to a different directory.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>