### PR TITLE
Fix a locking error in Store.Names()

### DIFF
--- a/store.go
+++ b/store.go
@@ -312,6 +312,7 @@ type Store interface {
 	Names(id string) ([]string, error)
 
 	// SetNames changes the list of names for a layer, image, or container.
+	// Duplicate names are removed from the list automatically.
 	SetNames(id string, names []string) error
 
 	// ListImageBigData retrieves a list of the (possibly large) chunks of

--- a/store.go
+++ b/store.go
@@ -1249,22 +1249,21 @@ func (s *store) Names(id string) ([]string, error) {
 		}
 	}
 
-	ristore, err := s.ImageStore()
+	istore, err := s.ImageStore()
 	if err != nil {
 		return nil, err
 	}
-	ristores, err := s.ROImageStores()
+	istores, err := s.ROImageStores()
 	if err != nil {
 		return nil, err
 	}
-	ristores = append([]ROImageStore{ristore}, ristores...)
-	for _, ristore := range stores {
-		ristore.Lock()
-		defer ristore.Unlock()
-		if modified, err := ristore.Modified(); modified || err != nil {
-			ristore.Load()
+	for _, store := range append([]ROImageStore{istore}, istores...) {
+		store.Lock()
+		defer store.Unlock()
+		if modified, err := store.Modified(); modified || err != nil {
+			store.Load()
 		}
-		if i, err := ristore.Get(id); i != nil && err == nil {
+		if i, err := store.Get(id); i != nil && err == nil {
 			return i.Names, nil
 		}
 	}


### PR DESCRIPTION
@umohnani8 noticed that `Store.Names()` was hitting a deadlock - when attempting to iterate through the concatenated list of read-write and read-only image stores, the method was actually walking the list of read-write and read-only layer stores a second time, so when it attempted to obtain a lock on the first layer store, it would deadlock.

This PR also teaches `Store.Lookup()` about read-only locations, and updates sections of the code that scan read-only layer and image stores to be more consistent in variable naming in an effort to avoid bugs like this one.