### PR TITLE
Add interfaces that were removed from upstream but containers/image uses

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -1226,3 +1226,26 @@ func (archive *TempArchive) Read(data []byte) (int, error) {
 	}
 	return n, err
 }
+
+// IsArchive checks for the magic bytes of a tar or any supported compression
+// algorithm.
+func IsArchive(header []byte) bool {
+	compression := DetectCompression(header)
+	if compression != Uncompressed {
+		return true
+	}
+	r := tar.NewReader(bytes.NewBuffer(header))
+	_, err := r.Next()
+	return err == nil
+}
+
+// UntarPath is a convenience function which looks for an archive
+// at filesystem path `src`, and unpacks it at `dst`.
+func UntarPath(src, dst string) error {
+	return NewDefaultArchiver().UntarPath(src, dst)
+}
+
+const (
+	// HeaderSize is the size in bytes of a tar header
+	HeaderSize = 512
+)


### PR DESCRIPTION
Add back in these interfaces since containers/image is using.
archive.UntartPath
archive.IsArchive

Also add back this constant for containers/image.
archive.HeaderSize

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>