### PR TITLE
Move no Dtype on Overlay from Error to warning.

### DIFF
--- a/docs/containers-storage.conf.5.md
+++ b/docs/containers-storage.conf.5.md
@@ -42,7 +42,7 @@ The `storage` table supports the following options:
   Default Copy On Write (COW) container storage driver
 
 **additionalimagestores**=[]
-  Paths to additional congtainer image stores. Usually these are read/only and stored on remote network shares.
+  Paths to additional container image stores. Usually these are read/only and stored on remote network shares.
 
 **size**=""
   Maximum size of a container image.  Default is 10GB.  This flag can be used to set quota

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -183,7 +183,9 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 		return nil, err
 	}
 	if !supportsDType {
-		return nil, overlayutils.ErrDTypeNotSupported("overlay", backingFs)
+		logrus.Warn(overlayutils.ErrDTypeNotSupported("overlay", backingFs))
+		// TODO: Will make fatal when CRI-O Has AMI built on RHEL7.4
+		// return nil, overlayutils.ErrDTypeNotSupported("overlay", backingFs)
 	}
 
 	d := &Driver{


### PR DESCRIPTION
Move lack of DTYpe on Overlay from Error down to Warning, temporarily until infrastructure CI has updated VMs with correct support.

Moby currently  has the same compromise.