### PR TITLE
Preallocate some slices that we build up

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -133,6 +133,7 @@ func (r *containerStore) Load() error {
 	ids := make(map[string]*Container)
 	names := make(map[string]*Container)
 	if err = json.Unmarshal(data, &containers); len(data) == 0 || err == nil {
+		idlist = make([]string, 0, len(containers))
 		for n, container := range containers {
 			idlist = append(idlist, container.ID)
 			ids[container.ID] = containers[n]
@@ -421,7 +422,7 @@ func (r *containerStore) SetBigData(id, key string, data []byte) error {
 }
 
 func (r *containerStore) Wipe() error {
-	ids := []string{}
+	ids := make([]string, 0, len(r.byid))
 	for id := range r.byid {
 		ids = append(ids, id)
 	}

--- a/images.go
+++ b/images.go
@@ -135,6 +135,7 @@ func (r *imageStore) Load() error {
 	ids := make(map[string]*Image)
 	names := make(map[string]*Image)
 	if err = json.Unmarshal(data, &images); len(data) == 0 || err == nil {
+		idlist = make([]string, 0, len(images))
 		for n, image := range images {
 			ids[image.ID] = images[n]
 			idlist = append(idlist, image.ID)
@@ -466,7 +467,7 @@ func (r *imageStore) Wipe() error {
 	if !r.IsReadWrite() {
 		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to delete images at %q", r.imagespath())
 	}
-	ids := []string{}
+	ids := make([]string, 0, len(r.byid))
 	for id := range r.byid {
 		ids = append(ids, id)
 	}

--- a/layers.go
+++ b/layers.go
@@ -254,6 +254,7 @@ func (r *layerStore) Load() error {
 	compressedsums := make(map[digest.Digest][]string)
 	uncompressedsums := make(map[digest.Digest][]string)
 	if err = json.Unmarshal(data, &layers); len(data) == 0 || err == nil {
+		idlist = make([]string, 0, len(layers))
 		for n, layer := range layers {
 			ids[layer.ID] = layers[n]
 			idlist = append(idlist, layer.ID)
@@ -338,7 +339,7 @@ func (r *layerStore) Save() error {
 	if err := os.MkdirAll(filepath.Dir(mpath), 0700); err != nil {
 		return err
 	}
-	mounts := []layerMountPoint{}
+	mounts := make([]layerMountPoint, 0, len(r.layers))
 	for _, layer := range r.layers {
 		if layer.MountPoint != "" && layer.MountCount > 0 {
 			mounts = append(mounts, layerMountPoint{
@@ -731,7 +732,7 @@ func (r *layerStore) Wipe() error {
 	if !r.IsReadWrite() {
 		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to delete layers at %q", r.layerspath())
 	}
-	ids := []string{}
+	ids := make([]string, 0, len(r.byid))
 	for id := range r.byid {
 		ids = append(ids, id)
 	}

--- a/store.go
+++ b/store.go
@@ -2231,7 +2231,7 @@ func makeBigDataBaseName(key string) string {
 }
 
 func stringSliceWithoutValue(slice []string, value string) []string {
-	modified := []string{}
+	modified := make([]string, 0, len(slice))
 	for _, v := range slice {
 		if v == value {
 			continue


### PR DESCRIPTION
Take a guess at the final size of some slices that we build up item by item, and try to allocate enough capacity for them before starting to build them.  It's probably not a big speedup, though.