### PR TITLE
Stop rejecting creation of images with no layers

### DIFF
--- a/cmd/containers-storage/create.go
+++ b/cmd/containers-storage/create.go
@@ -90,7 +90,11 @@ func createImage(flags *mflag.FlagSet, action string, m storage.Store, args []st
 		}
 		paramMetadata = string(b)
 	}
-	image, err := m.CreateImage(paramID, paramNames, args[0], paramMetadata, nil)
+	layer := ""
+	if len(args) > 0 {
+		layer = args[0]
+	}
+	image, err := m.CreateImage(paramID, paramNames, layer, paramMetadata, nil)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		return 1
@@ -172,7 +176,7 @@ func init() {
 		names:       []string{"create-image", "createimage"},
 		optionsHelp: "[options [...]] topLayerNameOrID",
 		usage:       "Create a new image using layers",
-		minArgs:     1,
+		minArgs:     0,
 		maxArgs:     1,
 		action:      createImage,
 		addFlags: func(flags *mflag.FlagSet, cmd *command) {

--- a/images.go
+++ b/images.go
@@ -24,8 +24,9 @@ type Image struct {
 	// unique among images.
 	Names []string `json:"names,omitempty"`
 
-	// TopLayer is the ID of the topmost layer of the image itself.
-	// Multiple images can refer to the same top layer.
+	// TopLayer is the ID of the topmost layer of the image itself, if the
+	// image contains one or more layers.  Multiple images can refer to the
+	// same top layer.
 	TopLayer string `json:"layer"`
 
 	// Metadata is data we keep for the convenience of the caller.  It is not


### PR DESCRIPTION
We need to be able to create images which consist of just a list of manifests, and those don't contain layers, so relax CreateImage()'s requirement that a layer be specified.