### PR TITLE
Be more thorough about deduplicating names

### DIFF
--- a/cmd/containers-storage/name.go
+++ b/cmd/containers-storage/name.go
@@ -10,6 +10,30 @@ import (
 	"github.com/containers/storage/pkg/mflag"
 )
 
+func getNames(flags *mflag.FlagSet, action string, m storage.Store, args []string) int {
+	if len(args) < 1 {
+		return 1
+	}
+	id, err := m.Lookup(args[0])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		return 1
+	}
+	names, err := m.Names(id)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%v\n", err)
+		return 1
+	}
+	if jsonOutput {
+		json.NewEncoder(os.Stdout).Encode(append([]string{}, names...))
+	} else {
+		for _, name := range names {
+			fmt.Printf("%s\n", name)
+		}
+	}
+	return 0
+}
+
 func addNames(flags *mflag.FlagSet, action string, m storage.Store, args []string) int {
 	if len(args) < 1 {
 		return 1
@@ -71,6 +95,16 @@ func setNames(flags *mflag.FlagSet, action string, m storage.Store, args []strin
 }
 
 func init() {
+	commands = append(commands, command{
+		names:       []string{"get-names", "getnames"},
+		optionsHelp: "[options [...]] imageOrContainerNameOrID",
+		usage:       "Get layer, image, or container name or names",
+		minArgs:     1,
+		action:      getNames,
+		addFlags: func(flags *mflag.FlagSet, cmd *command) {
+			flags.BoolVar(&jsonOutput, []string{"-json", "j"}, jsonOutput, "Prefer JSON output")
+		},
+	})
 	commands = append(commands, command{
 		names:       []string{"add-names", "addnames"},
 		optionsHelp: "[options [...]] imageOrContainerNameOrID",

--- a/containers.go
+++ b/containers.go
@@ -239,6 +239,7 @@ func (r *containerStore) Create(id string, names []string, image, layer, metadat
 	if _, idInUse := r.byid[id]; idInUse {
 		return nil, ErrDuplicateID
 	}
+	names = dedupeNames(names)
 	for _, name := range names {
 		if _, nameInUse := r.byname[name]; nameInUse {
 			return nil, ErrDuplicateName
@@ -288,6 +289,7 @@ func (r *containerStore) removeName(container *Container, name string) {
 }
 
 func (r *containerStore) SetNames(id string, names []string) error {
+	names = dedupeNames(names)
 	if container, ok := r.lookup(id); ok {
 		for _, name := range container.Names {
 			delete(r.byname, name)

--- a/docs/containers-storage-add-names.md
+++ b/docs/containers-storage-add-names.md
@@ -22,4 +22,5 @@ other layer, image, or container.
 **containers-storage add-names -n my-awesome-container -n my-for-realsies-awesome-container f3be6c6134d0d980936b4c894f1613b69a62b79588fdeda744d0be3693bde8ec**
 
 ## SEE ALSO
+containers-storage-get-names(1)
 containers-storage-set-names(1)

--- a/docs/containers-storage-get-names.md
+++ b/docs/containers-storage-get-names.md
@@ -1,0 +1,21 @@
+## containers-storage-get-names 1 "September 2017"
+
+## NAME
+containers-storage get-names - Get names of a layer/image/container
+
+## SYNOPSIS
+**containers-storage** **get-names** *layerOrImageOrContainerNameOrID*
+
+## DESCRIPTION
+In addition to IDs, *layers*, *images*, and *containers* can have
+human-readable names assigned to them in *containers-storage*.  The *get-names*
+command can be used to read the list of names for any of them.
+
+## OPTIONS
+
+## EXAMPLE
+**containers-storage get-names f3be6c6134d0d980936b4c894f1613b69a62b79588fdeda744d0be3693bde8ec**
+
+## SEE ALSO
+containers-storage-add-names(1)
+containers-storage-set-names(1)

--- a/docs/containers-storage-set-names.md
+++ b/docs/containers-storage-set-names.md
@@ -25,3 +25,4 @@ will be removed from the layer, image, or container.
 
 ## SEE ALSO
 containers-storage-add-names(1)
+containers-storage-get-names(1)

--- a/images.go
+++ b/images.go
@@ -270,6 +270,7 @@ func (r *imageStore) Create(id string, names []string, layer, metadata string, c
 	if _, idInUse := r.byid[id]; idInUse {
 		return nil, ErrDuplicateID
 	}
+	names = dedupeNames(names)
 	for _, name := range names {
 		if _, nameInUse := r.byname[name]; nameInUse {
 			return nil, ErrDuplicateName
@@ -326,6 +327,7 @@ func (r *imageStore) SetNames(id string, names []string) error {
 	if !r.IsReadWrite() {
 		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to change image name assignments at %q", r.imagespath())
 	}
+	names = dedupeNames(names)
 	if image, ok := r.lookup(id); ok {
 		for _, name := range image.Names {
 			delete(r.byname, name)

--- a/layers.go
+++ b/layers.go
@@ -490,6 +490,7 @@ func (r *layerStore) Put(id, parent string, names []string, mountLabel string, o
 	if _, idInUse := r.byid[id]; idInUse {
 		return nil, -1, ErrDuplicateID
 	}
+	names = dedupeNames(names)
 	for _, name := range names {
 		if _, nameInUse := r.byname[name]; nameInUse {
 			return nil, -1, ErrDuplicateName
@@ -626,6 +627,7 @@ func (r *layerStore) SetNames(id string, names []string) error {
 	if !r.IsReadWrite() {
 		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to change layer name assignments at %q", r.layerspath())
 	}
+	names = dedupeNames(names)
 	if layer, ok := r.lookup(id); ok {
 		for _, name := range layer.Names {
 			delete(r.byname, name)

--- a/store.go
+++ b/store.go
@@ -1174,15 +1174,20 @@ func (s *store) Exists(id string) bool {
 	return false
 }
 
-func (s *store) SetNames(id string, names []string) error {
-	deduped := []string{}
+func dedupeNames(names []string) []string {
 	seen := make(map[string]bool)
+	deduped := make([]string, 0, len(names))
 	for _, name := range names {
 		if _, wasSeen := seen[name]; !wasSeen {
 			seen[name] = true
 			deduped = append(deduped, name)
 		}
 	}
+	return deduped
+}
+
+func (s *store) SetNames(id string, names []string) error {
+	deduped := dedupeNames(names)
 
 	rlstore, err := s.LayerStore()
 	if err != nil {


### PR DESCRIPTION
We already deduplicated names in Store.SetNames(), but we weren't also doing that when creating layers, images, and containers, or in the individual store SetNames() methods.
