### PR TITLE
Specify OverrideKernelCheck and Size in /etc/containers/storage.conf

### DIFF
--- a/docs/containers-storage.conf.5.md
+++ b/docs/containers-storage.conf.5.md
@@ -28,7 +28,6 @@ No bare options are used. The format of TOML can be simplified to:
 
 The `storage` table supports the following options:
 
-
 **graphroot**=""
   container storage graph dir (default: "/var/lib/containers/storage")
   Default directory to store all writable content created by container storage programs
@@ -41,12 +40,21 @@ The `storage` table supports the following options:
   container storage driver (default is "overlay")
   Default Copy On Write (COW) container storage driver
 
+### STORAGE OPTIONS TABLE 
+
+The `storage.options` table supports the following options:
+
 **additionalimagestores**=[]
-  Paths to additional congtainer image stores. Usually these are read/only and stored on remote network shares.
+  Paths to additional container image stores. Usually these are read/only and stored on remote network shares.
 
 **size**=""
   Maximum size of a container image.  Default is 10GB.  This flag can be used to set quota
   on the size of container images.
+
+**override_kernel_check**=""
+  Tell storage drivers to ignore kernel version checks.  Some storage drivers assume that if a kernel is too
+  old, the driver is not supported.  But for kernels that have had the drivers backported, this flag
+  allows users to override the checks
 
 # HISTORY
 May 2017, Originally compiled by Dan Walsh <dwalsh@redhat.com>

--- a/storage.conf
+++ b/storage.conf
@@ -16,3 +16,10 @@ graphroot = "/var/lib/containers/storage"
 # Must be comma separated list.
 additionalimagestores = [
 ]
+
+# Size is used to set a maximum size of the container image.  Only supported by
+# certain container storage drivers.
+size = ""
+
+# OverrideKernelCheck tells the driver to ignore kernel checks based on kernel version
+override_kernel_check = "false"

--- a/store.go
+++ b/store.go
@@ -2249,6 +2249,12 @@ type OptionsConfig struct {
 	// Image stores.  Usually used to access Networked File System
 	// for shared image content
 	AdditionalImageStores []string `toml:"additionalimagestores"`
+
+	// Size
+	Size string `toml:"size"`
+
+	// OverrideKernelCheck
+	OverrideKernelCheck string `toml:"override_kernel_check"`
 }
 
 // TOML-friendly explicit tables used for conversions.
@@ -2292,7 +2298,12 @@ func init() {
 	for _, s := range config.Storage.Options.AdditionalImageStores {
 		DefaultStoreOptions.GraphDriverOptions = append(DefaultStoreOptions.GraphDriverOptions, fmt.Sprintf("%s.imagestore=%s", config.Storage.Driver, s))
 	}
-
+	if config.Storage.Options.Size != "" {
+		DefaultStoreOptions.GraphDriverOptions = append(DefaultStoreOptions.GraphDriverOptions, fmt.Sprintf("%s.size=%s", config.Storage.Driver, config.Storage.Options.Size))
+	}
+	if config.Storage.Options.OverrideKernelCheck != "" {
+		DefaultStoreOptions.GraphDriverOptions = append(DefaultStoreOptions.GraphDriverOptions, fmt.Sprintf("%s.override_kernel_check=%s", config.Storage.Driver, config.Storage.Options.OverrideKernelCheck))
+	}
 	if os.Getenv("STORAGE_DRIVER") != "" {
 		DefaultStoreOptions.GraphDriverName = os.Getenv("STORAGE_DRIVER")
 	}


### PR DESCRIPTION
Allow users to specify the maximum size of a containers in the
/etc/containers/storage.conf file.  This will enable quota checking
in the drivers that support it.

Allowe users to OverrideKernelCheck to tell drivers to ignore kernel
version checks that indicate whether the driver is supported on that
kernel.  These checks do not make sense on older RHEL kernels, since
the driver support was back ported.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>