### PR TITLE
Fix builds with go 1.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: go
 go:
     - tip
     - 1.8
+    - 1.7
 dist: trusty
 sudo: required
 before_install:

--- a/drivers/fsdiff.go
+++ b/drivers/fsdiff.go
@@ -94,7 +94,7 @@ func (gdw *NaiveDiffDriver) Diff(id, parent string) (arch io.ReadCloser, err err
 		// are extracted from tar's with full second precision on modified time.
 		// We need this hack here to make sure calls within same second receive
 		// correct result.
-		time.Sleep(time.Until(startTime.Truncate(time.Second).Add(time.Second)))
+		time.Sleep(startTime.Truncate(time.Second).Add(time.Second).Sub(time.Now()))
 		return err
 	}), nil
 }


### PR DESCRIPTION
The skopeo package builds on Darwin use Go 1.7, so make sure we can build on it, by replacing a call to `time.Until(t)` with `t.Sub(time.Now())`, as suggested in the standard library documentation.

This should get https://github.com/projectatomic/skopeo/pull/427 to pass its tests.