### PR TITLE
Initialize Flags and BigDataSizes maps

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -49,4 +49,6 @@ var (
 	ErrDuplicateImageNames = errors.New("read-only image store assigns the same name to multiple images")
 	// ErrDuplicateLayerNames indicates that the read-only store uses the same name for multiple layers.
 	ErrDuplicateLayerNames = errors.New("read-only layer store assigns the same name to multiple layers")
+	// ErrInvalidBigDataName indicates that the name for a big data item is not acceptable; it may be empty.
+	ErrInvalidBigDataName = errors.New("not a valid name for a big data item")
 )

--- a/layers.go
+++ b/layers.go
@@ -305,6 +305,9 @@ func (r *layerStore) Load() error {
 	// actually delete.
 	if r.IsReadWrite() {
 		for _, layer := range r.layers {
+			if layer.Flags == nil {
+				layer.Flags = make(map[string]interface{})
+			}
 			if cleanup, ok := layer.Flags[incompleteFlag]; ok {
 				if b, ok := cleanup.(bool); ok && b {
 					err = r.Delete(layer.ID)
@@ -454,6 +457,9 @@ func (r *layerStore) SetFlag(id string, flag string, value interface{}) error {
 	layer, ok := r.lookup(id)
 	if !ok {
 		return ErrLayerUnknown
+	}
+	if layer.Flags == nil {
+		layer.Flags = make(map[string]interface{})
 	}
 	layer.Flags[flag] = value
 	return r.Save()

--- a/store.go
+++ b/store.go
@@ -1841,10 +1841,16 @@ func (s *store) layersByMappedDigest(m func(ROLayerStore, digest.Digest) ([]Laye
 }
 
 func (s *store) LayersByCompressedDigest(d digest.Digest) ([]Layer, error) {
+	if err := d.Validate(); err != nil {
+		return nil, errors.Wrapf(err, "error looking for compressed layers matching digest %q", d)
+	}
 	return s.layersByMappedDigest(func(r ROLayerStore, d digest.Digest) ([]Layer, error) { return r.LayersByCompressedDigest(d) }, d)
 }
 
 func (s *store) LayersByUncompressedDigest(d digest.Digest) ([]Layer, error) {
+	if err := d.Validate(); err != nil {
+		return nil, errors.Wrapf(err, "error looking for layers matching digest %q", d)
+	}
 	return s.layersByMappedDigest(func(r ROLayerStore, d digest.Digest) ([]Layer, error) { return r.LayersByUncompressedDigest(d) }, d)
 }
 


### PR DESCRIPTION
When we read itms from disk, if maps in the structures are empty, they won't be allocated as part of the decoding process.  When we subsequently go to read or write something from such a map, make sure
it's been initialized.

Add some validation of names that we convert to file names, and of digest values, so that we can be more precise about the error code we return when there's a problem with the values.