### PR TITLE
Fixups for read-only store tests

### DIFF
--- a/tests/stores.bats
+++ b/tests/stores.bats
@@ -58,13 +58,16 @@ load helpers
         [ "$output" != "" ]
         image=${output%%  *}
 
+	# We no longer need to use the read-only root as a writeable location, so shut it down.
+	storage --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot shutdown
+
 	# Create a third layer based on the second one.
 	run storage --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root --debug=false create-layer "$midlayer"
 	[ "$status" -eq 0 ]
 	[ "$output" != "" ]
 	upperlayer="$output"
 	# Mount this layer.
-	run storage --debug=false mount $upperlayer
+	run storage --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root --debug=false mount $upperlayer
 	[ "$status" -eq 0 ]
 	[ "$output" != "" ]
 	uppermount="$output"
@@ -82,7 +85,7 @@ load helpers
 	[ "$output" != "" ]
 	container="$output"
 	# Mount this container.
-	run storage --debug=false mount $container
+	run storage --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root --debug=false mount $container
 	[ "$status" -eq 0 ]
 	[ "$output" != "" ]
 	containermount="$output"


### PR DESCRIPTION
* After we're done initializing a read-only store for a test, shut it down so that we'll be able to delete it when cleaning up later.
* When mounting a layer that inherits from read-only layers, don't forget to pass the read-only store's location to the CLI helper.