### PR TITLE
Change cri-o IRC channel to container-projects in CONTRIBUTING.md

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -118,7 +118,7 @@ commit automatically with `git commit -s`.
 ## Communications
 
 For general questions, or discussions, please use the 
-IRC group on `irc.freenode.net` called `cri-o`
+IRC group on `irc.freenode.net` called `container-projects`
 that has been setup.
 
 For discussions around issues/bugs and features, you can use the github


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Change IRC channel to container-projects from cri-o in the CONTRIBUTING.md file.