### PR TITLE
Fix LayersBy*Digest with multiple layer stores

### DIFF
--- a/store.go
+++ b/store.go
@@ -1888,9 +1888,15 @@ func (s *store) layersByMappedDigest(m func(ROLayerStore, digest.Digest) ([]Laye
 		}
 		storeLayers, err := m(store, d)
 		if err != nil {
-			return nil, err
+			if errors.Cause(err) != ErrLayerUnknown {
+				return nil, err
+			}
+			continue
 		}
 		layers = append(layers, storeLayers...)
+	}
+	if len(layers) == 0 {
+		return nil, ErrLayerUnknown
 	}
 	return layers, nil
 }


### PR DESCRIPTION
`LayersByCompressedDigest` and `LayersByUncompressedDigest` shouldn't fail if one of the stores being consulted doesn't have any layers that match the specified digest, since that's an expected possibility.