### PR TITLE
Don't run supportsOverlay check by default

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -124,10 +124,6 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 		return nil, err
 	}
 
-	if err := supportsOverlay(); err != nil {
-		return nil, errors.Wrap(graphdriver.ErrNotSupported, "kernel does not support overlay fs")
-	}
-
 	// require kernel 4.0.0 to ensure multiple lower dirs are supported
 	v, err := kernel.GetKernelVersion()
 	if err != nil {
@@ -264,7 +260,7 @@ func parseOptions(options []string) (*overlayOptions, error) {
 	return o, nil
 }
 
-func supportsOverlay() error {
+func SupportsOverlay() error {
 	// We can try to modprobe overlay first before looking at
 	// proc/filesystems for when overlay is supported
 	exec.Command("modprobe", "overlay").Run()


### PR DESCRIPTION
This will fail on a people using containers/storage inside of a container.
For example if you run buildah inside of a docker container on a system
with devicemapper backend.  The overlay module will not be loaded.  The
exec of "modprobe overlay" fails because there are no overlay modules inside
of the containers mount namespace.  If we ignore this check, when container/storage
eventually attempts the mount command, the kernel will be smart enough to load
the overlay module and things will succeed.  If the kernel actually does not support
overlay, the mount will fail and the user will get his answer.

If a container runtime daemon like CRI-O or Docker wants to verify at start up that
overlay file system is supported, I have made SupportsOverlay a public function and the
daemons can call this at start time.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>