### PR TITLE
overlay, vfs: Accept options without the driver name prefix

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -227,20 +227,20 @@ func parseOptions(options []string) (*overlayOptions, error) {
 		}
 		key = strings.ToLower(key)
 		switch key {
-		case "overlay.override_kernel_check", "overlay2.override_kernel_check":
+		case ".override_kernel_check", "overlay.override_kernel_check", "overlay2.override_kernel_check":
 			logrus.Debugf("overlay: override_kernelcheck=%s", val)
 			o.overrideKernelCheck, err = strconv.ParseBool(val)
 			if err != nil {
 				return nil, err
 			}
-		case "overlay.size", "overlay2.size":
+		case ".size", "overlay.size", "overlay2.size":
 			logrus.Debugf("overlay: size=%s", val)
 			size, err := units.RAMInBytes(val)
 			if err != nil {
 				return nil, err
 			}
 			o.quota.Size = uint64(size)
-		case "overlay.imagestore", "overlay2.imagestore":
+		case ".imagestore", "overlay.imagestore", "overlay2.imagestore":
 			logrus.Debugf("overlay: imagestore=%s", val)
 			// Additional read only image stores to use for lower paths
 			for _, store := range strings.Split(val, ",") {

--- a/drivers/vfs/driver.go
+++ b/drivers/vfs/driver.go
@@ -36,6 +36,11 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 	for _, option := range options {
 		if strings.HasPrefix(option, "vfs.imagestore=") {
 			d.homes = append(d.homes, strings.Split(option[15:], ",")...)
+			continue
+		}
+		if strings.HasPrefix(option, ".imagestore=") {
+			d.homes = append(d.homes, strings.Split(option[12:], ",")...)
+			continue
 		}
 	}
 	return graphdriver.NewNaiveDiffDriver(d, uidMaps, gidMaps), nil


### PR DESCRIPTION
In the overlay and vfs drivers, accept option names which we'd recognize, if they had the driver name as a prefix, as aliases for their proper names.