### PR TITLE
Add a notion of image "digests" based on their "manifest" data

### DIFF
--- a/cmd/containers-storage/images.go
+++ b/cmd/containers-storage/images.go
@@ -7,6 +7,11 @@ import (
 
 	"github.com/containers/storage"
 	"github.com/containers/storage/pkg/mflag"
+	digest "github.com/opencontainers/go-digest"
+)
+
+var (
+	imagesQuiet = false
 )
 
 func images(flags *mflag.FlagSet, action string, m storage.Store, args []string) int {
@@ -20,6 +25,45 @@ func images(flags *mflag.FlagSet, action string, m storage.Store, args []string)
 	} else {
 		for _, image := range images {
 			fmt.Printf("%s\n", image.ID)
+			if imagesQuiet {
+				continue
+			}
+			for _, name := range image.Names {
+				fmt.Printf("\tname: %s\n", name)
+			}
+			for _, name := range image.BigDataNames {
+				fmt.Printf("\tdata: %s\n", name)
+			}
+		}
+	}
+	return 0
+}
+
+func imagesByDigest(flags *mflag.FlagSet, action string, m storage.Store, args []string) int {
+	images := []*storage.Image{}
+	for _, arg := range args {
+		d := digest.Digest(arg)
+		if err := d.Validate(); err != nil {
+			fmt.Fprintf(os.Stderr, "%s: %v\n", arg, err)
+			return 1
+		}
+		matched, err := m.ImagesByDigest(d)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "%v\n", err)
+			return 1
+		}
+		for _, match := range matched {
+			images = append(images, match)
+		}
+	}
+	if jsonOutput {
+		json.NewEncoder(os.Stdout).Encode(images)
+	} else {
+		for _, image := range images {
+			fmt.Printf("%s\n", image.ID)
+			if imagesQuiet {
+				continue
+			}
 			for _, name := range image.Names {
 				fmt.Printf("\tname: %s\n", name)
 			}
@@ -40,6 +84,19 @@ func init() {
 		maxArgs:     0,
 		addFlags: func(flags *mflag.FlagSet, cmd *command) {
 			flags.BoolVar(&jsonOutput, []string{"-json", "j"}, jsonOutput, "Prefer JSON output")
+			flags.BoolVar(&imagesQuiet, []string{"-quiet", "q"}, imagesQuiet, "Only print IDs")
+		},
+	})
+	commands = append(commands, command{
+		names:       []string{"images-by-digest"},
+		optionsHelp: "[options [...]] DIGEST",
+		usage:       "List images by digest",
+		action:      imagesByDigest,
+		minArgs:     1,
+		maxArgs:     1,
+		addFlags: func(flags *mflag.FlagSet, cmd *command) {
+			flags.BoolVar(&jsonOutput, []string{"-json", "j"}, jsonOutput, "Prefer JSON output")
+			flags.BoolVar(&imagesQuiet, []string{"-quiet", "q"}, imagesQuiet, "Only print IDs")
 		},
 	})
 }

--- a/images_ffjson.go
+++ b/images_ffjson.go
@@ -54,9 +54,11 @@ func (j *Image) MarshalJSONBuf(buf fflib.EncodingBuffer) error {
 		}
 		buf.WriteByte(',')
 	}
-	buf.WriteString(`"layer":`)
-	fflib.WriteJsonString(buf, string(j.TopLayer))
-	buf.WriteByte(',')
+	if len(j.TopLayer) != 0 {
+		buf.WriteString(`"layer":`)
+		fflib.WriteJsonString(buf, string(j.TopLayer))
+		buf.WriteByte(',')
+	}
 	if len(j.Metadata) != 0 {
 		buf.WriteString(`"metadata":`)
 		fflib.WriteJsonString(buf, string(j.Metadata))

--- a/store.go
+++ b/store.go
@@ -370,6 +370,10 @@ type Store interface {
 	// and may have different metadata, big data items, and flags.
 	ImagesByTopLayer(id string) ([]*Image, error)
 
+	// ImagesByDigest returns a list of images which contain a big data item
+	// named ImageDigestBigDataKey whose contents have the specified digest.
+	ImagesByDigest(d digest.Digest) ([]*Image, error)
+
 	// Container returns a specific container.
 	Container(id string) (*Container, error)
 
@@ -2082,6 +2086,33 @@ func (s *store) ImagesByTopLayer(id string) ([]*Image, error) {
 				images = append(images, &image)
 			}
 		}
+	}
+	return images, nil
+}
+
+func (s *store) ImagesByDigest(d digest.Digest) ([]*Image, error) {
+	images := []*Image{}
+
+	istore, err := s.ImageStore()
+	if err != nil {
+		return nil, err
+	}
+
+	istores, err := s.ROImageStores()
+	if err != nil {
+		return nil, err
+	}
+	for _, store := range append([]ROImageStore{istore}, istores...) {
+		store.Lock()
+		defer store.Unlock()
+		if modified, err := store.Modified(); modified || err != nil {
+			store.Load()
+		}
+		imageList, err := store.ByDigest(d)
+		if err != nil && err != ErrImageUnknown {
+			return nil, err
+		}
+		images = append(images, imageList...)
 	}
 	return images, nil
 }

--- a/tests/image-by-digest.bats
+++ b/tests/image-by-digest.bats
@@ -1,0 +1,80 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "images-by-digest" {
+	# Bail if "sha256sum" isn't available.
+	if test -z "$(which sha256sum 2> /dev/null)" ; then
+		skip "need sha256sum"
+	fi
+
+	# Create a couple of random files.
+	createrandom ${TESTDIR}/random1
+	createrandom ${TESTDIR}/random2
+	digest1=$(sha256sum ${TESTDIR}/random1)
+	digest2=$(sha256sum ${TESTDIR}/random2)
+
+	# Create a layer.
+	run storage --debug=false create-layer
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	layer=$output
+
+	# Create an image using that layer.
+	run storage --debug=false create-image $layer
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	firstimage=${output%%	*}
+	# Set the first file as the manifest of this image.
+	run storage --debug=false set-image-data -f ${TESTDIR}/random1 ${firstimage} manifest
+
+	# Create another image using that layer.
+	run storage --debug=false create-image $layer
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	secondimage=${output%%	*}
+	# Set the first file as the manifest of this image.
+	run storage --debug=false set-image-data -f ${TESTDIR}/random1 ${secondimage} manifest
+
+	# Create yet another image using that layer.
+	run storage --debug=false create-image $layer
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	thirdimage=${output%%	*}
+	# Set the second file as the manifest of this image.
+	run storage --debug=false set-image-data -f ${TESTDIR}/random2 ${thirdimage} manifest
+
+	# Check that "images-by-digest" lists the right images.
+	run storage --debug=false images-by-digest --quiet sha256:${digest1// *}
+	echo :"$output":
+	[ "$status" -eq 0 ]
+	[ "${#lines[*]}" -eq 2 ]
+	[ "${lines[0]}" != "${lines[1]}" ]
+	[ "${lines[0]}" = "$firstimage" ] || [ "${lines[0]}" = "$secondimage" ]
+	[ "${lines[1]}" = "$firstimage" ] || [ "${lines[1]}" = "$secondimage" ]
+
+	run storage --debug=false images-by-digest --quiet sha256:${digest2// *}
+	echo :"$output":
+	[ "$status" -eq 0 ]
+	[ "${#lines[*]}" -eq 1 ]
+	[ "${lines[0]}" = "$thirdimage" ]
+
+	run storage --debug=false delete-image ${secondimage}
+	echo :"$output":
+	[ "$status" -eq 0 ]
+
+	run storage --debug=false images-by-digest --quiet sha256:${digest1// *}
+	echo :"$output":
+	[ "$status" -eq 0 ]
+	[ "${#lines[*]}" -eq 1 ]
+	[ "${lines[0]}" = "$firstimage" ]
+
+	run storage --debug=false delete-image ${firstimage}
+	echo :"$output":
+	[ "$status" -eq 0 ]
+
+	run storage --debug=false images-by-digest --quiet sha256:${digest1// *}
+	echo :"$output":
+	[ "$status" -eq 0 ]
+	[ "$output" = "" ]
+}


### PR DESCRIPTION
Add a "digest" of an image that is equal to the digest of its big data item named "manifest", if it has one, that we can index and use for locating images.  We'll be able to use this in the image library to help it locate images using canonical (digest-based) references.