### PR TITLE
Check for overlay merging optimization

### DIFF
--- a/drivers/btrfs/btrfs_test.go
+++ b/drivers/btrfs/btrfs_test.go
@@ -58,6 +58,10 @@ func TestBtrfsSubvolDelete(t *testing.T) {
 	}
 }
 
+func TestBtrfsEcho(t *testing.T) {
+	graphtest.DriverTestEcho(t, "btrfs")
+}
+
 func TestBtrfsTeardown(t *testing.T) {
 	graphtest.PutDriver(t)
 }

--- a/drivers/devmapper/devmapper_test.go
+++ b/drivers/devmapper/devmapper_test.go
@@ -86,6 +86,10 @@ func TestDevmapperTeardown(t *testing.T) {
 	graphtest.PutDriver(t)
 }
 
+func TestDevmapperEcho(t *testing.T) {
+	graphtest.DriverTestEcho(t, "devicemapper")
+}
+
 func TestDevmapperReduceLoopBackSize(t *testing.T) {
 	tenMB := int64(10 * 1024 * 1024)
 	testChangeLoopBackSize(t, -tenMB, defaultDataLoopbackSize, defaultMetaDataLoopbackSize)

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -740,6 +740,11 @@ func (d *Driver) Diff(id, parent, mountLabel string) (io.ReadCloser, error) {
 		return d.naiveDiff.Diff(id, parent, mountLabel)
 	}
 
+	lowerDirs, err := d.getLowerDirs(id)
+	if err != nil {
+		return nil, err
+	}
+
 	diffPath := d.getDiffPath(id)
 	logrus.Debugf("Tar with options on %s", diffPath)
 	return archive.TarWithOptions(diffPath, &archive.TarOptions{
@@ -747,6 +752,7 @@ func (d *Driver) Diff(id, parent, mountLabel string) (io.ReadCloser, error) {
 		UIDMaps:        d.uidMaps,
 		GIDMaps:        d.gidMaps,
 		WhiteoutFormat: archive.OverlayWhiteoutFormat,
+		WhiteoutData:   lowerDirs,
 	})
 }
 

--- a/drivers/overlay/overlay_test.go
+++ b/drivers/overlay/overlay_test.go
@@ -84,6 +84,10 @@ func TestOverlayTeardown(t *testing.T) {
 	graphtest.PutDriver(t)
 }
 
+func TestOverlayEcho(t *testing.T) {
+	graphtest.DriverTestEcho(t, driverName)
+}
+
 // Benchmarks should always setup new driver
 
 func BenchmarkExists(b *testing.B) {

--- a/drivers/vfs/vfs_test.go
+++ b/drivers/vfs/vfs_test.go
@@ -35,3 +35,15 @@ func TestVfsCreateSnap(t *testing.T) {
 func TestVfsTeardown(t *testing.T) {
 	graphtest.PutDriver(t)
 }
+
+func TestVfsDiffApply100Files(t *testing.T) {
+	graphtest.DriverTestDiffApply(t, 100, "vfs")
+}
+
+func TestVfsChanges(t *testing.T) {
+	graphtest.DriverTestChanges(t, "vfs")
+}
+
+func TestVfsEcho(t *testing.T) {
+	graphtest.DriverTestEcho(t, "vfs")
+}

--- a/drivers/zfs/zfs_test.go
+++ b/drivers/zfs/zfs_test.go
@@ -30,6 +30,10 @@ func TestZfsSetQuota(t *testing.T) {
 	graphtest.DriverTestSetQuota(t, "zfs")
 }
 
+func TestZfsEcho(t *testing.T) {
+	graphtest.DriverTestEcho(t, "zfs")
+}
+
 func TestZfsTeardown(t *testing.T) {
 	graphtest.PutDriver(t)
 }

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -45,6 +45,10 @@ type (
 		// This format will be converted to the standard format on pack
 		// and from the standard format on unpack.
 		WhiteoutFormat WhiteoutFormat
+		// This is additional data to be used by the converter.  It will
+		// not survive a round trip through JSON, so it's primarily
+		// intended for generating archives (i.e., converting writes).
+		WhiteoutData interface{}
 		// When unpacking, specifies whether overwriting a directory with a
 		// non-directory is allowed and vice versa.
 		NoOverwriteDirNonDir bool
@@ -702,7 +706,7 @@ func TarWithOptions(srcPath string, options *TarOptions) (io.ReadCloser, error) 
 			compressWriter,
 			options.ChownOpts,
 		)
-		ta.WhiteoutConverter = getWhiteoutConverter(options.WhiteoutFormat)
+		ta.WhiteoutConverter = getWhiteoutConverter(options.WhiteoutFormat, options.WhiteoutData)
 
 		defer func() {
 			// Make sure to check the error on Close.
@@ -860,7 +864,7 @@ func Unpack(decompressedArchive io.Reader, dest string, options *TarOptions) err
 	var dirs []*tar.Header
 	idMappings := idtools.NewIDMappingsFromMaps(options.UIDMaps, options.GIDMaps)
 	rootIDs := idMappings.RootPair()
-	whiteoutConverter := getWhiteoutConverter(options.WhiteoutFormat)
+	whiteoutConverter := getWhiteoutConverter(options.WhiteoutFormat, options.WhiteoutData)
 
 	// Iterate through the files in the archive.
 loop:

--- a/pkg/archive/archive_other.go
+++ b/pkg/archive/archive_other.go
@@ -2,6 +2,6 @@
 
 package archive
 
-func getWhiteoutConverter(format WhiteoutFormat) tarWhiteoutConverter {
+func getWhiteoutConverter(format WhiteoutFormat, data interface{}) tarWhiteoutConverter {
 	return nil
 }

--- a/pkg/archive/archive_unix_test.go
+++ b/pkg/archive/archive_unix_test.go
@@ -236,7 +236,8 @@ func TestTarUntarWithXattr(t *testing.T) {
 	require.NoError(t, err)
 	err = ioutil.WriteFile(filepath.Join(origin, "3"), []byte("will be ignored"), 0700)
 	require.NoError(t, err)
-	err = system.Lsetxattr(filepath.Join(origin, "2"), "security.capability", []byte{0x00}, 0)
+	encoded := [20]byte{0, 0, 0, 2}
+	err = system.Lsetxattr(filepath.Join(origin, "2"), "security.capability", encoded[:], 0)
 	require.NoError(t, err)
 
 	for _, c := range []Compression{

--- a/pkg/archive/changes.go
+++ b/pkg/archive/changes.go
@@ -81,7 +81,7 @@ func sameFsTimeSpec(a, b syscall.Timespec) bool {
 // Changes walks the path rw and determines changes for the files in the path,
 // with respect to the parent layers
 func Changes(layers []string, rw string) ([]Change, error) {
-	return changes(layers, rw, aufsDeletedFile, aufsMetadataSkip)
+	return changes(layers, rw, aufsDeletedFile, aufsMetadataSkip, aufsWhiteoutPresent)
 }
 
 func aufsMetadataSkip(path string) (skip bool, err error) {
@@ -104,10 +104,23 @@ func aufsDeletedFile(root, path string, fi os.FileInfo) (string, error) {
 	return "", nil
 }
 
+func aufsWhiteoutPresent(root, path string) (bool, error) {
+	f := filepath.Join(filepath.Dir(path), WhiteoutPrefix+filepath.Base(path))
+	_, err := os.Stat(filepath.Join(root, f))
+	if err == nil {
+		return true, nil
+	}
+	if os.IsNotExist(err) || isENOTDIR(err) {
+		return false, nil
+	}
+	return false, err
+}
+
 type skipChange func(string) (bool, error)
 type deleteChange func(string, string, os.FileInfo) (string, error)
+type whiteoutChange func(string, string) (bool, error)
 
-func changes(layers []string, rw string, dc deleteChange, sc skipChange) ([]Change, error) {
+func changes(layers []string, rw string, dc deleteChange, sc skipChange, wc whiteoutChange) ([]Change, error) {
 	var (
 		changes     []Change
 		changedDirs = make(map[string]struct{})
@@ -156,7 +169,28 @@ func changes(layers []string, rw string, dc deleteChange, sc skipChange) ([]Chan
 			change.Kind = ChangeAdd
 
 			// ...Unless it already existed in a top layer, in which case, it's a modification
+		layerScan:
 			for _, layer := range layers {
+				if wc != nil {
+					// ...Unless a lower layer also had whiteout for this directory or one of its parents,
+					// in which case, it's new
+					ignore, err := wc(layer, path)
+					if err != nil {
+						return err
+					}
+					if ignore {
+						break layerScan
+					}
+					for dir := filepath.Dir(path); dir != "" && dir != string(os.PathSeparator); dir = filepath.Dir(dir) {
+						ignore, err = wc(layer, dir)
+						if err != nil {
+							return err
+						}
+						if ignore {
+							break layerScan
+						}
+					}
+				}
 				stat, err := os.Stat(filepath.Join(layer, path))
 				if err != nil && !os.IsNotExist(err) {
 					return err

--- a/pkg/archive/changes.go
+++ b/pkg/archive/changes.go
@@ -187,10 +187,15 @@ func changes(layers []string, rw string, dc deleteChange, sc skipChange) ([]Chan
 		}
 		if change.Kind == ChangeAdd || change.Kind == ChangeDelete {
 			parent := filepath.Dir(path)
-			if _, ok := changedDirs[parent]; !ok && parent != "/" {
-				changes = append(changes, Change{Path: parent, Kind: ChangeModify})
-				changedDirs[parent] = struct{}{}
+			tail := []Change{}
+			for parent != "/" {
+				if _, ok := changedDirs[parent]; !ok && parent != "/" {
+					tail = append([]Change{{Path: parent, Kind: ChangeModify}}, tail...)
+					changedDirs[parent] = struct{}{}
+				}
+				parent = filepath.Dir(parent)
 			}
+			changes = append(changes, tail...)
 		}
 
 		// Record change

--- a/pkg/archive/changes_linux.go
+++ b/pkg/archive/changes_linux.go
@@ -300,7 +300,10 @@ func isENOTDIR(err error) bool {
 // OverlayChanges walks the path rw and determines changes for the files in the path,
 // with respect to the parent layers
 func OverlayChanges(layers []string, rw string) ([]Change, error) {
-	return changes(layers, rw, overlayDeletedFile, nil, overlayLowerContainsWhiteout)
+	dc := func(root, path string, fi os.FileInfo) (string, error) {
+		return overlayDeletedFile(layers, root, path, fi)
+	}
+	return changes(layers, rw, dc, nil, overlayLowerContainsWhiteout)
 }
 
 func overlayLowerContainsWhiteout(root, path string) (bool, error) {
@@ -321,23 +324,72 @@ func overlayLowerContainsWhiteout(root, path string) (bool, error) {
 	return false, nil
 }
 
-func overlayDeletedFile(root, path string, fi os.FileInfo) (string, error) {
+func overlayDeletedFile(layers []string, root, path string, fi os.FileInfo) (string, error) {
+	// If it's a whiteout item, then a file or directory with that name is removed by this layer.
 	if fi.Mode()&os.ModeCharDevice != 0 {
 		s := fi.Sys().(*syscall.Stat_t)
 		if major(s.Rdev) == 0 && minor(s.Rdev) == 0 {
 			return path, nil
 		}
 	}
-	if fi.Mode()&os.ModeDir != 0 {
-		opaque, err := system.Lgetxattr(filepath.Join(root, path), "trusted.overlay.opaque")
-		if err != nil {
+	// After this we only need to pay attention to directories.
+	if !fi.IsDir() {
+		return "", nil
+	}
+	// If the directory isn't marked as opaque, then it's just a normal directory.
+	opaque, err := system.Lgetxattr(filepath.Join(root, path), "trusted.overlay.opaque")
+	if err != nil {
+		return "", err
+	}
+	if len(opaque) != 1 || opaque[0] != 'y' {
+		return "", err
+	}
+	// If there are no lower layers, then it can't have been deleted and recreated in this layer.
+	if len(layers) == 0 {
+		return "", err
+	}
+	// At this point, we have a directory that's opaque.  If it appears in one of the lower
+	// layers, then it was newly-created here, so it wasn't also deleted here.
+	for _, layer := range layers {
+		stat, err := os.Stat(filepath.Join(layer, path))
+		if err != nil && !os.IsNotExist(err) && !isENOTDIR(err) {
+			// Not sure what happened here.
 			return "", err
 		}
-		if len(opaque) == 1 && opaque[0] == 'y' {
+		if err == nil {
+			if stat.Mode()&os.ModeCharDevice != 0 {
+				// It's a whiteout for this directory, so it can't have been
+				// deleted in this layer.
+				s := stat.Sys().(*syscall.Stat_t)
+				if major(s.Rdev) == 0 && minor(s.Rdev) == 0 {
+					return "", nil
+				}
+			}
+			// It's not whiteout, so it was there in the older layer, so it has to be
+			// marked as deleted in this layer.
 			return path, nil
+		}
+		for dir := filepath.Dir(path); dir != "" && dir != string(os.PathSeparator); dir = filepath.Dir(dir) {
+			// Check for whiteout for a parent directory.
+			stat, err := os.Stat(filepath.Join(layer, dir))
+			if err != nil && !os.IsNotExist(err) && !isENOTDIR(err) {
+				// Not sure what happened here.
+				return "", err
+			}
+			if err == nil {
+				if stat.Mode()&os.ModeCharDevice != 0 {
+					// If it's whiteout for a parent directory, then the
+					// original directory wasn't inherited into the top layer.
+					s := stat.Sys().(*syscall.Stat_t)
+					if major(s.Rdev) == 0 && minor(s.Rdev) == 0 {
+						return "", nil
+					}
+				}
+			}
 		}
 	}
 
+	// We didn't find the same path in any older layers, so it was new in this one.
 	return "", nil
 
 }

--- a/pkg/archive/changes_test.go
+++ b/pkg/archive/changes_test.go
@@ -212,6 +212,8 @@ func TestChangesWithChangesGH13590(t *testing.T) {
 	require.NoError(t, err)
 
 	expectedChanges := []Change{
+		{"/dir1", ChangeModify},
+		{"/dir1/dir2", ChangeModify},
 		{"/dir1/dir2/dir3", ChangeModify},
 		{"/dir1/dir2/dir3/file1.txt", ChangeAdd},
 	}

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -157,6 +157,9 @@ populate() {
 	mkdir "$uppermount"/layerdir4
 	mkdir "$uppermount"/layerdir4/layer1subdir
 	mkdir "$uppermount"/layerdir7
+	# Add some new contents, too.
+	mkdir "$uppermount"/layerdir3/layer3subdir
+	mkdir "$uppermount"/layerdir3/layer3subdir/layer3subsubdir
 	createrandom "$uppermount"/layerdir7/layer1file4
 	# Unmount the layer.
 	storage unmount $upperlayer
@@ -169,7 +172,8 @@ checkchanges() {
 	storage changes $lowerlayer
 	run storagewithsorting2 --debug=false changes $lowerlayer
 	[ "$status" -eq 0 ]
-	echo :"$output":
+	echo Changes for layer 1:
+	echo "$output"
 	[ "${#lines[*]}" -eq 18 ]
 	[ "${lines[0]}" = 'Add "/layer1file1"' ]
 	[ "${lines[1]}" = 'Add "/layer1file2"' ]
@@ -193,7 +197,8 @@ checkchanges() {
 	storage changes $midlayer
 	run storagewithsorting2 --debug=false changes $midlayer
 	[ "$status" -eq 0 ]
-	echo :"$output":
+	echo Changes for layer 2:
+	echo "$output"
 	[ "${#lines[*]}" -eq 14 ]
 	[ "${lines[0]}" = 'Delete "/layer1file1"' ]
 	[ "${lines[1]}" = 'Delete "/layer1file2"' ]
@@ -213,14 +218,18 @@ checkchanges() {
 	storage changes $upperlayer
 	run storagewithsorting2 --debug=false changes $upperlayer
 	[ "$status" -eq 0 ]
-	echo :"$output":
-	[ "${#lines[*]}" -eq 6 ]
+	echo Changes for layer 3:
+	echo "$output"
+	[ "${#lines[*]}" -eq 9 ]
 	[ "${lines[0]}" = 'Add "/layerdir1"' ]
-	[ "${lines[1]}" = 'Add "/layerdir4"' ]
-	[ "${lines[2]}" = 'Add "/layerdir4/layer1subdir"' ]
-	[ "${lines[3]}" = 'Add "/layerdir7"' ]
-	[ "${lines[4]}" = 'Add "/layerdir7/layer1file4"' ]
-	[ "${lines[5]}" = 'Add "/layerfile1"' ]
+	[ "${lines[1]}" = 'Modify "/layerdir3"' ]
+	[ "${lines[2]}" = 'Add "/layerdir3/layer3subdir"' ]
+	[ "${lines[3]}" = 'Add "/layerdir3/layer3subdir/layer3subsubdir"' ]
+	[ "${lines[4]}" = 'Add "/layerdir4"' ]
+	[ "${lines[5]}" = 'Add "/layerdir4/layer1subdir"' ]
+	[ "${lines[6]}" = 'Add "/layerdir7"' ]
+	[ "${lines[7]}" = 'Add "/layerdir7/layer1file4"' ]
+	[ "${lines[8]}" = 'Add "/layerfile1"' ]
 }
 
 # Check that the diff contents for layers created by populate() correspond to
@@ -231,7 +240,8 @@ checkdiffs() {
 	tar tf $TESTDIR/lower.tar > $TESTDIR/lower.txt
 	run env LC_ALL=C sort $TESTDIR/lower.txt
 	[ "$status" -eq 0 ]
-	echo :"$output":
+	echo Diff contents for layer 1:
+	echo "$output"
 	[ "${#lines[*]}" -eq 18 ]
 	[ "${lines[0]}" = 'layer1file1' ]
 	[ "${lines[1]}" = 'layer1file2' ]
@@ -256,7 +266,8 @@ checkdiffs() {
 	tar tzf $TESTDIR/middle.tar > $TESTDIR/middle.txt
 	run env LC_ALL=C sort $TESTDIR/middle.txt
 	[ "$status" -eq 0 ]
-	echo :"$output":
+	echo Diff contents for layer 2:
+	echo "$output"
 	[ "${#lines[*]}" -eq 14 ]
 	[ "${lines[0]}" = '.wh.layer1file1' ]
 	[ "${lines[1]}" = '.wh.layer1file2' ]
@@ -277,12 +288,16 @@ checkdiffs() {
 	tar tf $TESTDIR/upper.tar > $TESTDIR/upper.txt
 	run env LC_ALL=C sort $TESTDIR/upper.txt
 	[ "$status" -eq 0 ]
-	echo :"$output":
-	[ "${#lines[*]}" -eq 6 ]
+	echo Diff contents for layer 3:
+	echo "$output"
+	[ "${#lines[*]}" -eq 9 ]
 	[ "${lines[0]}" = 'layerdir1/' ]
-	[ "${lines[1]}" = 'layerdir4/' ]
-	[ "${lines[2]}" = 'layerdir4/layer1subdir/' ]
-	[ "${lines[3]}" = 'layerdir7/' ]
-	[ "${lines[4]}" = 'layerdir7/layer1file4' ]
-	[ "${lines[5]}" = 'layerfile1' ]
+	[ "${lines[1]}" = 'layerdir3/' ]
+	[ "${lines[2]}" = 'layerdir3/layer3subdir/' ]
+	[ "${lines[3]}" = 'layerdir3/layer3subdir/layer3subsubdir/' ]
+	[ "${lines[4]}" = 'layerdir4/' ]
+	[ "${lines[5]}" = 'layerdir4/layer1subdir/' ]
+	[ "${lines[6]}" = 'layerdir7/' ]
+	[ "${lines[7]}" = 'layerdir7/layer1file4' ]
+	[ "${lines[8]}" = 'layerfile1' ]
 }

--- a/tests/test_drivers.bash
+++ b/tests/test_drivers.bash
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+TMPDIR=${TMPDIR:-/var/tmp}
+
 aufs() {
 	modprobe aufs 2> /dev/null
 	grep -E -q '	aufs$' /proc/filesystems


### PR DESCRIPTION
Check if the overlay filesystem implements an optimization that landed in 97c684cc911060ba7f97c0925eaf842f159a39e8, and in the mainline kernel in 4.10:  directories created in merged directories are marked as opaque to let the kernel know that it needn't bother looking at lower layers when reading the contents of that directory.

This means that, when generating a layer diff for an upper directory, we can't treat the presence of an opaque whiteout entry as an indication that a layer diff needs to include whiteout for a directory of the same name from a lower layer.  If we do, when that diff is later applied, the directory gets created, and then removed, and then only recreated (possibly with different permissions) if the diff also places contents in the directory.