### PR TITLE
Turn DType testing back on

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -245,9 +245,7 @@ func supportsOverlay(home string, homeMagic graphdriver.FsMagic, rootUID, rootGI
 			return false, err
 		}
 		if !supportsDType {
-			logrus.Warn(overlayutils.ErrDTypeNotSupported("overlay", backingFs))
-			// TODO: Will make fatal when CRI-O Has AMI built on RHEL7.4
-			// return nil, overlayutils.ErrDTypeNotSupported("overlay", backingFs)
+			return false, overlayutils.ErrDTypeNotSupported("overlay", backingFs)
 		}
 
 		// Try a test mount in the specific location we're looking at using.


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

Reverting #106 to error on DType rather than just warn as support should have been added to the CI for this.