### PR TITLE
overlay: perform the support check after creating homedir

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -142,14 +142,16 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 		return nil, err
 	}
 
-	supportsDType, err := supportsOverlay(home, fsMagic, rootUID, rootGID)
-	if err != nil {
-		return nil, errors.Wrap(graphdriver.ErrNotSupported, "kernel does not support overlay fs")
-	}
-
 	// Create the driver home dir
 	if err := idtools.MkdirAllAs(path.Join(home, linkDir), 0700, rootUID, rootGID); err != nil && !os.IsExist(err) {
 		return nil, err
+	}
+
+	supportsDType, err := supportsOverlay(home, fsMagic, rootUID, rootGID)
+	if err != nil {
+		os.Remove(filepath.Join(home, linkDir))
+		os.Remove(home)
+		return nil, errors.Wrap(graphdriver.ErrNotSupported, "kernel does not support overlay fs")
 	}
 
 	if err := mount.MakePrivate(home); err != nil {


### PR DESCRIPTION
The supports-dtype check tries to create a subdirectory of the driver's home directory to use for its checks, so it needs to be called after that directory has been created.

If it fails, go ahead and try to rmdir() the directories that we've created to avoid creating a false positive indicator that this driver works, but let the attempt to remove them fail in case we've had previous successful startups and there's actually data here.