### PR TITLE
Make isENOTDIR available on all platforms

### DIFF
--- a/pkg/archive/changes.go
+++ b/pkg/archive/changes.go
@@ -116,6 +116,18 @@ func aufsWhiteoutPresent(root, path string) (bool, error) {
 	return false, err
 }
 
+func isENOTDIR(err error) bool {
+	if err == nil {
+		return false
+	}
+	if perror, ok := err.(*os.PathError); ok {
+		if errno, ok := perror.Err.(syscall.Errno); ok {
+			return errno == syscall.ENOTDIR
+		}
+	}
+	return false
+}
+
 type skipChange func(string) (bool, error)
 type deleteChange func(string, string, os.FileInfo) (string, error)
 type whiteoutChange func(string, string) (bool, error)

--- a/pkg/archive/changes_linux.go
+++ b/pkg/archive/changes_linux.go
@@ -285,18 +285,6 @@ func clen(n []byte) int {
 	return len(n)
 }
 
-func isENOTDIR(err error) bool {
-	if err == nil {
-		return false
-	}
-	if perror, ok := err.(*os.PathError); ok {
-		if errno, ok := perror.Err.(syscall.Errno); ok {
-			return errno == syscall.ENOTDIR
-		}
-	}
-	return false
-}
-
 // OverlayChanges walks the path rw and determines changes for the files in the path,
 // with respect to the parent layers
 func OverlayChanges(layers []string, rw string) ([]Change, error) {


### PR DESCRIPTION
This fixes compilation on macOS, at least, and by code inspection could work on Windows as well.

Fixes #160.

(Warning: untested other than `go build`. Hoping this PR triggers a test suite.)