### PR TITLE
Enable Stable + build/test on Fedora and CentOS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,15 +24,43 @@ env:
                       -e TRAVIS_JOB_ID=$TRAVIS_JOB_ID
                       -e TRAVIS_BUILD_DIR=$TRAVIS_BUILD_DIR"
     matrix:
-        # TODO: broken?
-        #- GO_VERSION="stable"
-        #  DISTRO="ubuntu"
-
-        - GO_VERSION="1.9"
+        # Ubuntu
+        - GO_VERSION="stable"
           DISTRO="ubuntu"
 
         - GO_VERSION="1.8"
           DISTRO="ubuntu"
+
+        - GO_VERSION="1.9"
+          DISTRO="ubuntu"
+
+        # Fedora
+        - GO_VERSION="stable"
+          DISTRO="fedora"
+
+        - GO_VERSION="1.9"
+          DISTRO="fedora"
+
+        - GO_VERSION="1.8"
+          DISTRO="fedora"
+
+        # CentOS
+        - GO_VERSION="stable"
+          DISTRO="centos"
+
+        - GO_VERSION="1.9"
+          DISTRO="centos"
+
+        - GO_VERSION="1.8"
+          DISTRO="centos"
+
+# GO_VERSION="stable" builds successfully, but tests fail on all platforms.
+# Run the tests, but ignore the result (for now)
+matrix:
+    allow_failures:
+        - env: GO_VERSION="stable" DISTRO="ubuntu"
+        - env: GO_VERSION="stable" DISTRO="fedora"
+        - env: GO_VERSION="stable" DISTRO="centos"
 
 before_install:
     - sudo apt-get -qq update

--- a/hack/run_ci_tests.sh
+++ b/hack/run_ci_tests.sh
@@ -9,6 +9,8 @@ set -e
 SPCCMD="${SPCCMD:-./hack/spc_ci_test.sh}"
 DISTRO="${DISTRO:-ubuntu}"
 FQIN="docker.io/cevich/travis_${DISTRO}:latest"
+
+# This can take a while, start it going as early as possible
 sudo docker pull $FQIN &
 
 REPO_DIR=$(realpath "$(dirname $0)/../")  # assume parent directory of 'hack'
@@ -46,7 +48,7 @@ ENV_ARGS="-e GO_VERSION=${GO_VERSION:-stable} -e HOME=/root -e SHELL=/bin/bash
           -e SPC=true -e DISTRO=$DISTRO -e REPO=$REPO_HOST/$REPO_OWNER/$REPO_NAME"
 
 echo
-echo "Preparing to run \$SPCMD=$SPCCMD in a $DISTRO SPC."
+echo "Preparing to run \$SPCMD=$SPCCMD in a \$DISTRO=$DISTRO SPC."
 echo "Override either for a different experience."
 wait  # for backgrounded processes to finish
 echo

--- a/hack/spc_ci_test.sh
+++ b/hack/spc_ci_test.sh
@@ -15,6 +15,14 @@ case "$DISTRO" in
     *ubuntu*)
         export INSTALL_CMD="apt-get -qq install bats btrfs-tools libdevmapper-dev"
         ;;
+    *fedora*)
+        export INSTALL_CMD="dnf -y install bats btrfs-progs btrfs-progs-devel
+                            e2fsprogs xfsprogs device-mapper-devel"
+        ;;
+    *centos*)
+        export INSTALL_CMD="yum install -y bats btrfs-progs btrfs-progs-devel
+                            e2fsprogs xfsprogs device-mapper-devel"
+        ;;
     *)
         echo "Unknown/unsupported \$DISTRO=$DISTRO"
         exit 2


### PR DESCRIPTION
* Added the few small changes needed to support these other distros.

* Enable building GO_VERSION "stable" on all distros, but ignore the
result.  The failures are seemingly similar, but beyond my ability to
debug.  For now, ignore the result to provide exposure and runtime
without any requirement to pass.