### PR TITLE
Restore details to "overlay not supported" errors

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -114,8 +114,8 @@ func init() {
 }
 
 // Init returns the a native diff driver for overlay filesystem.
-// If overlay filesystem is not supported on the host, graphdriver.ErrNotSupported is returned as error.
-// If an overlay filesystem is not supported over an existing filesystem then error graphdriver.ErrIncompatibleFS is returned.
+// If overlay filesystem is not supported on the host, a wrapped graphdriver.ErrNotSupported is returned as error.
+// If an overlay filesystem is not supported over an existing filesystem then a wrapped graphdriver.ErrIncompatibleFS is returned.
 func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (graphdriver.Driver, error) {
 	opts, err := parseOptions(options)
 	if err != nil {
@@ -151,7 +151,7 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 	if err != nil {
 		os.Remove(filepath.Join(home, linkDir))
 		os.Remove(home)
-		return nil, errors.Wrap(graphdriver.ErrNotSupported, "kernel does not support overlay fs")
+		return nil, errors.Wrap(err, "kernel does not support overlay fs")
 	}
 
 	if err := mount.MakePrivate(home); err != nil {

--- a/drivers/overlayutils/overlayutils.go
+++ b/drivers/overlayutils/overlayutils.go
@@ -3,8 +3,10 @@
 package overlayutils
 
 import (
-	"errors"
 	"fmt"
+
+	"github.com/containers/storage/drivers"
+	"github.com/pkg/errors"
 )
 
 // ErrDTypeNotSupported denotes that the backing filesystem doesn't support d_type.
@@ -14,5 +16,5 @@ func ErrDTypeNotSupported(driver, backingFs string) error {
 		msg += " Reformat the filesystem with ftype=1 to enable d_type support."
 	}
 	msg += " Running without d_type is not supported."
-	return errors.New(msg)
+	return errors.Wrap(graphdriver.ErrNotSupported, msg)
 }


### PR DESCRIPTION
Revert the mistaken change to wrap graphdriver.ErrNotSupported instead of the error returned by supportsOverlay(), when it returns an error, so that text describing exactly why overlay isn't supported will be returned to our caller.