### PR TITLE
Running all CI tests using podman or docker

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,7 +22,8 @@ env:
                       -e TRAVIS_PULL_REQUEST_SLUG=$TRAVIS_PULL_REQUEST_SLUG
                       -e TRAVIS_BRANCH=$TRAVIS_BRANCH
                       -e TRAVIS_JOB_ID=$TRAVIS_JOB_ID
-                      -e TRAVIS_BUILD_DIR=$TRAVIS_BUILD_DIR"
+                      -e TRAVIS_BUILD_DIR=$TRAVIS_BUILD_DIR
+                      -e CONTAINER=podman"
     matrix:
         # Ubuntu
         - GO_VERSION="stable"

--- a/hack/travis_podman_setup.sh
+++ b/hack/travis_podman_setup.sh
@@ -1,0 +1,13 @@
+
+
+# N/B: This script is only to be used by run_ci_tests.sh for setting up podman to run
+# in in the travis VM (host).  All other usage may result in severe halitosis.
+
+set -e
+
+if [[ "$CONTAINER" != "podman" ]] || [[ "$TRAVIS" != "true" ]]
+then
+    exit 42
+fi
+
+# FIXME: Add steps needed to install / setup podman on Ubuntu Trusty


### PR DESCRIPTION
Use podman by default unless ``$CONTAINER=docker``.
Same for local testing with ``hack/run_ci_tests.sh``.

Signed-off-by: Chris Evich <cevich@redhat.com>