### PR TITLE
Add debug message on mountFrom error

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -267,16 +267,22 @@ func supportsOverlay(home string, homeMagic graphdriver.FsMagic, rootUID, rootGI
 		_ = idtools.MkdirAs(lower2Dir, 0700, rootUID, rootGID)
 		flags := fmt.Sprintf("lowerdir=%s:%s", lower1Dir, lower2Dir)
 		if len(flags) < unix.Getpagesize() {
-			if mountFrom(filepath.Dir(home), "overlay", mergedDir, "overlay", 0, flags) == nil {
+			err := mountFrom(filepath.Dir(home), "overlay", mergedDir, "overlay", 0, flags)
+			if err == nil {
 				logrus.Debugf("overlay test mount with multiple lowers succeeded")
 				return supportsDType, nil
+			} else {
+				logrus.Debugf("overlay test mount with multiple lowers failed %v", err)
 			}
 		}
 		flags = fmt.Sprintf("lowerdir=%s", lower1Dir)
 		if len(flags) < unix.Getpagesize() {
-			if mountFrom(filepath.Dir(home), "overlay", mergedDir, "overlay", 0, flags) == nil {
+			err := mountFrom(filepath.Dir(home), "overlay", mergedDir, "overlay", 0, flags)
+			if err == nil {
 				logrus.Errorf("overlay test mount with multiple lowers failed, but succeeded with a single lower")
 				return supportsDType, errors.Wrap(graphdriver.ErrNotSupported, "kernel too old to provide multiple lowers feature for overlay")
+			} else {
+				logrus.Debugf("overlay test mount with a single lower failed %v", err)
 			}
 		}
 		logrus.Errorf("'overlay' is not supported over %s at %q", backingFs, home)


### PR DESCRIPTION
Signed-off-by: TomSweeneyRedHat <tsweeney@redhat.com>

While debugging an issue, the error message led you to believe that the error was with the kernel settings when in reality it was a port contention issue.  The error message from mountFrom that showed the true error was being swallowed.  Adding the debug will at least let us root cause it.