### PR TITLE
CLI: fix JSON output for layer/container-parent-owners

### DIFF
--- a/cmd/containers-storage/container.go
+++ b/cmd/containers-storage/container.go
@@ -186,15 +186,24 @@ func containerParentOwners(flags *mflag.FlagSet, action string, m storage.Store,
 			matched = append(matched, container)
 		}
 	}
-	if jsonOutput {
-		json.NewEncoder(os.Stdout).Encode(matched)
-	} else {
-		for _, container := range matched {
-			uids, gids, err := m.ContainerParentOwners(container.ID)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "ContainerParentOwner: %v\n", err)
-				return 1
+	for _, container := range matched {
+		uids, gids, err := m.ContainerParentOwners(container.ID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "ContainerParentOwner: %v\n", err)
+			return 1
+		}
+		if jsonOutput {
+			mappings := struct {
+				ID   string
+				UIDs []int
+				GIDs []int
+			}{
+				ID:   container.ID,
+				UIDs: uids,
+				GIDs: gids,
 			}
+			json.NewEncoder(os.Stdout).Encode(mappings)
+		} else {
 			fmt.Printf("ID: %s\n", container.ID)
 			if len(uids) > 0 {
 				fmt.Printf("UIDs: %v\n", uids)

--- a/cmd/containers-storage/layer.go
+++ b/cmd/containers-storage/layer.go
@@ -42,15 +42,24 @@ func layerParentOwners(flags *mflag.FlagSet, action string, m storage.Store, arg
 			matched = append(matched, layer)
 		}
 	}
-	if jsonOutput {
-		json.NewEncoder(os.Stdout).Encode(matched)
-	} else {
-		for _, layer := range matched {
-			uids, gids, err := m.LayerParentOwners(layer.ID)
-			if err != nil {
-				fmt.Fprintf(os.Stderr, "LayerParentOwner: %v\n", err)
-				return 1
+	for _, layer := range matched {
+		uids, gids, err := m.LayerParentOwners(layer.ID)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "LayerParentOwner: %v\n", err)
+			return 1
+		}
+		if jsonOutput {
+			mappings := struct {
+				ID   string
+				UIDs []int
+				GIDs []int
+			}{
+				ID:   layer.ID,
+				UIDs: uids,
+				GIDs: gids,
 			}
+			json.NewEncoder(os.Stdout).Encode(mappings)
+		} else {
 			fmt.Printf("ID: %s\n", layer.ID)
 			if len(uids) > 0 {
 				fmt.Printf("UIDs: %v\n", uids)


### PR DESCRIPTION
Provide the information that was actually requested when we produce JSON output for the layer-parent-owners and container-parent-owners commands.  Carried over from #156.