### PR TITLE
OCI RUntimes need to be able to search through container storage

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -882,6 +882,20 @@ func (d *Driver) UpdateLayerIDMap(id string, toContainer, toHost *idtools.IDMapp
 	if err := idtools.MkdirAs(diffDir, 0755, rootUID, rootGID); err != nil {
 		return err
 	}
+
+	// Make sure that host root is the only user that can search through
+	// the container storage directory.
+	if err = os.Chmod(dir, 0700); err != nil {
+		return errors.Wrapf(err, "cannot chmod '%s'", dir)
+	}
+
+	if rootUID != 0 {
+		// If using userns make sure the container dir is owned by
+		// root of the container.
+		if err = os.Chown(dir, rootUID, rootGID); err != nil {
+			return errors.Wrapf(err, "cannot chown '%s'", dir)
+		}
+	}
 	return nil
 }
 

--- a/store.go
+++ b/store.go
@@ -551,7 +551,7 @@ func GetStore(options StoreOptions) (Store, error) {
 	if err := os.MkdirAll(options.RunRoot, 0700); err != nil && !os.IsExist(err) {
 		return nil, err
 	}
-	if err := os.MkdirAll(options.GraphRoot, 0700); err != nil && !os.IsExist(err) {
+	if err := os.MkdirAll(filepath.Join(options.GraphRoot, options.GraphDriverName), 0711); err != nil && !os.IsExist(err) {
 		return nil, err
 	}
 	for _, subdir := range []string{"mounts", "tmp", options.GraphDriverName} {


### PR DESCRIPTION
This change is requied to allow runc to mount a file system while
sitting in a userns.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>