### PR TITLE
Add default mount options to pass to drivers

### DIFF
--- a/docs/containers-storage.conf.5.md
+++ b/docs/containers-storage.conf.5.md
@@ -58,6 +58,10 @@ The `storage.options` table supports the following options:
 **mount_program**=""
   Specifies the path to a custom program to use instead for mounting the file system.
 
+**mountopt**=""
+
+  Comma separated list of default options to be used to mount container images.  Suggested value "nodev".
+
 [storage.options.thinpool]
 
 Storage Options for thinpool
@@ -111,10 +115,6 @@ Specifies the min free space percent in a thin pool required for new device crea
 **mkfsarg**=""
 
 Specifies extra mkfs arguments to be used when creating the base device.
-
-**mountopt**=""
-
-Specifies extra mount options used when mounting the thin devices.
 
 **use_deferred_removal**=""
 

--- a/drivers/aufs/aufs.go
+++ b/drivers/aufs/aufs.go
@@ -42,6 +42,7 @@ import (
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/locker"
 	mountpk "github.com/containers/storage/pkg/mount"
+	"github.com/containers/storage/pkg/parsers"
 	"github.com/containers/storage/pkg/system"
 	rsystem "github.com/opencontainers/runc/libcontainer/system"
 	"github.com/opencontainers/selinux/go-selinux/label"
@@ -77,6 +78,7 @@ type Driver struct {
 	pathCache     map[string]string
 	naiveDiff     graphdriver.DiffDriver
 	locker        *locker.Locker
+	mountOptions  string
 }
 
 // Init returns a new AUFS driver.
@@ -103,6 +105,20 @@ func Init(root string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 		return nil, errors.Wrapf(graphdriver.ErrIncompatibleFS, "AUFS is not supported over %q", backingFs)
 	}
 
+	var mountOptions string
+	for _, option := range options {
+		key, val, err := parsers.ParseKeyValueOpt(option)
+		if err != nil {
+			return nil, err
+		}
+		key = strings.ToLower(key)
+		switch key {
+		case "aufs.mountopt":
+			mountOptions = val
+		default:
+			return nil, fmt.Errorf("option %s not supported", option)
+		}
+	}
 	paths := []string{
 		"mnt",
 		"diff",
@@ -110,12 +126,13 @@ func Init(root string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 	}
 
 	a := &Driver{
-		root:      root,
-		uidMaps:   uidMaps,
-		gidMaps:   gidMaps,
-		pathCache: make(map[string]string),
-		ctr:       graphdriver.NewRefCounter(graphdriver.NewFsChecker(graphdriver.FsMagicAufs)),
-		locker:    locker.New(),
+		root:         root,
+		uidMaps:      uidMaps,
+		gidMaps:      gidMaps,
+		pathCache:    make(map[string]string),
+		ctr:          graphdriver.NewRefCounter(graphdriver.NewFsChecker(graphdriver.FsMagicAufs)),
+		locker:       locker.New(),
+		mountOptions: mountOptions,
 	}
 
 	rootUID, rootGID, err := idtools.GetRootUIDGID(uidMaps, gidMaps)
@@ -653,6 +670,10 @@ func (a *Driver) aufsMount(ro []string, rw, target, mountLabel string) (err erro
 	}
 
 	opts := "dio,xino=/dev/shm/aufs.xino"
+	if a.mountOptions != "" {
+		opts += fmt.Sprintf(",%s", a.mountOptions)
+	}
+
 	if useDirperm() {
 		opts += ",dirperm1"
 	}

--- a/drivers/btrfs/btrfs.go
+++ b/drivers/btrfs/btrfs.go
@@ -110,6 +110,8 @@ func parseOptions(opt []string) (btrfsOptions, bool, error) {
 			}
 			userDiskQuota = true
 			options.minSpace = uint64(minSpace)
+		case "btrfs.mountopt":
+			return options, userDiskQuota, fmt.Errorf("btrfs driver does not support mount options")
 		default:
 			return options, userDiskQuota, fmt.Errorf("Unknown option %s", key)
 		}

--- a/drivers/devmapper/deviceset.go
+++ b/drivers/devmapper/deviceset.go
@@ -2690,7 +2690,7 @@ func NewDeviceSet(root string, doInit bool, options []string, uidMaps, gidMaps [
 			devices.filesystem = val
 		case "dm.mkfsarg":
 			devices.mkfsArgs = append(devices.mkfsArgs, val)
-		case "dm.mountopt":
+		case "dm.mountopt", "devicemapper.mountopt":
 			devices.mountOptions = joinMountOptions(devices.mountOptions, val)
 		case "dm.metadatadev":
 			devices.metadataDevice = val

--- a/drivers/vfs/driver.go
+++ b/drivers/vfs/driver.go
@@ -55,6 +55,9 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 			}
 			d.ostreeRepo = option[13:]
 		}
+		if strings.HasPrefix(option, "vfs.mountopt=") {
+			return nil, fmt.Errorf("vfs driver does not support mount options")
+		}
 	}
 	if d.ostreeRepo != "" {
 		rootUID, rootGID, err := idtools.GetRootUIDGID(uidMaps, gidMaps)

--- a/drivers/windows/windows.go
+++ b/drivers/windows/windows.go
@@ -86,6 +86,14 @@ type Driver struct {
 func InitFilter(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (graphdriver.Driver, error) {
 	logrus.Debugf("WindowsGraphDriver InitFilter at %s", home)
 
+	for _, option := range options {
+		if strings.HasPrefix(option, "windows.mountopt=") {
+			return nil, fmt.Errorf("windows driver does not support mount options")
+		} else {
+			return nil, fmt.Errorf("option %s not supported", option)
+		}
+	}
+
 	fsType, err := getFileSystemType(string(home[0]))
 	if err != nil {
 		return nil, err

--- a/drivers/zfs/zfs.go
+++ b/drivers/zfs/zfs.go
@@ -24,8 +24,9 @@ import (
 )
 
 type zfsOptions struct {
-	fsName    string
-	mountPath string
+	fsName       string
+	mountPath    string
+	mountOptions string
 }
 
 func init() {
@@ -134,6 +135,8 @@ func parseOptions(opt []string) (zfsOptions, error) {
 		switch key {
 		case "zfs.fsname":
 			options.fsName = val
+		case "zfs.mountopt":
+			options.mountOptions = val
 		default:
 			return options, fmt.Errorf("Unknown option %s", key)
 		}
@@ -364,7 +367,7 @@ func (d *Driver) Get(id, mountLabel string) (string, error) {
 	}
 
 	filesystem := d.zfsPath(id)
-	options := label.FormatMountLabel("", mountLabel)
+	options := label.FormatMountLabel(d.options.mountOptions, mountLabel)
 	logrus.Debugf(`[zfs] mount("%s", "%s", "%s")`, filesystem, mountpoint, options)
 
 	rootUID, rootGID, err := idtools.GetRootUIDGID(d.uidMaps, d.gidMaps)

--- a/storage.conf
+++ b/storage.conf
@@ -32,6 +32,9 @@ size = ""
 # OverrideKernelCheck tells the driver to ignore kernel checks based on kernel version
 override_kernel_check = "false"
 
+# mountopt specifies comma separated list of extra mount options
+mountopt = "nodev"
+
 # Remap-UIDs/GIDs is the mapping from UIDs/GIDs as they should appear inside of
 # a container, to UIDs/GIDs as they should appear outside of the container, and
 # the length of the range of UIDs/GIDs.  Additional mapped sets can be listed
@@ -102,9 +105,6 @@ override_kernel_check = "false"
 # mkfsarg specifies extra mkfs arguments to be used when creating the base.
 # device.
 # mkfsarg = ""
-
-# mountopt specifies extra mount options used when mounting the thin devices.
-# mountopt = ""
 
 # use_deferred_removal marks devicemapper block device for deferred removal.
 # If the thinpool is in use when the driver attempts to remove it, the driver 

--- a/store.go
+++ b/store.go
@@ -3015,6 +3015,9 @@ type OptionsConfig struct {
 
 	// Alternative program to use for the mount of the file system
 	MountProgram string `toml:"mount_program"`
+
+	// MountOpt specifies extra mount options used when mounting
+	MountOpt string `toml:"mountopt"`
 }
 
 // TOML-friendly explicit tables used for conversions.
@@ -3086,7 +3089,7 @@ func ReloadConfigurationFile(configFile string, storeOptions *StoreOptions) {
 		storeOptions.GraphDriverOptions = append(storeOptions.GraphDriverOptions, fmt.Sprintf("dm.mkfsarg=%s", config.Storage.Options.Thinpool.MkfsArg))
 	}
 	if config.Storage.Options.Thinpool.MountOpt != "" {
-		storeOptions.GraphDriverOptions = append(storeOptions.GraphDriverOptions, fmt.Sprintf("dm.mountopt=%s", config.Storage.Options.Thinpool.MountOpt))
+		storeOptions.GraphDriverOptions = append(storeOptions.GraphDriverOptions, fmt.Sprintf("%s.mountopt=%s", config.Storage.Driver, config.Storage.Options.Thinpool.MountOpt))
 	}
 	if config.Storage.Options.Thinpool.UseDeferredDeletion != "" {
 		storeOptions.GraphDriverOptions = append(storeOptions.GraphDriverOptions, fmt.Sprintf("dm.use_deferred_deletion=%s", config.Storage.Options.Thinpool.UseDeferredDeletion))
@@ -3111,6 +3114,9 @@ func ReloadConfigurationFile(configFile string, storeOptions *StoreOptions) {
 	}
 	if config.Storage.Options.MountProgram != "" {
 		storeOptions.GraphDriverOptions = append(storeOptions.GraphDriverOptions, fmt.Sprintf("%s.mount_program=%s", config.Storage.Driver, config.Storage.Options.MountProgram))
+	}
+	if config.Storage.Options.MountOpt != "" {
+		storeOptions.GraphDriverOptions = append(storeOptions.GraphDriverOptions, fmt.Sprintf("%s.mountopt=%s", config.Storage.Driver, config.Storage.Options.MountOpt))
 	}
 	if config.Storage.Options.OverrideKernelCheck != "" {
 		storeOptions.GraphDriverOptions = append(storeOptions.GraphDriverOptions, fmt.Sprintf("%s.override_kernel_check=%s", config.Storage.Driver, config.Storage.Options.OverrideKernelCheck))


### PR DESCRIPTION
I believe we should be running container images mounted with nodev by default.
This would eliminate the disk of a device sneaking into the container without
being on the approved list.  This would give us the same or potentially additional
security over the device cgroup.

It would be nice if this could be passed in on an image by image basis.  So users
could also specify if they want nosuid images.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>