### PR TITLE
Fix build on macOS

### DIFF
--- a/pkg/directory/directory_unix.go
+++ b/pkg/directory/directory_unix.go
@@ -1,4 +1,4 @@
-// +build linux freebsd solaris
+// +build linux darwin freebsd solaris
 
 package directory
 


### PR DESCRIPTION
Without this build fails on macOS with
> ./store.go:1561:12: undefined: directory.Size
> ./store.go:1566:11: undefined: directory.Size

because `directory.Size` has no implementation.