### PR TITLE
containers-storage: add new option .fuse_program

### DIFF
--- a/docs/containers-storage.conf.5.md
+++ b/docs/containers-storage.conf.5.md
@@ -89,6 +89,10 @@ Tells driver to wipe device (directlvm_device) even if device already has a file
 
 Specifies the filesystem type to use for the base device. (default: xfs)
 
+**fuse_program**=""
+
+Specifies the path to a custom FUSE program to use instead for mounting the file system.
+
 **log_level**=""
 
 Sets the log level of devicemapper.


### PR DESCRIPTION
When specified the mount of the overlay file system is delegated to
the specified command instead of mounting it directly.

This patch enables the usage of helpers programs for mounting overlay using a FUSE program.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>