### PR TITLE
Size can not be larger then a unint32

### DIFF
--- a/cmd/containers-storage/container.go
+++ b/cmd/containers-storage/container.go
@@ -201,8 +201,8 @@ func containerParentOwners(flags *mflag.FlagSet, action string, m storage.Store,
 		if jsonOutput {
 			mappings := struct {
 				ID   string
-				UIDs []int
-				GIDs []int
+				UIDs []uint32
+				GIDs []uint32
 			}{
 				ID:   container.ID,
 				UIDs: uids,

--- a/cmd/containers-storage/copy.go
+++ b/cmd/containers-storage/copy.go
@@ -38,7 +38,7 @@ func copyContent(flags *mflag.FlagSet, action string, m storage.Store, args []st
 			fmt.Fprintf(os.Stderr, "error %q as a numeric GID: %v", chownParts[1], err)
 			return 1
 		}
-		chownOpts = &idtools.IDPair{UID: int(uid), GID: int(gid)}
+		chownOpts = &idtools.IDPair{UID: uint32(uid), GID: uint32(gid)}
 	}
 	target := args[len(args)-1]
 	if strings.Contains(target, ":") {

--- a/cmd/containers-storage/create.go
+++ b/cmd/containers-storage/create.go
@@ -87,9 +87,9 @@ func paramIDMapping() (*storage.IDMappingOptions, error) {
 					return nil, fmt.Errorf("%s map is malformed", mapType)
 				}
 				mapping := idtools.IDMap{
-					ContainerID: int(cid),
-					HostID:      int(hid),
-					Size:        int(size),
+					ContainerID: cid,
+					HostID:      hid,
+					Size:        size,
 				}
 				idmap = append(idmap, mapping)
 			}

--- a/cmd/containers-storage/layer.go
+++ b/cmd/containers-storage/layer.go
@@ -57,8 +57,8 @@ func layerParentOwners(flags *mflag.FlagSet, action string, m storage.Store, arg
 		if jsonOutput {
 			mappings := struct {
 				ID   string
-				UIDs []int
-				GIDs []int
+				UIDs []uint32
+				GIDs []uint32
 			}{
 				ID:   layer.ID,
 				UIDs: uids,

--- a/drivers/aufs/aufs.go
+++ b/drivers/aufs/aufs.go
@@ -297,8 +297,8 @@ func (a *Driver) createDirsFor(id, parent string) error {
 			if err != nil {
 				return err
 			}
-			rootPair.UID = int(st.UID())
-			rootPair.GID = int(st.GID())
+			rootPair.UID = st.UID()
+			rootPair.GID = st.GID()
 		}
 		if err := idtools.MkdirAllAndChownNew(path.Join(a.rootPath(), p, id), os.FileMode(0755), rootPair); err != nil {
 			return err

--- a/drivers/btrfs/btrfs.go
+++ b/drivers/btrfs/btrfs.go
@@ -548,7 +548,7 @@ func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) error {
 	// if we have a remapped root (user namespaces enabled), change the created snapshot
 	// dir ownership to match
 	if rootUID != 0 || rootGID != 0 {
-		if err := os.Chown(path.Join(subvolumes, id), rootUID, rootGID); err != nil {
+		if err := os.Chown(path.Join(subvolumes, id), int(rootUID), int(rootGID)); err != nil {
 			return err
 		}
 	}

--- a/drivers/chown_unix.go
+++ b/drivers/chown_unix.go
@@ -18,7 +18,7 @@ func platformLChown(path string, info os.FileInfo, toHost, toContainer *idtools.
 		// second map.  Skip that first step if they're 0, to
 		// compensate for cases where a parent layer should
 		// have had a mapped value, but didn't.
-		uid, gid := int(st.Uid), int(st.Gid)
+		uid, gid := st.Uid, st.Gid
 		if toContainer != nil {
 			pair := idtools.IDPair{
 				UID: uid,
@@ -44,9 +44,9 @@ func platformLChown(path string, info os.FileInfo, toHost, toContainer *idtools.
 			}
 			uid, gid = mappedPair.UID, mappedPair.GID
 		}
-		if uid != int(st.Uid) || gid != int(st.Gid) {
+		if uid != st.Uid || gid != st.Gid {
 			// Make the change.
-			if err := syscall.Lchown(path, uid, gid); err != nil {
+			if err := syscall.Lchown(path, int(uid), int(gid)); err != nil {
 				return fmt.Errorf("%s: chown(%q): %v", os.Args[0], path, err)
 			}
 		}

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -247,7 +247,7 @@ func parseOptions(options []string) (*overlayOptions, error) {
 	return o, nil
 }
 
-func supportsOverlay(home string, homeMagic graphdriver.FsMagic, rootUID, rootGID int) (supportsDType bool, err error) {
+func supportsOverlay(home string, homeMagic graphdriver.FsMagic, rootUID, rootGID uint32) (supportsDType bool, err error) {
 	// We can try to modprobe overlay first
 
 	exec.Command("modprobe", "overlay").Run()
@@ -412,8 +412,8 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts) (retErr
 		if err != nil {
 			return err
 		}
-		rootUID = int(st.UID())
-		rootGID = int(st.GID())
+		rootUID = st.UID()
+		rootGID = st.GID()
 	}
 	if err := idtools.MkdirAs(dir, 0700, rootUID, rootGID); err != nil {
 		return err
@@ -709,7 +709,7 @@ func (d *Driver) Get(id, mountLabel string) (_ string, retErr error) {
 		return "", err
 	}
 
-	if err := os.Chown(path.Join(workDir, "work"), rootUID, rootGID); err != nil {
+	if err := os.Chown(path.Join(workDir, "work"), int(rootUID), int(rootGID)); err != nil {
 		return "", err
 	}
 
@@ -861,7 +861,7 @@ func (d *Driver) UpdateLayerIDMap(id string, toContainer, toHost *idtools.IDMapp
 	dir := d.dir(id)
 	diffDir := filepath.Join(dir, "diff")
 
-	rootUID, rootGID := 0, 0
+	var rootUID, rootGID uint32
 	if toHost != nil {
 		rootUID, rootGID, err = idtools.GetRootUIDGID(toHost.UIDs(), toHost.GIDs())
 		if err != nil {

--- a/drivers/vfs/driver.go
+++ b/drivers/vfs/driver.go
@@ -96,8 +96,8 @@ func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) error {
 		if err != nil {
 			return err
 		}
-		rootIDs.UID = int(st.UID())
-		rootIDs.GID = int(st.GID())
+		rootIDs.UID = st.UID()
+		rootIDs.GID = st.GID()
 	}
 	if err := idtools.MkdirAndChown(dir, 0755, rootIDs); err != nil {
 		return err

--- a/drivers/zfs/zfs.go
+++ b/drivers/zfs/zfs.go
@@ -385,7 +385,7 @@ func (d *Driver) Get(id, mountLabel string) (string, error) {
 
 	// this could be our first mount after creation of the filesystem, and the root dir may still have root
 	// permissions instead of the remapped root uid:gid (if user namespaces are enabled):
-	if err := os.Chown(mountpoint, rootUID, rootGID); err != nil {
+	if err := os.Chown(mountpoint, int(rootUID), int(rootGID)); err != nil {
 		mount.Unmount(mountpoint)
 		d.ctr.Decrement(mountpoint)
 		return "", fmt.Errorf("error modifying zfs mountpoint (%s) directory ownership: %v", mountpoint, err)

--- a/pkg/archive/archive_unix.go
+++ b/pkg/archive/archive_unix.go
@@ -74,7 +74,7 @@ func getFileUIDGID(stat interface{}) (idtools.IDPair, error) {
 	if !ok {
 		return idtools.IDPair{}, errors.New("cannot convert stat value to syscall.Stat_t")
 	}
-	return idtools.IDPair{UID: int(s.Uid), GID: int(s.Gid)}, nil
+	return idtools.IDPair{UID: uint32(s.Uid), GID: uint32(s.Gid)}, nil
 }
 
 func major(device uint64) uint64 {

--- a/pkg/archive/changes_unix.go
+++ b/pkg/archive/changes_unix.go
@@ -15,10 +15,10 @@ func statDifferent(oldStat *system.StatT, oldInfo *FileInfo, newStat *system.Sta
 	// Don't look at size for dirs, its not a good measure of change
 	oldUid, oldGid := oldStat.UID(), oldStat.GID()
 	uid, gid := newStat.UID(), newStat.GID()
-	if cuid, cgid, err := newInfo.idMappings.ToContainer(idtools.IDPair{UID: int(uid), GID: int(gid)}); err == nil {
+	if cuid, cgid, err := newInfo.idMappings.ToContainer(idtools.IDPair{UID: uint32(uid), GID: uint32(gid)}); err == nil {
 		uid = uint32(cuid)
 		gid = uint32(cgid)
-		if oldcuid, oldcgid, err := oldInfo.idMappings.ToContainer(idtools.IDPair{UID: int(oldUid), GID: int(oldGid)}); err == nil {
+		if oldcuid, oldcgid, err := oldInfo.idMappings.ToContainer(idtools.IDPair{UID: uint32(oldUid), GID: uint32(oldGid)}); err == nil {
 			oldUid = uint32(oldcuid)
 			oldGid = uint32(oldcgid)
 		}

--- a/pkg/idtools/idtools_unix.go
+++ b/pkg/idtools/idtools_unix.go
@@ -20,7 +20,7 @@ var (
 	getentCmd string
 )
 
-func mkdirAs(path string, mode os.FileMode, ownerUID, ownerGID int, mkAll, chownExisting bool) error {
+func mkdirAs(path string, mode os.FileMode, ownerUID, ownerGID uint32, mkAll, chownExisting bool) error {
 	// make an array containing the original path asked for, plus (for mkAll == true)
 	// all path components leading up to the complete path that don't exist before we MkdirAll
 	// so that we can chown all of them properly at the end.  If chownExisting is false, we won't
@@ -30,7 +30,7 @@ func mkdirAs(path string, mode os.FileMode, ownerUID, ownerGID int, mkAll, chown
 		paths = []string{path}
 	} else if err == nil && chownExisting {
 		// short-circuit--we were called with an existing directory and chown was requested
-		return os.Chown(path, ownerUID, ownerGID)
+		return os.Chown(path, int(ownerUID), int(ownerGID))
 	} else if err == nil {
 		// nothing to do; directory path fully exists already and chown was NOT requested
 		return nil
@@ -60,7 +60,7 @@ func mkdirAs(path string, mode os.FileMode, ownerUID, ownerGID int, mkAll, chown
 	// even if it existed, we will chown the requested path + any subpaths that
 	// didn't exist when we called MkdirAll
 	for _, pathComponent := range paths {
-		if err := os.Chown(pathComponent, ownerUID, ownerGID); err != nil {
+		if err := os.Chown(pathComponent, int(ownerUID), int(ownerGID)); err != nil {
 			return err
 		}
 	}

--- a/pkg/idtools/idtools_windows.go
+++ b/pkg/idtools/idtools_windows.go
@@ -10,7 +10,7 @@ import (
 
 // Platforms such as Windows do not support the UID/GID concept. So make this
 // just a wrapper around system.MkdirAll.
-func mkdirAs(path string, mode os.FileMode, ownerUID, ownerGID int, mkAll, chownExisting bool) error {
+func mkdirAs(path string, mode os.FileMode, ownerUID, ownerGID uint32, mkAll, chownExisting bool) error {
 	if err := system.MkdirAll(path, mode, ""); err != nil && !os.IsExist(err) {
 		return err
 	}

--- a/store.go
+++ b/store.go
@@ -311,7 +311,7 @@ type Store interface {
 	// LayerParentOwners returns the UIDs and GIDs of owners of parents of
 	// the layer's mountpoint for which the layer's UID and GID maps (if
 	// any are defined) don't contain corresponding IDs.
-	LayerParentOwners(id string) ([]int, []int, error)
+	LayerParentOwners(id string) ([]uint32, []uint32, error)
 
 	// Layers returns a list of the currently known layers.
 	Layers() ([]Layer, error)
@@ -433,7 +433,7 @@ type Store interface {
 	// ContainerParentOwners returns the UIDs and GIDs of owners of parents
 	// of the container's layer's mountpoint for which the layer's UID and
 	// GID maps (if any are defined) don't contain corresponding IDs.
-	ContainerParentOwners(id string) ([]int, []int, error)
+	ContainerParentOwners(id string) ([]uint32, []uint32, error)
 
 	// Lookup returns the ID of a layer, image, or container with the specified
 	// name or ID.
@@ -2414,7 +2414,7 @@ func (s *store) LayerSize(id string) (int64, error) {
 	return -1, ErrLayerUnknown
 }
 
-func (s *store) LayerParentOwners(id string) ([]int, []int, error) {
+func (s *store) LayerParentOwners(id string) ([]uint32, []uint32, error) {
 	rlstore, err := s.LayerStore()
 	if err != nil {
 		return nil, nil, err
@@ -2430,7 +2430,7 @@ func (s *store) LayerParentOwners(id string) ([]int, []int, error) {
 	return nil, nil, ErrLayerUnknown
 }
 
-func (s *store) ContainerParentOwners(id string) ([]int, []int, error) {
+func (s *store) ContainerParentOwners(id string) ([]uint32, []uint32, error) {
 	rlstore, err := s.LayerStore()
 	if err != nil {
 		return nil, nil, err
@@ -3134,9 +3134,9 @@ func init() {
 					return nil
 				}
 				mapping := idtools.IDMap{
-					ContainerID: int(cid),
-					HostID:      int(hid),
-					Size:        int(size),
+					ContainerID: cid,
+					HostID:      hid,
+					Size:        size,
 				}
 				idmap = append(idmap, mapping)
 			}


### PR DESCRIPTION
Since the kernel does not use sizes larger then uint32 we should setup
the structure to reflect this fact.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>