### PR TITLE
log errors from ApplyUncompressedLayer

### DIFF
--- a/drivers/fsdiff.go
+++ b/drivers/fsdiff.go
@@ -163,6 +163,7 @@ func (gdw *NaiveDiffDriver) ApplyDiff(id string, applyMappings *idtools.IDMappin
 	start := time.Now().UTC()
 	logrus.Debug("Start untar layer")
 	if size, err = ApplyUncompressedLayer(layerFs, diff, options); err != nil {
+		logrus.Errorf("Error while applying layer: %s", err)
 		return
 	}
 	logrus.Debugf("Untar time: %vs", time.Now().UTC().Sub(start).Seconds())


### PR DESCRIPTION
without
```
Writing manifest to image destination
Storing signatures
DEBU[0004] Start untar layer
Failed
ERRO[0004] error pulling image "docker.io/library/busybox": unable to pull docker.io/library/busybox: unable to find image in the registries defined in "/etc/containers/registries.conf"
```

with
```
Writing manifest to image destination
Storing signatures
DEBU[0005] Start untar layer
ERRO[0005] Error while applying layer: ApplyLayer exit status 1 stdout:  stderr: lchown /home: invalid argument
Failed
ERRO[0005] error pulling image "docker.io/library/busybox": unable to pull docker.io/library/busybox: unable to find image in the registries defined in "/etc/containers/registries.conf"
```

Related: https://github.com/projectatomic/libpod/issues/1087