### PR TITLE
Fix overlay to handle mountopt properly

### DIFF
--- a/pkg/mount/flags.go
+++ b/pkg/mount/flags.go
@@ -111,9 +111,9 @@ func MergeTmpfsOptions(options []string) ([]string, error) {
 	return newOptions, nil
 }
 
-// Parse fstab type mount options into mount() flags
+// ParseOptions parses fstab type mount options into mount() flags
 // and device specific data
-func parseOptions(options string) (int, string) {
+func ParseOptions(options string) (int, string) {
 	var (
 		flag int
 		data []string
@@ -138,7 +138,7 @@ func parseOptions(options string) (int, string) {
 
 // ParseTmpfsOptions parse fstab type mount options into flags and data
 func ParseTmpfsOptions(options string) (int, string, error) {
-	flags, data := parseOptions(options)
+	flags, data := ParseOptions(options)
 	for _, o := range strings.Split(data, ",") {
 		opt := strings.SplitN(o, "=", 2)
 		if !validFlags[opt[0]] {

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -39,7 +39,7 @@ func Mounted(mountpoint string) (bool, error) {
 // specified like the mount or fstab unix commands: "opt1=val1,opt2=val2". See
 // flags.go for supported option flags.
 func Mount(device, target, mType, options string) error {
-	flag, _ := parseOptions(options)
+	flag, _ := ParseOptions(options)
 	if flag&REMOUNT != REMOUNT {
 		if mounted, err := Mounted(target); err != nil || mounted {
 			return err
@@ -53,7 +53,7 @@ func Mount(device, target, mType, options string) error {
 // specified like the mount or fstab unix commands: "opt1=val1,opt2=val2". See
 // flags.go for supported option flags.
 func ForceMount(device, target, mType, options string) error {
-	flag, data := parseOptions(options)
+	flag, data := ParseOptions(options)
 	return mount(device, target, mType, uintptr(flag), data)
 }
 

--- a/pkg/mount/mount_unix_test.go
+++ b/pkg/mount/mount_unix_test.go
@@ -11,7 +11,7 @@ import (
 func TestMountOptionsParsing(t *testing.T) {
 	options := "noatime,ro,size=10k"
 
-	flag, data := parseOptions(options)
+	flag, data := ParseOptions(options)
 
 	if data != "size=10k" {
 		t.Fatalf("Expected size=10 got %s", data)


### PR DESCRIPTION
We need to translate the mount options into flags or
data, so this PR makes the parse code public so we can
use it in containers/storage.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>