### PR TITLE
storage.conf: Don't specify nodev by default

### DIFF
--- a/storage.conf
+++ b/storage.conf
@@ -33,7 +33,7 @@ size = ""
 override_kernel_check = "false"
 
 # mountopt specifies comma separated list of extra mount options
-mountopt = "nodev"
+mountopt = ""
 
 # Remap-UIDs/GIDs is the mapping from UIDs/GIDs as they should appear inside of
 # a container, to UIDs/GIDs as they should appear outside of the container, and


### PR DESCRIPTION
This breaks previously valid configurations, such as using
`mock` inside a privileged container.  While it's easy for
such containers to learn to `mount -o remount,dev /`, it's a needless
compatibility break.

Rather, e.g. podman should learn to inject it only if it's known
safe to do so (e.g. the target container doesn't have CAP_MKNOD anyways).