### PR TITLE
Add lock sanity checks to Save() methods

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -192,6 +192,9 @@ func (r *containerStore) Load() error {
 }
 
 func (r *containerStore) Save() error {
+	if !r.Locked() {
+		return errors.New("container store is not locked")
+	}
 	rpath := r.containerspath()
 	if err := os.MkdirAll(filepath.Dir(rpath), 0700); err != nil {
 		return err
@@ -559,4 +562,8 @@ func (r *containerStore) IsReadWrite() bool {
 
 func (r *containerStore) TouchedSince(when time.Time) bool {
 	return r.lockfile.TouchedSince(when)
+}
+
+func (r *containerStore) Locked() bool {
+	return r.lockfile.Locked()
 }

--- a/images.go
+++ b/images.go
@@ -219,6 +219,9 @@ func (r *imageStore) Save() error {
 	if !r.IsReadWrite() {
 		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to modify the image store at %q", r.imagespath())
 	}
+	if !r.Locked() {
+		return errors.New("image store is not locked")
+	}
 	rpath := r.imagespath()
 	if err := os.MkdirAll(filepath.Dir(rpath), 0700); err != nil {
 		return err
@@ -700,4 +703,8 @@ func (r *imageStore) IsReadWrite() bool {
 
 func (r *imageStore) TouchedSince(when time.Time) bool {
 	return r.lockfile.TouchedSince(when)
+}
+
+func (r *imageStore) Locked() bool {
+	return r.lockfile.Locked()
 }

--- a/layers.go
+++ b/layers.go
@@ -371,6 +371,9 @@ func (r *layerStore) Save() error {
 	if !r.IsReadWrite() {
 		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to modify the layer store at %q", r.layerspath())
 	}
+	if !r.Locked() {
+		return errors.New("layer store is not locked")
+	}
 	rpath := r.layerspath()
 	if err := os.MkdirAll(filepath.Dir(rpath), 0700); err != nil {
 		return err
@@ -1180,4 +1183,8 @@ func (r *layerStore) IsReadWrite() bool {
 
 func (r *layerStore) TouchedSince(when time.Time) bool {
 	return r.lockfile.TouchedSince(when)
+}
+
+func (r *layerStore) Locked() bool {
+	return r.lockfile.Locked()
 }

--- a/lockfile.go
+++ b/lockfile.go
@@ -28,6 +28,9 @@ type Locker interface {
 
 	// IsReadWrite() checks if the lock file is read-write
 	IsReadWrite() bool
+
+	// Locked() checks if lock is locked
+	Locked() bool
 }
 
 var (


### PR DESCRIPTION
I have experienced "layer not known" corruption triggered by concurrent
buildah/skopeo processes, and hopefully lock sanity checks will help to
prevent this kind of problem.

Signed-off-by: Zac Medico <zmedico@gmail.com>