### PR TITLE
 Add MountOpts to stop adding fields to Get Interface 

### DIFF
--- a/drivers/aufs/aufs.go
+++ b/drivers/aufs/aufs.go
@@ -416,7 +416,7 @@ func atomicRemove(source string) error {
 
 // Get returns the rootfs path for the id.
 // This will mount the dir at its given path
-func (a *Driver) Get(id, mountLabel string, uidMaps, gidMaps []idtools.IDMap) (string, error) {
+func (a *Driver) Get(id string, options graphdriver.MountOpts) (string, error) {
 	a.locker.Lock(id)
 	defer a.locker.Unlock(id)
 	parents, err := a.getParentLayerPaths(id)
@@ -441,7 +441,7 @@ func (a *Driver) Get(id, mountLabel string, uidMaps, gidMaps []idtools.IDMap) (s
 	// If a dir does not have a parent ( no layers )do not try to mount
 	// just return the diff path to the data
 	if len(parents) > 0 {
-		if err := a.mount(id, m, mountLabel, parents); err != nil {
+		if err := a.mount(id, m, options.MountLabel, parents); err != nil {
 			return "", err
 		}
 	}

--- a/drivers/aufs/aufs_test.go
+++ b/drivers/aufs/aufs_test.go
@@ -44,7 +44,10 @@ func testInit(dir string, t testing.TB) graphdriver.Driver {
 }
 
 func driverGet(d *Driver, id string, mntLabel string) (string, error) {
-	return d.Get(id, mntLabel, nil, nil)
+	options := graphdriver.MountOpts{
+		MountLabel: mntLabel,
+	}
+	return d.Get(id, options)
 }
 
 func newDriver(t testing.TB) *Driver {
@@ -171,7 +174,7 @@ func TestGetWithoutParent(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	diffPath, err := d.Get("1", "", nil, nil)
+	diffPath, err := d.Get("1", graphdriver.MountOpts{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -224,7 +227,7 @@ func TestMountedTrueResponse(t *testing.T) {
 	err = d.Create("2", "1", nil)
 	require.NoError(t, err)
 
-	_, err = d.Get("2", "", nil, nil)
+	_, err = d.Get("2", graphdriver.MountOpts{})
 	require.NoError(t, err)
 
 	response, err := d.mounted(d.pathCache["2"])
@@ -249,7 +252,7 @@ func TestMountWithParent(t *testing.T) {
 		}
 	}()
 
-	mntPath, err := d.Get("2", "", nil, nil)
+	mntPath, err := d.Get("2", graphdriver.MountOpts{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -280,7 +283,7 @@ func TestRemoveMountedDir(t *testing.T) {
 		}
 	}()
 
-	mntPath, err := d.Get("2", "", nil, nil)
+	mntPath, err := d.Get("2", graphdriver.MountOpts{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -760,7 +763,7 @@ func BenchmarkConcurrentAccess(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				innerGroup.Add(1)
 				go func() {
-					d.Get(id, "", nil, nil)
+					d.Get(id, graphdriver.MountOpts{})
 					d.Put(id)
 					innerGroup.Done()
 				}()

--- a/drivers/btrfs/btrfs.go
+++ b/drivers/btrfs/btrfs.go
@@ -634,7 +634,7 @@ func (d *Driver) Remove(id string) error {
 }
 
 // Get the requested filesystem id.
-func (d *Driver) Get(id, mountLabel string, uidMaps, gidMaps []idtools.IDMap) (string, error) {
+func (d *Driver) Get(id string, options graphdriver.MountOpts) (string, error) {
 	dir := d.subvolumesDirID(id)
 	st, err := os.Stat(dir)
 	if err != nil {

--- a/drivers/btrfs/btrfs_test.go
+++ b/drivers/btrfs/btrfs_test.go
@@ -7,6 +7,7 @@ import (
 	"path"
 	"testing"
 
+	"github.com/containers/storage/drivers"
 	"github.com/containers/storage/drivers/graphtest"
 )
 
@@ -35,7 +36,7 @@ func TestBtrfsSubvolDelete(t *testing.T) {
 	}
 	defer graphtest.PutDriver(t)
 
-	dir, err := d.Get("test", "", nil, nil)
+	dir, err := d.Get("test", graphdriver.MountOpts{})
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/drivers/chown.go
+++ b/drivers/chown.go
@@ -114,7 +114,10 @@ func NewNaiveLayerIDMapUpdater(driver ProtoDriver) LayerIDMapUpdater {
 // same "container" IDs.
 func (n *naiveLayerIDMapUpdater) UpdateLayerIDMap(id string, toContainer, toHost *idtools.IDMappings, mountLabel string) error {
 	driver := n.ProtoDriver
-	layerFs, err := driver.Get(id, mountLabel, nil, nil)
+	options := MountOpts{
+		MountLabel: mountLabel,
+	}
+	layerFs, err := driver.Get(id, options)
 	if err != nil {
 		return err
 	}

--- a/drivers/devmapper/driver.go
+++ b/drivers/devmapper/driver.go
@@ -163,7 +163,7 @@ func (d *Driver) Remove(id string) error {
 }
 
 // Get mounts a device with given id into the root filesystem
-func (d *Driver) Get(id, mountLabel string, uidMaps, gidMaps []idtools.IDMap) (string, error) {
+func (d *Driver) Get(id string, options graphdriver.MountOpts) (string, error) {
 	d.locker.Lock(id)
 	defer d.locker.Unlock(id)
 	mp := path.Join(d.home, "mnt", id)
@@ -189,7 +189,7 @@ func (d *Driver) Get(id, mountLabel string, uidMaps, gidMaps []idtools.IDMap) (s
 	}
 
 	// Mount the device
-	if err := d.DeviceSet.MountDevice(id, mp, mountLabel); err != nil {
+	if err := d.DeviceSet.MountDevice(id, mp, options.MountLabel); err != nil {
 		d.ctr.Decrement(mp)
 		return "", err
 	}

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -42,6 +42,15 @@ type CreateOpts struct {
 	StorageOpt map[string]string
 }
 
+// MountOpts contains optional arguments for LayerStope.Mount() methods.
+type MountOpts struct {
+	// Mount label is the MAC Labels to assign to mount point (SELINUX)
+	MountLabel string
+	// UidMaps & GidMaps are the User Namespace mappings to be assigned to content in the mount point
+	UidMaps []idtools.IDMap
+	GidMaps []idtools.IDMap
+}
+
 // InitFunc initializes the storage driver.
 type InitFunc func(root string, options []string, uidMaps, gidMaps []idtools.IDMap) (Driver, error)
 
@@ -68,7 +77,7 @@ type ProtoDriver interface {
 	// to by this id. You can optionally specify a mountLabel or "".
 	// Optionally it gets the mappings used to create the layer.
 	// Returns the absolute path to the mounted layered filesystem.
-	Get(id, mountLabel string, uidMaps, gidMaps []idtools.IDMap) (dir string, err error)
+	Get(id string, options MountOpts) (dir string, err error)
 	// Put releases the system resources for the specified id,
 	// e.g, unmounting layered filesystem.
 	Put(id string) error

--- a/drivers/fsdiff.go
+++ b/drivers/fsdiff.go
@@ -51,7 +51,10 @@ func (gdw *NaiveDiffDriver) Diff(id string, idMappings *idtools.IDMappings, pare
 		parentMappings = &idtools.IDMappings{}
 	}
 
-	layerFs, err := driver.Get(id, mountLabel, nil, nil)
+	options := MountOpts{
+		MountLabel: mountLabel,
+	}
+	layerFs, err := driver.Get(id, options)
 	if err != nil {
 		return nil, err
 	}
@@ -78,7 +81,7 @@ func (gdw *NaiveDiffDriver) Diff(id string, idMappings *idtools.IDMappings, pare
 		}), nil
 	}
 
-	parentFs, err := driver.Get(parent, mountLabel, nil, nil)
+	parentFs, err := driver.Get(parent, options)
 	if err != nil {
 		return nil, err
 	}
@@ -119,7 +122,10 @@ func (gdw *NaiveDiffDriver) Changes(id string, idMappings *idtools.IDMappings, p
 		parentMappings = &idtools.IDMappings{}
 	}
 
-	layerFs, err := driver.Get(id, mountLabel, nil, nil)
+	options := MountOpts{
+		MountLabel: mountLabel,
+	}
+	layerFs, err := driver.Get(id, options)
 	if err != nil {
 		return nil, err
 	}
@@ -128,7 +134,10 @@ func (gdw *NaiveDiffDriver) Changes(id string, idMappings *idtools.IDMappings, p
 	parentFs := ""
 
 	if parent != "" {
-		parentFs, err = driver.Get(parent, mountLabel, nil, nil)
+		options := MountOpts{
+			MountLabel: mountLabel,
+		}
+		parentFs, err = driver.Get(parent, options)
 		if err != nil {
 			return nil, err
 		}
@@ -149,7 +158,10 @@ func (gdw *NaiveDiffDriver) ApplyDiff(id string, applyMappings *idtools.IDMappin
 	}
 
 	// Mount the root filesystem so we can apply the diff/layer.
-	layerFs, err := driver.Get(id, mountLabel, nil, nil)
+	mountOpts := MountOpts{
+		MountLabel: mountLabel,
+	}
+	layerFs, err := driver.Get(id, mountOpts)
 	if err != nil {
 		return
 	}
@@ -189,7 +201,10 @@ func (gdw *NaiveDiffDriver) DiffSize(id string, idMappings *idtools.IDMappings, 
 		return
 	}
 
-	layerFs, err := driver.Get(id, mountLabel, nil, nil)
+	options := MountOpts{
+		MountLabel: mountLabel,
+	}
+	layerFs, err := driver.Get(id, options)
 	if err != nil {
 		return
 	}

--- a/drivers/graphtest/graphbench_unix.go
+++ b/drivers/graphtest/graphbench_unix.go
@@ -9,6 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
+	"github.com/containers/storage/drivers"
 	"github.com/containers/storage/pkg/stringid"
 )
 
@@ -44,7 +45,7 @@ func DriverBenchGetEmpty(b *testing.B, drivername string, driveroptions ...strin
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {
-		_, err := driver.Get(base, "", nil, nil)
+		_, err := driver.Get(base, graphdriver.MountOpts{})
 		b.StopTimer()
 		if err != nil {
 			b.Fatalf("Error getting mount: %s", err)
@@ -235,7 +236,7 @@ func DriverBenchDeepLayerRead(b *testing.B, layerCount int, drivername string, d
 		b.Fatal(err)
 	}
 
-	root, err := driver.Get(topLayer, "", nil, nil)
+	root, err := driver.Get(topLayer, graphdriver.MountOpts{})
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/drivers/graphtest/graphtest_unix.go
+++ b/drivers/graphtest/graphtest_unix.go
@@ -99,7 +99,7 @@ func DriverTestCreateEmpty(t testing.TB, drivername string, driverOptions ...str
 		t.Fatal("Newly created image doesn't exist")
 	}
 
-	dir, err := driver.Get("empty", "", nil, nil)
+	dir, err := driver.Get("empty", graphdriver.MountOpts{})
 	require.NoError(t, err)
 
 	verifyFile(t, dir, 0755|os.ModeDir, 0, 0)
@@ -327,7 +327,7 @@ func DriverTestSetQuota(t *testing.T, drivername string) {
 		t.Fatal(err)
 	}
 
-	mountPath, err := driver.Get("zfsTest", "", nil, nil)
+	mountPath, err := driver.Get("zfsTest", graphdriver.MountOpts{})
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -357,7 +357,7 @@ func DriverTestEcho(t testing.TB, drivername string, driverOptions ...string) {
 			t.Fatal(err)
 		}
 
-		if root, err = driver.Get(base, "", nil, nil); err != nil {
+		if root, err = driver.Get(base, graphdriver.MountOpts{}); err != nil {
 			t.Fatal(err)
 		}
 
@@ -392,7 +392,7 @@ func DriverTestEcho(t testing.TB, drivername string, driverOptions ...string) {
 			t.Fatal(err)
 		}
 
-		if root, err = driver.Get(second, "", nil, nil); err != nil {
+		if root, err = driver.Get(second, graphdriver.MountOpts{}); err != nil {
 			t.Fatal(err)
 		}
 
@@ -418,7 +418,7 @@ func DriverTestEcho(t testing.TB, drivername string, driverOptions ...string) {
 			t.Fatal(err)
 		}
 
-		if root, err = driver.Get(third, "", nil, nil); err != nil {
+		if root, err = driver.Get(third, graphdriver.MountOpts{}); err != nil {
 			t.Fatal(err)
 		}
 

--- a/drivers/graphtest/testutil.go
+++ b/drivers/graphtest/testutil.go
@@ -30,7 +30,7 @@ func randomContent(size int, seed int64) []byte {
 }
 
 func addFiles(drv graphdriver.Driver, layer string, seed int64) error {
-	root, err := drv.Get(layer, "", nil, nil)
+	root, err := drv.Get(layer, graphdriver.MountOpts{})
 	if err != nil {
 		return err
 	}
@@ -50,7 +50,7 @@ func addFiles(drv graphdriver.Driver, layer string, seed int64) error {
 }
 
 func checkFile(drv graphdriver.Driver, layer, filename string, content []byte) error {
-	root, err := drv.Get(layer, "", nil, nil)
+	root, err := drv.Get(layer, graphdriver.MountOpts{})
 	if err != nil {
 		return err
 	}
@@ -69,7 +69,7 @@ func checkFile(drv graphdriver.Driver, layer, filename string, content []byte) e
 }
 
 func addFile(drv graphdriver.Driver, layer, filename string, content []byte) error {
-	root, err := drv.Get(layer, "", nil, nil)
+	root, err := drv.Get(layer, graphdriver.MountOpts{})
 	if err != nil {
 		return err
 	}
@@ -79,7 +79,7 @@ func addFile(drv graphdriver.Driver, layer, filename string, content []byte) err
 }
 
 func addDirectory(drv graphdriver.Driver, layer, dir string) error {
-	root, err := drv.Get(layer, "", nil, nil)
+	root, err := drv.Get(layer, graphdriver.MountOpts{})
 	if err != nil {
 		return err
 	}
@@ -89,7 +89,7 @@ func addDirectory(drv graphdriver.Driver, layer, dir string) error {
 }
 
 func removeAll(drv graphdriver.Driver, layer string, names ...string) error {
-	root, err := drv.Get(layer, "", nil, nil)
+	root, err := drv.Get(layer, graphdriver.MountOpts{})
 	if err != nil {
 		return err
 	}
@@ -104,7 +104,7 @@ func removeAll(drv graphdriver.Driver, layer string, names ...string) error {
 }
 
 func checkFileRemoved(drv graphdriver.Driver, layer, filename string) error {
-	root, err := drv.Get(layer, "", nil, nil)
+	root, err := drv.Get(layer, graphdriver.MountOpts{})
 	if err != nil {
 		return err
 	}
@@ -120,7 +120,7 @@ func checkFileRemoved(drv graphdriver.Driver, layer, filename string) error {
 }
 
 func addManyFiles(drv graphdriver.Driver, layer string, count int, seed int64) error {
-	root, err := drv.Get(layer, "", nil, nil)
+	root, err := drv.Get(layer, graphdriver.MountOpts{})
 	if err != nil {
 		return err
 	}
@@ -143,7 +143,7 @@ func addManyFiles(drv graphdriver.Driver, layer string, count int, seed int64) e
 }
 
 func changeManyFiles(drv graphdriver.Driver, layer string, count int, seed int64) ([]archive.Change, error) {
-	root, err := drv.Get(layer, "", nil, nil)
+	root, err := drv.Get(layer, graphdriver.MountOpts{})
 	if err != nil {
 		return nil, err
 	}
@@ -194,7 +194,7 @@ func changeManyFiles(drv graphdriver.Driver, layer string, count int, seed int64
 }
 
 func checkManyFiles(drv graphdriver.Driver, layer string, count int, seed int64) error {
-	root, err := drv.Get(layer, "", nil, nil)
+	root, err := drv.Get(layer, graphdriver.MountOpts{})
 	if err != nil {
 		return err
 	}
@@ -248,7 +248,7 @@ func checkChanges(expected, actual []archive.Change) error {
 }
 
 func addLayerFiles(drv graphdriver.Driver, layer, parent string, i int) error {
-	root, err := drv.Get(layer, "", nil, nil)
+	root, err := drv.Get(layer, graphdriver.MountOpts{})
 	if err != nil {
 		return err
 	}
@@ -289,7 +289,7 @@ func addManyLayers(drv graphdriver.Driver, baseLayer string, count int) (string,
 }
 
 func checkManyLayers(drv graphdriver.Driver, layer string, count int) error {
-	root, err := drv.Get(layer, "", nil, nil)
+	root, err := drv.Get(layer, graphdriver.MountOpts{})
 	if err != nil {
 		return err
 	}

--- a/drivers/graphtest/testutil_unix.go
+++ b/drivers/graphtest/testutil_unix.go
@@ -40,7 +40,7 @@ func createBase(t testing.TB, driver graphdriver.Driver, name string) {
 	err := driver.CreateReadWrite(name, "", nil)
 	require.NoError(t, err)
 
-	dir, err := driver.Get(name, "", nil, nil)
+	dir, err := driver.Get(name, graphdriver.MountOpts{})
 	require.NoError(t, err)
 	defer driver.Put(name)
 
@@ -54,7 +54,7 @@ func createBase(t testing.TB, driver graphdriver.Driver, name string) {
 }
 
 func verifyBase(t testing.TB, driver graphdriver.Driver, name string) {
-	dir, err := driver.Get(name, "", nil, nil)
+	dir, err := driver.Get(name, graphdriver.MountOpts{})
 	require.NoError(t, err)
 	defer driver.Put(name)
 

--- a/drivers/vfs/driver.go
+++ b/drivers/vfs/driver.go
@@ -137,7 +137,7 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts, ro bool
 		label.SetFileLabel(dir, mountLabel)
 	}
 	if parent != "" {
-		parentDir, err := d.Get(parent, "", nil, nil)
+		parentDir, err := d.Get(parent, graphdriver.MountOpts{})
 		if err != nil {
 			return fmt.Errorf("%s: %s", parent, err)
 		}
@@ -179,7 +179,7 @@ func (d *Driver) Remove(id string) error {
 }
 
 // Get returns the directory for the given id.
-func (d *Driver) Get(id, mountLabel string, uidMaps, gidMaps []idtools.IDMap) (string, error) {
+func (d *Driver) Get(id string, options graphdriver.MountOpts) (_ string, retErr error) {
 	dir := d.dir(id)
 	if st, err := os.Stat(dir); err != nil {
 		return "", err

--- a/drivers/windows/windows.go
+++ b/drivers/windows/windows.go
@@ -362,7 +362,7 @@ func (d *Driver) Remove(id string) error {
 }
 
 // Get returns the rootfs path for the id. This will mount the dir at its given path.
-func (d *Driver) Get(id, mountLabel string, uidMaps, gidMaps []idtools.IDMap) (string, error) {
+func (d *Driver) Get(id string, options graphdriver.MountOpts) (string, error) {
 	panicIfUsedByLcow()
 	logrus.Debugf("WindowsGraphDriver Get() id %s mountLabel %s", id, mountLabel)
 	var dir string
@@ -620,7 +620,7 @@ func (d *Driver) DiffSize(id string, idMappings *idtools.IDMappings, parent stri
 		return
 	}
 
-	layerFs, err := d.Get(id, "", nil, nil)
+	layerFs, err := d.Get(id, graphdriver.MountOpts{})
 	if err != nil {
 		return
 	}

--- a/store.go
+++ b/store.go
@@ -2273,7 +2273,12 @@ func (s *store) Mount(id, mountLabel string) (string, error) {
 		rlstore.Load()
 	}
 	if rlstore.Exists(id) {
-		return rlstore.Mount(id, mountLabel, uidMap, gidMap)
+		options := drivers.MountOpts{
+			MountLabel: mountLabel,
+			UidMaps:    uidMap,
+			GidMaps:    gidMap,
+		}
+		return rlstore.Mount(id, options)
 	}
 	return "", ErrLayerUnknown
 }


### PR DESCRIPTION
This patch adds a MountOpts field to the drivers so we can simplify
the interface to Get and allow additional options to be passed in the future.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>