### PR TITLE
Implement Locker.Locked() for windows

### DIFF
--- a/lockfile_windows.go
+++ b/lockfile_windows.go
@@ -9,18 +9,29 @@ import (
 )
 
 func getLockFile(path string, ro bool) (Locker, error) {
-	return &lockfile{}, nil
+	return &lockfile{locked: false}, nil
 }
 
 type lockfile struct {
-	mu   sync.Mutex
-	file string
+	mu     sync.Mutex
+	file   string
+	locked bool
 }
 
 func (l *lockfile) Lock() {
+	l.mu.Lock()
+	l.locked = true
 }
+
 func (l *lockfile) Unlock() {
+	l.locked = false
+	l.mu.Unlock()
 }
+
+func (l *lockfile) Locked() bool {
+	return l.locked
+}
+
 func (l *lockfile) Modified() (bool, error) {
 	return false, nil
 }


### PR DESCRIPTION
The Locked() method must be implemented so that Save() will work on
windows.

Fixes: c7ba5749d44a ("Add lock sanity checks to Save() methods")
See: https://github.com/containers/storage/pull/210#issuecomment-416671810
Reported-by: Miloslav Trmač <mitr@redhat.com>
Signed-off-by: Zac Medico <zmedico@gmail.com>