### PR TITLE
Setting storage options could break overlay commit.

### DIFF
--- a/drivers/overlay/check.go
+++ b/drivers/overlay/check.go
@@ -20,7 +20,7 @@ import (
 // which copies up the opaque flag when copying up an opaque
 // directory or the kernel enable CONFIG_OVERLAY_FS_REDIRECT_DIR.
 // When these exist naive diff should be used.
-func doesSupportNativeDiff(d string) error {
+func doesSupportNativeDiff(d, mountOpts string) error {
 	td, err := ioutil.TempDir(d, "opaque-bug-check")
 	if err != nil {
 		return err
@@ -57,6 +57,9 @@ func doesSupportNativeDiff(d string) error {
 	}
 
 	opts := fmt.Sprintf("lowerdir=%s:%s,upperdir=%s,workdir=%s", path.Join(td, "l2"), path.Join(td, "l1"), path.Join(td, "l3"), path.Join(td, "work"))
+	if mountOpts != "" {
+		opts = fmt.Sprintf("%s,%s", opts, mountOpts)
+	}
 	if err := unix.Mount("overlay", filepath.Join(td, "merged"), "overlay", 0, opts); err != nil {
 		return errors.Wrap(err, "failed to mount overlay")
 	}

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -340,7 +340,7 @@ func supportsOverlay(home string, homeMagic graphdriver.FsMagic, rootUID, rootGI
 
 func (d *Driver) useNaiveDiff() bool {
 	useNaiveDiffLock.Do(func() {
-		if err := doesSupportNativeDiff(d.home); err != nil {
+		if err := doesSupportNativeDiff(d.home, d.options.mountOptions); err != nil {
 			logrus.Warnf("Not using native diff for overlay, this may cause degraded performance for building images: %v", err)
 			useNaiveDiffOnly = true
 		}

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -206,7 +206,7 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 		return nil, fmt.Errorf("Storage option overlay.size only supported for backingFS XFS. Found %v", backingFs)
 	}
 
-	logrus.Debugf("backingFs=%s, projectQuotaSupported=%v, useNativeDiff=%v", backingFs, projectQuotaSupported, !useNaiveDiff(home))
+	logrus.Debugf("backingFs=%s, projectQuotaSupported=%v, useNativeDiff=%v", backingFs, projectQuotaSupported, !d.useNaiveDiff())
 
 	return d, nil
 }
@@ -338,9 +338,9 @@ func supportsOverlay(home string, homeMagic graphdriver.FsMagic, rootUID, rootGI
 	return supportsDType, errors.Wrap(graphdriver.ErrNotSupported, "'overlay' not found as a supported filesystem on this host. Please ensure kernel is new enough and has overlay support loaded.")
 }
 
-func useNaiveDiff(home string) bool {
+func (d *Driver) useNaiveDiff() bool {
 	useNaiveDiffLock.Do(func() {
-		if err := doesSupportNativeDiff(home); err != nil {
+		if err := doesSupportNativeDiff(d.home); err != nil {
 			logrus.Warnf("Not using native diff for overlay, this may cause degraded performance for building images: %v", err)
 			useNaiveDiffOnly = true
 		}
@@ -358,7 +358,7 @@ func (d *Driver) Status() [][2]string {
 	return [][2]string{
 		{"Backing Filesystem", backingFs},
 		{"Supports d_type", strconv.FormatBool(d.supportsDType)},
-		{"Native Overlay Diff", strconv.FormatBool(!useNaiveDiff(d.home))},
+		{"Native Overlay Diff", strconv.FormatBool(!d.useNaiveDiff())},
 	}
 }
 
@@ -883,7 +883,7 @@ func (d *Driver) getDiffPath(id string) string {
 // and its parent and returns the size in bytes of the changes
 // relative to its base filesystem directory.
 func (d *Driver) DiffSize(id string, idMappings *idtools.IDMappings, parent string, parentMappings *idtools.IDMappings, mountLabel string) (size int64, err error) {
-	if useNaiveDiff(d.home) || !d.isParent(id, parent) {
+	if d.useNaiveDiff() || !d.isParent(id, parent) {
 		return d.naiveDiff.DiffSize(id, idMappings, parent, parentMappings, mountLabel)
 	}
 	return directory.Size(d.getDiffPath(id))
@@ -892,7 +892,7 @@ func (d *Driver) DiffSize(id string, idMappings *idtools.IDMappings, parent stri
 // Diff produces an archive of the changes between the specified
 // layer and its parent layer which may be "".
 func (d *Driver) Diff(id string, idMappings *idtools.IDMappings, parent string, parentMappings *idtools.IDMappings, mountLabel string) (io.ReadCloser, error) {
-	if useNaiveDiff(d.home) || !d.isParent(id, parent) {
+	if d.useNaiveDiff() || !d.isParent(id, parent) {
 		return d.naiveDiff.Diff(id, idMappings, parent, parentMappings, mountLabel)
 	}
 
@@ -919,7 +919,7 @@ func (d *Driver) Diff(id string, idMappings *idtools.IDMappings, parent string, 
 // Changes produces a list of changes between the specified layer
 // and its parent layer. If parent is "", then all changes will be ADD changes.
 func (d *Driver) Changes(id string, idMappings *idtools.IDMappings, parent string, parentMappings *idtools.IDMappings, mountLabel string) ([]archive.Change, error) {
-	if useNaiveDiff(d.home) || !d.isParent(id, parent) {
+	if d.useNaiveDiff() || !d.isParent(id, parent) {
 		return d.naiveDiff.Changes(id, idMappings, parent, parentMappings, mountLabel)
 	}
 	// Overlay doesn't have snapshots, so we need to get changes from all parent

--- a/drivers/overlay/overlay_test.go
+++ b/drivers/overlay/overlay_test.go
@@ -43,7 +43,7 @@ func skipIfNaive(t *testing.T) {
 	}
 	defer os.RemoveAll(td)
 
-	if err := doesSupportNativeDiff(td); err != nil {
+	if err := doesSupportNativeDiff(td, ""); err != nil {
 		t.Skipf("Cannot run test with naive diff")
 	}
 }

--- a/drivers/overlay/overlay_test.go
+++ b/drivers/overlay/overlay_test.go
@@ -43,7 +43,7 @@ func skipIfNaive(t *testing.T) {
 	}
 	defer os.RemoveAll(td)
 
-	if useNaiveDiff(td) {
+	if err := doesSupportNativeDiff(td); err != nil {
 		t.Skipf("Cannot run test with naive diff")
 	}
 }


### PR DESCRIPTION

If in storage.conf I set the mount options to:
mountopt = "nodev,metacopy=on,redirect_dir=on"
This will turn on redirect_dir but the useNaiveDiff does not currently check
this option.  This will cause container images on commit to not be saved
correctly.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>