### PR TITLE
make: clean up .PHONY targets list

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-.PHONY: all binary build build-binary build-gccgo cross default docs gccgo test test-integration-cli test-unit validate help win tgz
+.PHONY: all binary clean cross default docs gccgo help install.tools local-binary local-cross local-gccgo local-test-integration local-test-unit local-validate test test-integration test-unit validate
 
 PACKAGE := github.com/containers/storage
 GIT_BRANCH := $(shell git rev-parse --abbrev-ref HEAD 2>/dev/null)
@@ -81,7 +81,6 @@ local-validate: ## validate DCO and gofmt on the host
 validate: ## validate DCO, gofmt, ./pkg/ isolation, golint,\ngo vet and vendor using VMs
 	$(RUNINVM) make local-$@
 
-.PHONY: install.tools
 install.tools:
 	go get -u $(BUILDFLAGS) github.com/cpuguy83/go-md2man
 	go get -u $(BUILDFLAGS) github.com/vbatts/git-validation

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 layers, container images, and containers.  A `containers-storage` CLI wrapper
 is also included for manual and scripting use.
 
-To build the CLI wrapper, use 'make build-binary'.
+To build the CLI wrapper, use 'make binary'.
 
 Operations which use VMs expect to launch them using 'vagrant', defaulting to
 using its 'libvirt' provider.  The boxes used are also available for the


### PR DESCRIPTION
Make the list of .PHONY targets consistent with the actual Makefile
targets. Update The README with the correct make target for the
CLI wrapper.

Signed-off-by: Marco Vedovati <mvedovati@suse.com>