### PR TITLE
overlay: use AUFS whiteout format when using mount_program

### DIFF
--- a/hack/spc_ci_test.sh
+++ b/hack/spc_ci_test.sh
@@ -10,9 +10,12 @@ then
     exit 1
 fi
 
+export UPDATE_CMD="true"
+
 # Additional packages needed ontop of the base (generic) image
 case "$DISTRO" in
     *ubuntu*)
+        export UPDATE_CMD="apt-get update"
         export INSTALL_CMD="apt-get -qq install bats btrfs-tools libdevmapper-dev ostree libostree-dev"
         ;;
     *fedora*)
@@ -33,6 +36,7 @@ echo
 echo "Executing: $INSTALL_CMD"
 # Don't spam...unless it breaks
 TMPFILE=$(mktemp)
+$UPDATE_CMD &> $TMPFILE || ( cat $TMPFILE && exit 3 )
 $INSTALL_CMD &> $TMPFILE || ( cat $TMPFILE && exit 3 )
 rm -f "$TMPFILE"
 echo "done"


### PR DESCRIPTION
an unprivileged user doesn't have the permission to use mknod (except
in file systems owned by the user itself, e.g. tmpfs), so the unpack
would always fail with EPERM.  Use the AUFS whiteout format that
doesn't require CAP_MKNOD.

Closes: https://github.com/containers/buildah/issues/1160

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>