### PR TITLE
layers: return the in-use layer on ErrDuplicateID

### DIFF
--- a/layers.go
+++ b/layers.go
@@ -542,8 +542,8 @@ func (r *layerStore) Put(id string, parentLayer *Layer, names []string, mountLab
 			_, idInUse = r.byid[id]
 		}
 	}
-	if _, idInUse := r.byid[id]; idInUse {
-		return nil, -1, ErrDuplicateID
+	if duplicateLayer, idInUse := r.byid[id]; idInUse {
+		return duplicateLayer, -1, ErrDuplicateID
 	}
 	names = dedupeNames(names)
 	for _, name := range names {


### PR DESCRIPTION
We've seen a panic on Azure with CRI-O/OCP:
```
Nov 08 17:52:58 master-000002 crio[5779]: panic: runtime error: invalid memory address or nil pointer dereference
Nov 08 17:52:58 master-000002 crio[5779]: [signal SIGSEGV: segmentation violation code=0x1 addr=0x8 pc=0x55cec3a16669]
Nov 08 17:52:58 master-000002 crio[5779]: goroutine 127 [running]:
Nov 08 17:52:58 master-000002 crio[5779]: panic(0x55cec467fda0, 0x55cec52cba20)
Nov 08 17:52:58 master-000002 crio[5779]: /opt/rh/go-toolset-7/root/usr/lib/go-toolset-7-golang/src/runtime/panic.go:551 +0x3c5 fp=0xc4206e17f0 sp=0xc4206e1750 pc=0x55cec2f47685
Nov 08 17:52:58 master-000002 crio[5779]: runtime.panicmem()
Nov 08 17:52:58 master-000002 crio[5779]: /opt/rh/go-toolset-7/root/usr/lib/go-toolset-7-golang/src/runtime/panic.go:63 +0x60 fp=0xc4206e1810 sp=0xc4206e17f0 pc=0x55cec2f46520
Nov 08 17:52:58 master-000002 crio[5779]: runtime.sigpanic()
Nov 08 17:52:58 master-000002 crio[5779]: /opt/rh/go-toolset-7/root/usr/lib/go-toolset-7-golang/src/runtime/signal_unix.go:388 +0x17e fp=0xc4206e1860 sp=0xc4206e1810 pc=0x55cec2f5d7fe
Nov 08 17:52:58 master-000002 crio[5779]: github.com/kubernetes-sigs/cri-o/vendor/github.com/containers/image/storage.(*storageImageDestination).Commit(0xc420556540, 0x55cec48b7fe0, 0xc4200ac048, 0x0, 0x0)
Nov 08 17:52:58 master-000002 crio[5779]: /builddir/build/BUILD/cri-o-71cc46544a8d31229c4ef2b88b42485f4d997c03/_output/src/github.com/kubernetes-sigs/cri-o/vendor/github.com/containers/image/storage/storage_imag
```
That nil pointer dereference is caused by containers/image storage
`Commit()` as it ignores `ErrDuplicateID` but the layer object is later
reused when nil.

This commit fixes the panic above by returning the layer in-use even on error so
containers/image won't panic.

I'll vendor this in c/image once merged and then in CRI-O.

Signed-off-by: Antonio Murdaca <runcom@linux.com>