### PR TITLE
archive: propagate InUserNS option to storage-untar

### DIFF
--- a/drivers/fsdiff.go
+++ b/drivers/fsdiff.go
@@ -8,6 +8,7 @@ import (
 	"github.com/containers/storage/pkg/chrootarchive"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/ioutils"
+	rsystem "github.com/opencontainers/runc/libcontainer/system"
 	"github.com/sirupsen/logrus"
 )
 
@@ -167,7 +168,9 @@ func (gdw *NaiveDiffDriver) ApplyDiff(id string, applyMappings *idtools.IDMappin
 	}
 	defer driver.Put(id)
 
-	options := &archive.TarOptions{}
+	options := &archive.TarOptions{
+		InUserNS: rsystem.RunningInUserNS(),
+	}
 	if applyMappings != nil {
 		options.UIDMaps = applyMappings.UIDs()
 		options.GIDMaps = applyMappings.GIDs()

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -29,6 +29,7 @@ import (
 	"github.com/containers/storage/pkg/parsers"
 	"github.com/containers/storage/pkg/system"
 	units "github.com/docker/go-units"
+	rsystem "github.com/opencontainers/runc/libcontainer/system"
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
@@ -874,6 +875,7 @@ func (d *Driver) ApplyDiff(id string, idMappings *idtools.IDMappings, parent str
 		UIDMaps:        idMappings.UIDs(),
 		GIDMaps:        idMappings.GIDs(),
 		WhiteoutFormat: d.getWhiteoutFormat(),
+		InUserNS:       rsystem.RunningInUserNS(),
 	}); err != nil {
 		return 0, err
 	}

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -22,6 +22,7 @@ import (
 	"github.com/containers/storage/pkg/pools"
 	"github.com/containers/storage/pkg/promise"
 	"github.com/containers/storage/pkg/system"
+	rsystem "github.com/opencontainers/runc/libcontainer/system"
 	"github.com/sirupsen/logrus"
 )
 
@@ -1054,6 +1055,7 @@ func (archiver *Archiver) TarUntar(src, dst string) error {
 		GIDMaps:     tarMappings.GIDs(),
 		Compression: Uncompressed,
 		CopyPass:    true,
+		InUserNS:    rsystem.RunningInUserNS(),
 	}
 	archive, err := TarWithOptions(src, options)
 	if err != nil {
@@ -1068,6 +1070,7 @@ func (archiver *Archiver) TarUntar(src, dst string) error {
 		UIDMaps:   untarMappings.UIDs(),
 		GIDMaps:   untarMappings.GIDs(),
 		ChownOpts: archiver.ChownOpts,
+		InUserNS:  rsystem.RunningInUserNS(),
 	}
 	return archiver.Untar(archive, dst, options)
 }
@@ -1087,6 +1090,7 @@ func (archiver *Archiver) UntarPath(src, dst string) error {
 		UIDMaps:   untarMappings.UIDs(),
 		GIDMaps:   untarMappings.GIDs(),
 		ChownOpts: archiver.ChownOpts,
+		InUserNS:  rsystem.RunningInUserNS(),
 	}
 	return archiver.Untar(archive, dst, options)
 }
@@ -1186,6 +1190,7 @@ func (archiver *Archiver) CopyFileWithTar(src, dst string) (err error) {
 		UIDMaps:   archiver.UntarIDMappings.UIDs(),
 		GIDMaps:   archiver.UntarIDMappings.GIDs(),
 		ChownOpts: archiver.ChownOpts,
+		InUserNS:  rsystem.RunningInUserNS(),
 	}
 	err = archiver.Untar(r, filepath.Dir(dst), options)
 	if err != nil {

--- a/pkg/chrootarchive/archive.go
+++ b/pkg/chrootarchive/archive.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/containers/storage/pkg/archive"
 	"github.com/containers/storage/pkg/idtools"
+	rsystem "github.com/opencontainers/runc/libcontainer/system"
 )
 
 // NewArchiver returns a new Archiver which uses chrootarchive.Untar
@@ -52,6 +53,7 @@ func untarHandler(tarArchive io.Reader, dest string, options *archive.TarOptions
 	}
 	if options == nil {
 		options = &archive.TarOptions{}
+		options.InUserNS = rsystem.RunningInUserNS()
 	}
 	if options.ExcludePatterns == nil {
 		options.ExcludePatterns = []string{}


### PR DESCRIPTION
we cannot check if we are running in an user namespace after the
chroot, as /proc is not accessible.  So let's pass this option down
before re-execing and doing a chroot.

Closes: https://github.com/containers/libpod/issues/1775

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>