### PR TITLE
[docs] Add man-page of subcommand mounted

### DIFF
--- a/docs/containers-storage-mount.md
+++ b/docs/containers-storage-mount.md
@@ -19,4 +19,5 @@ Specify an SELinux context for the mounted layer.
 **containers-storage mount my-container**
 
 ## SEE ALSO
+containers-storage-mounted(1)
 containers-storage-unmount(1)

--- a/docs/containers-storage-mounted.md
+++ b/docs/containers-storage-mounted.md
@@ -1,0 +1,17 @@
+## containers-storage-mounted 1 "November 2018"
+
+## NAME
+containers-storage mounted - Check if a file system is mounted
+
+## SYNOPSIS
+**containers-storage** **mounted** *LayerOrContainerNameOrID*
+
+## DESCRIPTION
+Check if a filesystem is mounted
+
+## EXAMPLE
+**containers-storage mounted my-container**
+
+## SEE ALSO
+containers-storage-mount(1)
+containers-storage-unmount(1)

--- a/docs/containers-storage-unmount.md
+++ b/docs/containers-storage-unmount.md
@@ -11,7 +11,9 @@ Unmounts a layer or a container's layer from the host's filesystem.
 
 ## EXAMPLE
 **containers-storage unmount my-container**
+
 **containers-storage unmount /var/lib/containers/storage/mounts/my-container**
 
 ## SEE ALSO
 containers-storage-mount(1)
+containers-storage-mounted(1)

--- a/docs/containers-storage.md
+++ b/docs/containers-storage.md
@@ -53,37 +53,71 @@ configuration will be stored as data items.
 ## SUB-COMMANDS
 The *containers-storage* command's features are broken down into several subcommands:
  **containers-storage add-names(1)**           Add layer, image, or container name or names
+
  **containers-storage applydiff(1)**           Apply a diff to a layer
+
  **containers-storage changes(1)**             Compare two layers
+
  **containers-storage container(1)**           Examine a container
+
  **containers-storage containers(1)**          List containers
+
  **containers-storage create-container(1)**    Create a new container from an image
+
  **containers-storage create-image(1)**        Create a new image using layers
+
  **containers-storage create-layer(1)**        Create a new layer
+
  **containers-storage delete(1)**              Delete a layer or image or container, with no safety checks
+
  **containers-storage delete-container(1)**    Delete a container, with safety checks
+
  **containers-storage delete-image(1)**        Delete an image, with safety checks
+
  **containers-storage delete-layer(1)**        Delete a layer, with safety checks
+
  **containers-storage diff(1)**                Compare two layers
+
  **containers-storage diffsize(1)**            Compare two layers
+
  **containers-storage exists(1)**              Check if a layer or image or container exists
+
  **containers-storage get-container-data(1)**  Get data that is attached to a container
+
  **containers-storage get-image-data(1)**      Get data that is attached to an image
+
  **containers-storage image(1)**               Examine an image
+
  **containers-storage images(1)**              List images
+
  **containers-storage layers(1)**              List layers
+
  **containers-storage list-container-data(1)** List data items that are attached to a container
+
  **containers-storage list-image-data(1)**     List data items that are attached to an image
+
  **containers-storage metadata(1)**            Retrieve layer, image, or container metadata
+
  **containers-storage mount(1)**               Mount a layer or container
+
+ **containers-storage mounted(1)**             Check if a file system is mounted
+
  **containers-storage set-container-data(1)**  Set data that is attached to a container
+
  **containers-storage set-image-data(1)**      Set data that is attached to an image
+
  **containers-storage set-metadata(1)**        Set layer, image, or container metadata
+
  **containers-storage set-names(1)**           Set layer, image, or container name or names
+
  **containers-storage shutdown(1)**            Shut down graph driver
+
  **containers-storage status(1)**              Check on graph driver status
+
  **containers-storage unmount(1)**             Unmount a layer or container
+
  **containers-storage version(1)**             Return containers-storage version information
+
  **containers-storage wipe(1)**                Wipe all layers, images, and containers
 
 ## OPTIONS


### PR DESCRIPTION
Add a man-page of subcommand mounted that is added by commit 1075a73cac.
Add new lines to prevent the section SUB-COMMANDS of containers-storage.md from crushing when previews as markdown.

Signed-off-by: ERAMOTO Masaya <eramoto.masaya@jp.fujitsu.com>