### PR TITLE
Refactor ParseIDMap, allow parsing multiple maps at once

### DIFF
--- a/cmd/containers-storage/create.go
+++ b/cmd/containers-storage/create.go
@@ -56,11 +56,11 @@ func paramIDMapping() (*storage.IDMappingOptions, error) {
 		options.UIDMap = mappings.UIDs()
 		options.GIDMap = mappings.GIDs()
 	}
-	parsedUIDMap, err := idtools.ParseIDMap(paramUIDMap, "uid")
+	parsedUIDMap, err := idtools.ParseIDMap([]string{paramUIDMap}, "uid")
 	if err != nil {
 		return nil, err
 	}
-	parsedGIDMap, err := idtools.ParseIDMap(paramGIDMap, "gid")
+	parsedGIDMap, err := idtools.ParseIDMap([]string{paramGIDMap}, "gid")
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/idtools/parser.go
+++ b/pkg/idtools/parser.go
@@ -30,8 +30,8 @@ func parseTriple(spec []string) (container, host, size uint32, err error) {
 }
 
 // ParseIDMap parses idmap triples from string.
-func ParseIDMap(idMapSpec, mapSetting string) (idmap []IDMap, err error) {
-	if len(idMapSpec) > 0 {
+func ParseIDMap(mapSpec []string, mapSetting string) (idmap []IDMap, err error) {
+	for _, idMapSpec := range mapSpec {
 		idSpec := strings.Fields(strings.Map(nonDigitsToWhitespace, idMapSpec))
 		if len(idSpec)%3 != 0 {
 			return nil, fmt.Errorf("error initializing ID mappings: %s setting is malformed", mapSetting)

--- a/store.go
+++ b/store.go
@@ -3203,13 +3203,13 @@ func ReloadConfigurationFile(configFile string, storeOptions *StoreOptions) {
 		storeOptions.GIDMap = mappings.GIDs()
 	}
 
-	uidmap, err := idtools.ParseIDMap(config.Storage.Options.RemapUIDs, "remap-uids")
+	uidmap, err := idtools.ParseIDMap([]string{config.Storage.Options.RemapUIDs}, "remap-uids")
 	if err != nil {
 		fmt.Print(err)
 	} else {
 		storeOptions.UIDMap = append(storeOptions.UIDMap, uidmap...)
 	}
-	gidmap, err := idtools.ParseIDMap(config.Storage.Options.RemapGIDs, "remap-gids")
+	gidmap, err := idtools.ParseIDMap([]string{config.Storage.Options.RemapGIDs}, "remap-gids")
 	if err != nil {
 		fmt.Print(err)
 	} else {


### PR DESCRIPTION
I found that other projects, tend to parse multiple maps at once. So, we may want to allow the base library to do so in order to decrease complexity in the upper layers. (For comparison please see: https://github.com/kubernetes-sigs/cri-o/blob/4cd5a7c60349be0678d9f1b0657683324c1a2726/server/server.go#L248 https://github.com/containers/libpod/blob/e8e16fcc789df6a705fbbf5c5597f16a4255d690/pkg/util/utils.go#L172 https://github.com/containers/buildah/blob/c116133dd5d62e3791ff792468c9a11b1bdffafd/util/util.go#L421 )

This is follow-up on previous refactoring in 7b209d36fd98ff0a969, I didn't got it right on first try, sry.

Signed-off-by: Šimon Lukašík <isimluk@fedoraproject.org>