### PR TITLE
Add list of supported graph drivers to manpage

### DIFF
--- a/docs/containers-storage.conf.5.md
+++ b/docs/containers-storage.conf.5.md
@@ -39,8 +39,10 @@ The `storage` table supports the following options:
 **driver**=""
   container storage driver (default: "overlay")
   Default Copy On Write (COW) container storage driver
+  Valid drivers are "overlay", "vfs", "devmapper", "aufs", "btrfs", and "zfs"
+  Some drivers (for example, "zfs", "btrfs", and "aufs") may not work if your kernel lacks support for the filesystem
 
-### STORAGE OPTIONS TABLE 
+### STORAGE OPTIONS TABLE
 
 The `storage.options` table supports the following options:
 


### PR DESCRIPTION
People looking to modify storage.conf might be confused as to what the valid graph drivers and their names are. List all supported drivers in the manpage to assist them.

Shouldn't be necessary elsewhere, most of the other fields are just paths.