### PR TITLE
graphtest: insulate against filesystems with low timestamp granularity

### DIFF
--- a/drivers/devmapper/deviceset.go
+++ b/drivers/devmapper/deviceset.go
@@ -2401,7 +2401,7 @@ func (devices *DeviceSet) MountDevice(hash, path string, moptions graphdriver.Mo
 		addNouuid := strings.Contains("nouuid", mountOptions)
 		mountOptions = strings.Join(moptions.Options, ",")
 		if addNouuid {
-			mountOptions = fmt.Sprintf("nouuid,", mountOptions)
+			mountOptions = fmt.Sprintf("nouuid,%s", mountOptions)
 		}
 	}
 

--- a/drivers/graphtest/testutil.go
+++ b/drivers/graphtest/testutil.go
@@ -166,10 +166,19 @@ func changeManyFiles(drv graphdriver.Driver, layer string, count int, seed int64
 			switch j % 3 {
 			// Update file
 			case 0:
+				var originalFileInfo, updatedFileInfo os.FileInfo
 				change.Path = path.Join(archiveRoot, fmt.Sprintf("file-%d", i+j))
 				change.Kind = archive.ChangeModify
-				if err := ioutil.WriteFile(path.Join(root, change.Path), randomContent(64, seed+int64(i+j)), 0755); err != nil {
+				if originalFileInfo, err = os.Stat(path.Join(root, change.Path)); err != nil {
 					return nil, err
+				}
+				for updatedFileInfo == nil || updatedFileInfo.ModTime().Equal(originalFileInfo.ModTime()) {
+					if err := ioutil.WriteFile(path.Join(root, change.Path), randomContent(64, seed+int64(i+j)), 0755); err != nil {
+						return nil, err
+					}
+					if updatedFileInfo, err = os.Stat(path.Join(root, change.Path)); err != nil {
+						return nil, err
+					}
 				}
 			// Add file
 			case 1:


### PR DESCRIPTION
When we test for change detection on top of filesystems with low timestamp granularity, we can end up updating a file without forcing a change to its modification timestamp.  Check for that when we attempt to
modify the files, and just keep rewriting it until the timestamp changes.