### PR TITLE
Remove mounts private from zfs, it is causing issues on reboot with zfs

### DIFF
--- a/drivers/zfs/zfs.go
+++ b/drivers/zfs/zfs.go
@@ -111,10 +111,6 @@ func Init(base string, opt []string, uidMaps, gidMaps []idtools.IDMap) (graphdri
 		return nil, fmt.Errorf("Failed to create '%s': %v", base, err)
 	}
 
-	if err := mount.MakePrivate(base); err != nil {
-		return nil, err
-	}
-
 	d := &Driver{
 		dataset:          rootDataset,
 		options:          options,


### PR DESCRIPTION
This was originally put in to prevent potential leaks of mount points to
different mount namespaces.  Lets remove it and fix the issue with
zfs, and see if we experience leaked mounts.  oci-umount should also
clean up any leaks, if installed.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>