### PR TITLE
Check for the OS when setting btrfs/libdm/ostree tags

### DIFF
--- a/hack/btrfs_tag.sh
+++ b/hack/btrfs_tag.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+if test $(${GO:-go} env GOOS) != "linux" ; then
+	exit 0
+fi
 cc -E - > /dev/null 2> /dev/null << EOF
 #include <btrfs/version.h>
 EOF

--- a/hack/libdm_tag.sh
+++ b/hack/libdm_tag.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+if test $(${GO:-go} env GOOS) != "linux" ; then
+	exit 0
+fi
 tmpdir="$PWD/tmp.$RANDOM"
 mkdir -p "$tmpdir"
 trap 'rm -fr "$tmpdir"' EXIT

--- a/hack/ostree_tag.sh
+++ b/hack/ostree_tag.sh
@@ -1,4 +1,7 @@
 #!/bin/bash
+if test $(${GO:-go} env GOOS) != "linux" ; then
+	exit 0
+fi
 cc -E - $(pkg-config --cflags ostree-1) > /dev/null 2> /dev/null << EOF
 #include <ostree-1/ostree.h>
 EOF


### PR DESCRIPTION
Before checking for btrfs/libdm/ostree availability, check which OS we're on, and if it isn't Linux, disable them.  This should simplify cross-compiling at least a bit.