### PR TITLE
Don't fail the mounter test because the kernel added options

### DIFF
--- a/pkg/mount/mounter_linux_test.go
+++ b/pkg/mount/mounter_linux_test.go
@@ -140,6 +140,7 @@ func validateMount(t *testing.T, mnt string, opts, optional, vfs string) {
 			wantedVFS[opt] = struct{}{}
 		}
 	}
+	volunteeredVFS := map[string]struct{}{"seclabel": {}}
 
 	mnts := make(map[int]*Info, len(info))
 	for _, mi := range info {
@@ -199,7 +200,7 @@ func validateMount(t *testing.T, mnt string, opts, optional, vfs string) {
 			if mi.VfsOpts != "" {
 				for _, opt := range strings.Split(mi.VfsOpts, ",") {
 					opt = clean(opt)
-					if !has(wantedVFS, opt) {
+					if !has(wantedVFS, opt) && !has(volunteeredVFS, opt) {
 						t.Errorf("unexpected mount option %q expected %q", opt, vfs)
 					}
 					delete(wantedVFS, opt)


### PR DESCRIPTION
On SELinux-enabled kernels, the kernel will helpfully add a "seclabel" option to mounted filesystems to indicate that labeling is supported.  Don't let that break our tests.