### PR TITLE
Move structs for storage.conf to pkg/config

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,0 +1,96 @@
+package config
+
+// ThinpoolOptionsConfig represents the "storage.options.thinpool"
+// TOML config table.
+type ThinpoolOptionsConfig struct {
+	// AutoExtendPercent determines the amount by which pool needs to be
+	// grown. This is specified in terms of % of pool size. So a value of
+	// 20 means that when threshold is hit, pool will be grown by 20% of
+	// existing pool size.
+	AutoExtendPercent string `toml:"autoextend_percent"`
+
+	// AutoExtendThreshold determines the pool extension threshold in terms
+	// of percentage of pool size. For example, if threshold is 60, that
+	// means when pool is 60% full, threshold has been hit.
+	AutoExtendThreshold string `toml:"autoextend_threshold"`
+
+	// BaseSize specifies the size to use when creating the base device,
+	// which limits the size of images and containers.
+	BaseSize string `toml:"basesize"`
+
+	// BlockSize specifies a custom blocksize to use for the thin pool.
+	BlockSize string `toml:"blocksize"`
+
+	// DirectLvmDevice specifies a custom block storage device to use for
+	// the thin pool.
+	DirectLvmDevice string `toml:"directlvm_device"`
+
+	// DirectLvmDeviceForcewipes device even if device already has a
+	// filesystem
+	DirectLvmDeviceForce string `toml:"directlvm_device_force"`
+
+	// Fs specifies the filesystem type to use for the base device.
+	Fs string `toml:"fs"`
+
+	// log_level sets the log level of devicemapper.
+	LogLevel string `toml:"log_level"`
+
+	// MinFreeSpace specifies the min free space percent in a thin pool
+	// require for new device creation to
+	MinFreeSpace string `toml:"min_free_space"`
+
+	// MkfsArg specifies extra mkfs arguments to be used when creating the
+	// basedevice.
+	MkfsArg string `toml:"mkfsarg"`
+
+	// MountOpt specifies extra mount options used when mounting the thin
+	// devices.
+	MountOpt string `toml:"mountopt"`
+
+	// UseDeferredDeletion marks device for deferred deletion
+	UseDeferredDeletion string `toml:"use_deferred_deletion"`
+
+	// UseDeferredRemoval marks device for deferred removal
+	UseDeferredRemoval string `toml:"use_deferred_removal"`
+
+	// XfsNoSpaceMaxRetriesFreeSpace specifies the maximum number of
+	// retries XFS should attempt to complete IO when ENOSPC (no space)
+	// error is returned by underlying storage device.
+	XfsNoSpaceMaxRetries string `toml:"xfs_nospace_max_retries"`
+}
+
+// OptionsConfig represents the "storage.options" TOML config table.
+type OptionsConfig struct {
+	// AdditionalImagesStores is the location of additional read/only
+	// Image stores.  Usually used to access Networked File System
+	// for shared image content
+	AdditionalImageStores []string `toml:"additionalimagestores"`
+
+	// Size
+	Size string `toml:"size"`
+
+	// RemapUIDs is a list of default UID mappings to use for layers.
+	RemapUIDs string `toml:"remap-uids"`
+	// RemapGIDs is a list of default GID mappings to use for layers.
+	RemapGIDs string `toml:"remap-gids"`
+
+	// RemapUser is the name of one or more entries in /etc/subuid which
+	// should be used to set up default UID mappings.
+	RemapUser string `toml:"remap-user"`
+	// RemapGroup is the name of one or more entries in /etc/subgid which
+	// should be used to set up default GID mappings.
+	RemapGroup string `toml:"remap-group"`
+	// Thinpool container options to be handed to thinpool drivers
+	Thinpool struct{ ThinpoolOptionsConfig } `toml:"thinpool"`
+	// OSTree repository
+	OstreeRepo string `toml:"ostree_repo"`
+
+	// Do not create a bind mount on the storage home
+	SkipMountHome string `toml:"skip_mount_home"`
+
+	// Alternative program to use for the mount of the file system
+	MountProgram string `toml:"mount_program"`
+
+	// MountOpt specifies extra mount options used when mounting
+	MountOpt string `toml:"mountopt"`
+}

--- a/store.go
+++ b/store.go
@@ -18,6 +18,7 @@ import (
 	"github.com/BurntSushi/toml"
 	drivers "github.com/containers/storage/drivers"
 	"github.com/containers/storage/pkg/archive"
+	"github.com/containers/storage/pkg/config"
 	"github.com/containers/storage/pkg/directory"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/ioutils"
@@ -3005,108 +3006,13 @@ func copyStringInterfaceMap(m map[string]interface{}) map[string]interface{} {
 // DefaultConfigFile path to the system wide storage.conf file
 const DefaultConfigFile = "/etc/containers/storage.conf"
 
-// ThinpoolOptionsConfig represents the "storage.options.thinpool"
-// TOML config table.
-type ThinpoolOptionsConfig struct {
-	// AutoExtendPercent determines the amount by which pool needs to be
-	// grown. This is specified in terms of % of pool size. So a value of
-	// 20 means that when threshold is hit, pool will be grown by 20% of
-	// existing pool size.
-	AutoExtendPercent string `toml:"autoextend_percent"`
-
-	// AutoExtendThreshold determines the pool extension threshold in terms
-	// of percentage of pool size. For example, if threshold is 60, that
-	// means when pool is 60% full, threshold has been hit.
-	AutoExtendThreshold string `toml:"autoextend_threshold"`
-
-	// BaseSize specifies the size to use when creating the base device,
-	// which limits the size of images and containers.
-	BaseSize string `toml:"basesize"`
-
-	// BlockSize specifies a custom blocksize to use for the thin pool.
-	BlockSize string `toml:"blocksize"`
-
-	// DirectLvmDevice specifies a custom block storage device to use for
-	// the thin pool.
-	DirectLvmDevice string `toml:"directlvm_device"`
-
-	// DirectLvmDeviceForcewipes device even if device already has a
-	// filesystem
-	DirectLvmDeviceForce string `toml:"directlvm_device_force"`
-
-	// Fs specifies the filesystem type to use for the base device.
-	Fs string `toml:"fs"`
-
-	// log_level sets the log level of devicemapper.
-	LogLevel string `toml:"log_level"`
-
-	// MinFreeSpace specifies the min free space percent in a thin pool
-	// require for new device creation to
-	MinFreeSpace string `toml:"min_free_space"`
-
-	// MkfsArg specifies extra mkfs arguments to be used when creating the
-	// basedevice.
-	MkfsArg string `toml:"mkfsarg"`
-
-	// MountOpt specifies extra mount options used when mounting the thin
-	// devices.
-	MountOpt string `toml:"mountopt"`
-
-	// UseDeferredDeletion marks device for deferred deletion
-	UseDeferredDeletion string `toml:"use_deferred_deletion"`
-
-	// UseDeferredRemoval marks device for deferred removal
-	UseDeferredRemoval string `toml:"use_deferred_removal"`
-
-	// XfsNoSpaceMaxRetriesFreeSpace specifies the maximum number of
-	// retries XFS should attempt to complete IO when ENOSPC (no space)
-	// error is returned by underlying storage device.
-	XfsNoSpaceMaxRetries string `toml:"xfs_nospace_max_retries"`
-}
-
-// OptionsConfig represents the "storage.options" TOML config table.
-type OptionsConfig struct {
-	// AdditionalImagesStores is the location of additional read/only
-	// Image stores.  Usually used to access Networked File System
-	// for shared image content
-	AdditionalImageStores []string `toml:"additionalimagestores"`
-
-	// Size
-	Size string `toml:"size"`
-
-	// RemapUIDs is a list of default UID mappings to use for layers.
-	RemapUIDs string `toml:"remap-uids"`
-	// RemapGIDs is a list of default GID mappings to use for layers.
-	RemapGIDs string `toml:"remap-gids"`
-
-	// RemapUser is the name of one or more entries in /etc/subuid which
-	// should be used to set up default UID mappings.
-	RemapUser string `toml:"remap-user"`
-	// RemapGroup is the name of one or more entries in /etc/subgid which
-	// should be used to set up default GID mappings.
-	RemapGroup string `toml:"remap-group"`
-	// Thinpool container options to be handed to thinpool drivers
-	Thinpool struct{ ThinpoolOptionsConfig } `toml:"thinpool"`
-	// OSTree repository
-	OstreeRepo string `toml:"ostree_repo"`
-
-	// Do not create a bind mount on the storage home
-	SkipMountHome string `toml:"skip_mount_home"`
-
-	// Alternative program to use for the mount of the file system
-	MountProgram string `toml:"mount_program"`
-
-	// MountOpt specifies extra mount options used when mounting
-	MountOpt string `toml:"mountopt"`
-}
-
 // TOML-friendly explicit tables used for conversions.
 type tomlConfig struct {
 	Storage struct {
-		Driver    string                  `toml:"driver"`
-		RunRoot   string                  `toml:"runroot"`
-		GraphRoot string                  `toml:"graphroot"`
-		Options   struct{ OptionsConfig } `toml:"options"`
+		Driver    string                         `toml:"driver"`
+		RunRoot   string                         `toml:"runroot"`
+		GraphRoot string                         `toml:"graphroot"`
+		Options   struct{ config.OptionsConfig } `toml:"options"`
 	} `toml:"storage"`
 }
 


### PR DESCRIPTION
Need to access the storage structs in the machine-config
operator code for container runtime configuration but
with it being in store.go, it is pullng in way too many
dependencies. Moving it out to a separate package cuts down
the dependencies by a huge amount.

Signed-off-by: Urvashi Mohnani <umohnani@redhat.com>