### PR TITLE
Don't ignore errors reloading layer/image/container lists

### DIFF
--- a/store.go
+++ b/store.go
@@ -843,12 +843,16 @@ func (s *store) PutLayer(id, parent string, names []string, mountLabel string, w
 	rlstore.Lock()
 	defer rlstore.Unlock()
 	if modified, err := rlstore.Modified(); modified || err != nil {
-		rlstore.Load()
+		if err = rlstore.Load(); err != nil {
+			return nil, -1, err
+		}
 	}
 	rcstore.Lock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
-		rcstore.Load()
+		if err = rcstore.Load(); err != nil {
+			return nil, -1, err
+		}
 	}
 	if id == "" {
 		id = stringid.GenerateRandomID()
@@ -871,7 +875,9 @@ func (s *store) PutLayer(id, parent string, names []string, mountLabel string, w
 				lstore.Lock()
 				defer lstore.Unlock()
 				if modified, err := lstore.Modified(); modified || err != nil {
-					lstore.Load()
+					if err = lstore.Load(); err != nil {
+						return nil, -1, err
+					}
 				}
 			}
 			if l, err := lstore.Get(parent); err == nil && l != nil {
@@ -947,7 +953,9 @@ func (s *store) CreateImage(id string, names []string, layer, metadata string, o
 			store.Lock()
 			defer store.Unlock()
 			if modified, err := store.Modified(); modified || err != nil {
-				store.Load()
+				if err = store.Load(); err != nil {
+					return nil, err
+				}
 			}
 			ilayer, err = store.Get(layer)
 			if err == nil {
@@ -967,7 +975,9 @@ func (s *store) CreateImage(id string, names []string, layer, metadata string, o
 	ristore.Lock()
 	defer ristore.Unlock()
 	if modified, err := ristore.Modified(); modified || err != nil {
-		ristore.Load()
+		if err = ristore.Load(); err != nil {
+			return nil, err
+		}
 	}
 
 	creationDate := time.Now().UTC()
@@ -1005,7 +1015,9 @@ func (s *store) imageTopLayerForMapping(image *Image, ristore ROImageStore, crea
 			store.Lock()
 			defer store.Unlock()
 			if modified, err := store.Modified(); modified || err != nil {
-				store.Load()
+				if err = store.Load(); err != nil {
+					return nil, err
+				}
 			}
 		}
 		// Walk the top layer list.
@@ -1126,14 +1138,18 @@ func (s *store) CreateContainer(id string, names []string, image, layer, metadat
 		rlstore.Lock()
 		defer rlstore.Unlock()
 		if modified, err := rlstore.Modified(); modified || err != nil {
-			rlstore.Load()
+			if err = rlstore.Load(); err != nil {
+				return nil, err
+			}
 		}
 		var cimage *Image
 		for _, store := range append([]ROImageStore{istore}, istores...) {
 			store.Lock()
 			defer store.Unlock()
 			if modified, err := store.Modified(); modified || err != nil {
-				store.Load()
+				if err = store.Load(); err != nil {
+					return nil, err
+				}
 			}
 			cimage, err = store.Get(image)
 			if err == nil {
@@ -1163,7 +1179,9 @@ func (s *store) CreateContainer(id string, names []string, image, layer, metadat
 		rlstore.Lock()
 		defer rlstore.Unlock()
 		if modified, err := rlstore.Modified(); modified || err != nil {
-			rlstore.Load()
+			if err = rlstore.Load(); err != nil {
+				return nil, err
+			}
 		}
 		if !options.HostUIDMapping && len(options.UIDMap) == 0 {
 			uidMap = s.uidMap
@@ -1223,7 +1241,9 @@ func (s *store) CreateContainer(id string, names []string, image, layer, metadat
 	rcstore.Lock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
-		rcstore.Load()
+		if err = rcstore.Load(); err != nil {
+			return nil, err
+		}
 	}
 	options.IDMappingOptions = IDMappingOptions{
 		HostUIDMapping: len(options.UIDMap) == 0,
@@ -1255,17 +1275,23 @@ func (s *store) SetMetadata(id, metadata string) error {
 	rlstore.Lock()
 	defer rlstore.Unlock()
 	if modified, err := rlstore.Modified(); modified || err != nil {
-		rlstore.Load()
+		if err = rlstore.Load(); err != nil {
+			return err
+		}
 	}
 	ristore.Lock()
 	defer ristore.Unlock()
 	if modified, err := ristore.Modified(); modified || err != nil {
-		ristore.Load()
+		if err := ristore.Load(); err != nil {
+			return err
+		}
 	}
 	rcstore.Lock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
-		rcstore.Load()
+		if err = rcstore.Load(); err != nil {
+			return err
+		}
 	}
 
 	if rlstore.Exists(id) {
@@ -1293,7 +1319,9 @@ func (s *store) Metadata(id string) (string, error) {
 		store.Lock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
-			store.Load()
+			if err = store.Load(); err != nil {
+				return "", err
+			}
 		}
 		if store.Exists(id) {
 			return store.Metadata(id)
@@ -1312,7 +1340,9 @@ func (s *store) Metadata(id string) (string, error) {
 		store.Lock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
-			store.Load()
+			if err = store.Load(); err != nil {
+				return "", err
+			}
 		}
 		if store.Exists(id) {
 			return store.Metadata(id)
@@ -1326,7 +1356,9 @@ func (s *store) Metadata(id string) (string, error) {
 	cstore.Lock()
 	defer cstore.Unlock()
 	if modified, err := cstore.Modified(); modified || err != nil {
-		cstore.Load()
+		if err = cstore.Load(); err != nil {
+			return "", err
+		}
 	}
 	if cstore.Exists(id) {
 		return cstore.Metadata(id)
@@ -1347,7 +1379,9 @@ func (s *store) ListImageBigData(id string) ([]string, error) {
 		store.Lock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
-			store.Load()
+			if err = store.Load(); err != nil {
+				return nil, err
+			}
 		}
 		bigDataNames, err := store.BigDataNames(id)
 		if err == nil {
@@ -1370,7 +1404,9 @@ func (s *store) ImageBigDataSize(id, key string) (int64, error) {
 		store.Lock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
-			store.Load()
+			if err = store.Load(); err != nil {
+				return -1, err
+			}
 		}
 		size, err := store.BigDataSize(id, key)
 		if err == nil {
@@ -1394,7 +1430,9 @@ func (s *store) ImageBigDataDigest(id, key string) (digest.Digest, error) {
 		ristore.Lock()
 		defer ristore.Unlock()
 		if modified, err := ristore.Modified(); modified || err != nil {
-			ristore.Load()
+			if err = ristore.Load(); err != nil {
+				return "", nil
+			}
 		}
 		d, err := ristore.BigDataDigest(id, key)
 		if err == nil && d.Validate() == nil {
@@ -1417,7 +1455,9 @@ func (s *store) ImageBigData(id, key string) ([]byte, error) {
 		store.Lock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
-			store.Load()
+			if err = store.Load(); err != nil {
+				return nil, err
+			}
 		}
 		data, err := store.BigData(id, key)
 		if err == nil {
@@ -1436,7 +1476,9 @@ func (s *store) SetImageBigData(id, key string, data []byte) error {
 	ristore.Lock()
 	defer ristore.Unlock()
 	if modified, err := ristore.Modified(); modified || err != nil {
-		ristore.Load()
+		if err = ristore.Load(); err != nil {
+			return nil
+		}
 	}
 
 	return ristore.SetBigData(id, key, data)
@@ -1457,7 +1499,9 @@ func (s *store) ImageSize(id string) (int64, error) {
 		store.Lock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
-			store.Load()
+			if err = store.Load(); err != nil {
+				return -1, err
+			}
 		}
 	}
 
@@ -1476,7 +1520,9 @@ func (s *store) ImageSize(id string) (int64, error) {
 		store.Lock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
-			store.Load()
+			if err = store.Load(); err != nil {
+				return -1, err
+			}
 		}
 		if image, err = store.Get(id); err == nil {
 			imageStore = store
@@ -1561,7 +1607,9 @@ func (s *store) ContainerSize(id string) (int64, error) {
 		store.Lock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
-			store.Load()
+			if err = store.Load(); err != nil {
+				return -1, err
+			}
 		}
 	}
 
@@ -1583,7 +1631,9 @@ func (s *store) ContainerSize(id string) (int64, error) {
 	rcstore.Lock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
-		rcstore.Load()
+		if err = rcstore.Load(); err != nil {
+			return -1, err
+		}
 	}
 
 	// Read the container record.
@@ -1645,7 +1695,9 @@ func (s *store) ListContainerBigData(id string) ([]string, error) {
 	rcstore.Lock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
-		rcstore.Load()
+		if err = rcstore.Load(); err != nil {
+			return nil, err
+		}
 	}
 
 	return rcstore.BigDataNames(id)
@@ -1659,7 +1711,9 @@ func (s *store) ContainerBigDataSize(id, key string) (int64, error) {
 	rcstore.Lock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
-		rcstore.Load()
+		if err = rcstore.Load(); err != nil {
+			return -1, err
+		}
 	}
 	return rcstore.BigDataSize(id, key)
 }
@@ -1672,7 +1726,9 @@ func (s *store) ContainerBigDataDigest(id, key string) (digest.Digest, error) {
 	rcstore.Lock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
-		rcstore.Load()
+		if err = rcstore.Load(); err != nil {
+			return "", err
+		}
 	}
 	return rcstore.BigDataDigest(id, key)
 }
@@ -1685,7 +1741,9 @@ func (s *store) ContainerBigData(id, key string) ([]byte, error) {
 	rcstore.Lock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
-		rcstore.Load()
+		if err = rcstore.Load(); err != nil {
+			return nil, err
+		}
 	}
 	return rcstore.BigData(id, key)
 }
@@ -1698,7 +1756,9 @@ func (s *store) SetContainerBigData(id, key string, data []byte) error {
 	rcstore.Lock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
-		rcstore.Load()
+		if err = rcstore.Load(); err != nil {
+			return err
+		}
 	}
 	return rcstore.SetBigData(id, key, data)
 }
@@ -1716,7 +1776,9 @@ func (s *store) Exists(id string) bool {
 		store.Lock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
-			store.Load()
+			if err = store.Load(); err != nil {
+				return false
+			}
 		}
 		if store.Exists(id) {
 			return true
@@ -1735,7 +1797,9 @@ func (s *store) Exists(id string) bool {
 		store.Lock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
-			store.Load()
+			if err = store.Load(); err != nil {
+				return false
+			}
 		}
 		if store.Exists(id) {
 			return true
@@ -1749,7 +1813,9 @@ func (s *store) Exists(id string) bool {
 	rcstore.Lock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
-		rcstore.Load()
+		if err = rcstore.Load(); err != nil {
+			return false
+		}
 	}
 	if rcstore.Exists(id) {
 		return true
@@ -1780,7 +1846,9 @@ func (s *store) SetNames(id string, names []string) error {
 	rlstore.Lock()
 	defer rlstore.Unlock()
 	if modified, err := rlstore.Modified(); modified || err != nil {
-		rlstore.Load()
+		if err = rlstore.Load(); err != nil {
+			return err
+		}
 	}
 	if rlstore.Exists(id) {
 		return rlstore.SetNames(id, deduped)
@@ -1793,7 +1861,9 @@ func (s *store) SetNames(id string, names []string) error {
 	ristore.Lock()
 	defer ristore.Unlock()
 	if modified, err := ristore.Modified(); modified || err != nil {
-		ristore.Load()
+		if err = ristore.Load(); err != nil {
+			return err
+		}
 	}
 	if ristore.Exists(id) {
 		return ristore.SetNames(id, deduped)
@@ -1806,7 +1876,9 @@ func (s *store) SetNames(id string, names []string) error {
 	rcstore.Lock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
-		rcstore.Load()
+		if err = rcstore.Load(); err != nil {
+			return err
+		}
 	}
 	if rcstore.Exists(id) {
 		return rcstore.SetNames(id, deduped)
@@ -1827,7 +1899,9 @@ func (s *store) Names(id string) ([]string, error) {
 		store.Lock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
-			store.Load()
+			if err = store.Load(); err != nil {
+				return nil, err
+			}
 		}
 		if l, err := store.Get(id); l != nil && err == nil {
 			return l.Names, nil
@@ -1846,7 +1920,9 @@ func (s *store) Names(id string) ([]string, error) {
 		store.Lock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
-			store.Load()
+			if err = store.Load(); err != nil {
+				return nil, err
+			}
 		}
 		if i, err := store.Get(id); i != nil && err == nil {
 			return i.Names, nil
@@ -1860,7 +1936,9 @@ func (s *store) Names(id string) ([]string, error) {
 	rcstore.Lock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
-		rcstore.Load()
+		if err = rcstore.Load(); err != nil {
+			return nil, err
+		}
 	}
 	if c, err := rcstore.Get(id); c != nil && err == nil {
 		return c.Names, nil
@@ -1881,7 +1959,9 @@ func (s *store) Lookup(name string) (string, error) {
 		store.Lock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
-			store.Load()
+			if err = store.Load(); err != nil {
+				return "", err
+			}
 		}
 		if l, err := store.Get(name); l != nil && err == nil {
 			return l.ID, nil
@@ -1900,7 +1980,9 @@ func (s *store) Lookup(name string) (string, error) {
 		store.Lock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
-			store.Load()
+			if err = store.Load(); err != nil {
+				return "", err
+			}
 		}
 		if i, err := store.Get(name); i != nil && err == nil {
 			return i.ID, nil
@@ -1914,7 +1996,9 @@ func (s *store) Lookup(name string) (string, error) {
 	cstore.Lock()
 	defer cstore.Unlock()
 	if modified, err := cstore.Modified(); modified || err != nil {
-		cstore.Load()
+		if err = cstore.Load(); err != nil {
+			return "", err
+		}
 	}
 	if c, err := cstore.Get(name); c != nil && err == nil {
 		return c.ID, nil
@@ -1940,17 +2024,23 @@ func (s *store) DeleteLayer(id string) error {
 	rlstore.Lock()
 	defer rlstore.Unlock()
 	if modified, err := rlstore.Modified(); modified || err != nil {
-		rlstore.Load()
+		if err = rlstore.Load(); err != nil {
+			return err
+		}
 	}
 	ristore.Lock()
 	defer ristore.Unlock()
 	if modified, err := ristore.Modified(); modified || err != nil {
-		ristore.Load()
+		if err = ristore.Load(); err != nil {
+			return err
+		}
 	}
 	rcstore.Lock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
-		rcstore.Load()
+		if err = rcstore.Load(); err != nil {
+			return err
+		}
 	}
 
 	if rlstore.Exists(id) {
@@ -2006,17 +2096,23 @@ func (s *store) DeleteImage(id string, commit bool) (layers []string, err error)
 	rlstore.Lock()
 	defer rlstore.Unlock()
 	if modified, err := rlstore.Modified(); modified || err != nil {
-		rlstore.Load()
+		if err = rlstore.Load(); err != nil {
+			return nil, err
+		}
 	}
 	ristore.Lock()
 	defer ristore.Unlock()
 	if modified, err := ristore.Modified(); modified || err != nil {
-		ristore.Load()
+		if err = ristore.Load(); err != nil {
+			return nil, err
+		}
 	}
 	rcstore.Lock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
-		rcstore.Load()
+		if err = rcstore.Load(); err != nil {
+			return nil, err
+		}
 	}
 	layersToRemove := []string{}
 	if ristore.Exists(id) {
@@ -2138,17 +2234,23 @@ func (s *store) DeleteContainer(id string) error {
 	rlstore.Lock()
 	defer rlstore.Unlock()
 	if modified, err := rlstore.Modified(); modified || err != nil {
-		rlstore.Load()
+		if err = rlstore.Load(); err != nil {
+			return err
+		}
 	}
 	ristore.Lock()
 	defer ristore.Unlock()
 	if modified, err := ristore.Modified(); modified || err != nil {
-		ristore.Load()
+		if err = ristore.Load(); err != nil {
+			return err
+		}
 	}
 	rcstore.Lock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
-		rcstore.Load()
+		if err = rcstore.Load(); err != nil {
+			return err
+		}
 	}
 
 	if rcstore.Exists(id) {
@@ -2193,17 +2295,23 @@ func (s *store) Delete(id string) error {
 	rlstore.Lock()
 	defer rlstore.Unlock()
 	if modified, err := rlstore.Modified(); modified || err != nil {
-		rlstore.Load()
+		if err = rlstore.Load(); err != nil {
+			return err
+		}
 	}
 	ristore.Lock()
 	defer ristore.Unlock()
 	if modified, err := ristore.Modified(); modified || err != nil {
-		ristore.Load()
+		if err := ristore.Load(); err != nil {
+			return err
+		}
 	}
 	rcstore.Lock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
-		rcstore.Load()
+		if err = rcstore.Load(); err != nil {
+			return err
+		}
 	}
 
 	if rcstore.Exists(id) {
@@ -2255,17 +2363,23 @@ func (s *store) Wipe() error {
 	rlstore.Lock()
 	defer rlstore.Unlock()
 	if modified, err := rlstore.Modified(); modified || err != nil {
-		rlstore.Load()
+		if err = rlstore.Load(); err != nil {
+			return err
+		}
 	}
 	ristore.Lock()
 	defer ristore.Unlock()
 	if modified, err := ristore.Modified(); modified || err != nil {
-		ristore.Load()
+		if err = ristore.Load(); err != nil {
+			return err
+		}
 	}
 	rcstore.Lock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
-		rcstore.Load()
+		if err = rcstore.Load(); err != nil {
+			return err
+		}
 	}
 
 	if err = rcstore.Wipe(); err != nil {
@@ -2307,7 +2421,9 @@ func (s *store) Mount(id, mountLabel string) (string, error) {
 	rlstore.Lock()
 	defer rlstore.Unlock()
 	if modified, err := rlstore.Modified(); modified || err != nil {
-		rlstore.Load()
+		if err = rlstore.Load(); err != nil {
+			return "", err
+		}
 	}
 	if rlstore.Exists(id) {
 		options := drivers.MountOpts{
@@ -2332,7 +2448,9 @@ func (s *store) Mounted(id string) (int, error) {
 	rlstore.Lock()
 	defer rlstore.Unlock()
 	if modified, err := rlstore.Modified(); modified || err != nil {
-		rlstore.Load()
+		if err = rlstore.Load(); err != nil {
+			return 0, err
+		}
 	}
 
 	return rlstore.Mounted(id)
@@ -2349,7 +2467,9 @@ func (s *store) Unmount(id string, force bool) (bool, error) {
 	rlstore.Lock()
 	defer rlstore.Unlock()
 	if modified, err := rlstore.Modified(); modified || err != nil {
-		rlstore.Load()
+		if err = rlstore.Load(); err != nil {
+			return false, err
+		}
 	}
 	if rlstore.Exists(id) {
 		return rlstore.Unmount(id, force)
@@ -2370,7 +2490,9 @@ func (s *store) Changes(from, to string) ([]archive.Change, error) {
 		store.Lock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
-			store.Load()
+			if err = store.Load(); err != nil {
+				return nil, err
+			}
 		}
 		if store.Exists(to) {
 			return store.Changes(from, to)
@@ -2392,7 +2514,9 @@ func (s *store) DiffSize(from, to string) (int64, error) {
 		store.Lock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
-			store.Load()
+			if err = store.Load(); err != nil {
+				return -1, err
+			}
 		}
 		if store.Exists(to) {
 			return store.DiffSize(from, to)
@@ -2413,7 +2537,9 @@ func (s *store) Diff(from, to string, options *DiffOptions) (io.ReadCloser, erro
 	for _, store := range append([]ROLayerStore{lstore}, lstores...) {
 		store.Lock()
 		if modified, err := store.Modified(); modified || err != nil {
-			store.Load()
+			if err = store.Load(); err != nil {
+				return nil, err
+			}
 		}
 		if store.Exists(to) {
 			rc, err := store.Diff(from, to, options)
@@ -2441,7 +2567,9 @@ func (s *store) ApplyDiff(to string, diff io.Reader) (int64, error) {
 	rlstore.Lock()
 	defer rlstore.Unlock()
 	if modified, err := rlstore.Modified(); modified || err != nil {
-		rlstore.Load()
+		if err = rlstore.Load(); err != nil {
+			return -1, err
+		}
 	}
 	if rlstore.Exists(to) {
 		return rlstore.ApplyDiff(to, diff)
@@ -2464,7 +2592,9 @@ func (s *store) layersByMappedDigest(m func(ROLayerStore, digest.Digest) ([]Laye
 		store.Lock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
-			store.Load()
+			if err = store.Load(); err != nil {
+				return nil, err
+			}
 		}
 		storeLayers, err := m(store, d)
 		if err != nil {
@@ -2508,7 +2638,9 @@ func (s *store) LayerSize(id string) (int64, error) {
 		store.Lock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
-			store.Load()
+			if err = store.Load(); err != nil {
+				return -1, err
+			}
 		}
 		if store.Exists(id) {
 			return store.Size(id)
@@ -2525,7 +2657,9 @@ func (s *store) LayerParentOwners(id string) ([]int, []int, error) {
 	rlstore.Lock()
 	defer rlstore.Unlock()
 	if modified, err := rlstore.Modified(); modified || err != nil {
-		rlstore.Load()
+		if err = rlstore.Load(); err != nil {
+			return nil, nil, err
+		}
 	}
 	if rlstore.Exists(id) {
 		return rlstore.ParentOwners(id)
@@ -2545,12 +2679,16 @@ func (s *store) ContainerParentOwners(id string) ([]int, []int, error) {
 	rlstore.Lock()
 	defer rlstore.Unlock()
 	if modified, err := rlstore.Modified(); modified || err != nil {
-		rlstore.Load()
+		if err = rlstore.Load(); err != nil {
+			return nil, nil, err
+		}
 	}
 	rcstore.Lock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
-		rcstore.Load()
+		if err = rcstore.Load(); err != nil {
+			return nil, nil, err
+		}
 	}
 	container, err := rcstore.Get(id)
 	if err != nil {
@@ -2578,7 +2716,9 @@ func (s *store) Layers() ([]Layer, error) {
 		store.Lock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
-			store.Load()
+			if err = store.Load(); err != nil {
+				return nil, err
+			}
 		}
 		storeLayers, err := store.Layers()
 		if err != nil {
@@ -2604,7 +2744,9 @@ func (s *store) Images() ([]Image, error) {
 		store.Lock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
-			store.Load()
+			if err = store.Load(); err != nil {
+				return nil, err
+			}
 		}
 		storeImages, err := store.Images()
 		if err != nil {
@@ -2624,7 +2766,9 @@ func (s *store) Containers() ([]Container, error) {
 	rcstore.Lock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
-		rcstore.Load()
+		if err = rcstore.Load(); err != nil {
+			return nil, err
+		}
 	}
 
 	return rcstore.Containers()
@@ -2643,7 +2787,9 @@ func (s *store) Layer(id string) (*Layer, error) {
 		store.Lock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
-			store.Load()
+			if err = store.Load(); err != nil {
+				return nil, err
+			}
 		}
 		layer, err := store.Get(id)
 		if err == nil {
@@ -2666,7 +2812,9 @@ func (s *store) Image(id string) (*Image, error) {
 		store.Lock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
-			store.Load()
+			if err = store.Load(); err != nil {
+				return nil, err
+			}
 		}
 		image, err := store.Get(id)
 		if err == nil {
@@ -2696,7 +2844,9 @@ func (s *store) ImagesByTopLayer(id string) ([]*Image, error) {
 		store.Lock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
-			store.Load()
+			if err = store.Load(); err != nil {
+				return nil, err
+			}
 		}
 		imageList, err := store.Images()
 		if err != nil {
@@ -2727,7 +2877,9 @@ func (s *store) ImagesByDigest(d digest.Digest) ([]*Image, error) {
 		store.Lock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
-			store.Load()
+			if err = store.Load(); err != nil {
+				return nil, err
+			}
 		}
 		imageList, err := store.ByDigest(d)
 		if err != nil && err != ErrImageUnknown {
@@ -2746,7 +2898,9 @@ func (s *store) Container(id string) (*Container, error) {
 	rcstore.Lock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
-		rcstore.Load()
+		if err = rcstore.Load(); err != nil {
+			return nil, err
+		}
 	}
 
 	return rcstore.Get(id)
@@ -2760,7 +2914,9 @@ func (s *store) ContainerLayerID(id string) (string, error) {
 	rcstore.Lock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
-		rcstore.Load()
+		if err = rcstore.Load(); err != nil {
+			return "", err
+		}
 	}
 	container, err := rcstore.Get(id)
 	if err != nil {
@@ -2781,7 +2937,9 @@ func (s *store) ContainerByLayer(id string) (*Container, error) {
 	rcstore.Lock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
-		rcstore.Load()
+		if err = rcstore.Load(); err != nil {
+			return nil, err
+		}
 	}
 	containerList, err := rcstore.Containers()
 	if err != nil {
@@ -2804,7 +2962,9 @@ func (s *store) ContainerDirectory(id string) (string, error) {
 	rcstore.Lock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
-		rcstore.Load()
+		if err = rcstore.Load(); err != nil {
+			return "", err
+		}
 	}
 
 	id, err = rcstore.Lookup(id)
@@ -2829,7 +2989,9 @@ func (s *store) ContainerRunDirectory(id string) (string, error) {
 	rcstore.Lock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
-		rcstore.Load()
+		if err = rcstore.Load(); err != nil {
+			return "", err
+		}
 	}
 
 	id, err = rcstore.Lookup(id)
@@ -2900,7 +3062,9 @@ func (s *store) Shutdown(force bool) ([]string, error) {
 	rlstore.Lock()
 	defer rlstore.Unlock()
 	if modified, err := rlstore.Modified(); modified || err != nil {
-		rlstore.Load()
+		if err = rlstore.Load(); err != nil {
+			return nil, err
+		}
 	}
 
 	layers, err := rlstore.Layers()


### PR DESCRIPTION
Check for errors returned by various `Load()` methods.