### PR TITLE
images: always set Digest if we have digests

### DIFF
--- a/images.go
+++ b/images.go
@@ -228,6 +228,9 @@ func (image *Image) recomputeDigests() error {
 			validDigests = append(validDigests, digest)
 		}
 	}
+	if image.Digest == "" && len(validDigests) > 0 {
+		image.Digest = validDigests[0]
+	}
 	image.Digests = validDigests
 	return nil
 }


### PR DESCRIPTION
Make sure that an Image that has at least one digest always has a populated Digest field.