### PR TITLE
Make use of overlay.override_kernel_check a warning instead of an error

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -239,6 +239,8 @@ func parseOptions(options []string) (*overlayOptions, error) {
 		}
 		key = strings.ToLower(key)
 		switch key {
+		case ".override_kernel_check", "overlay.override_kernel_check", "overlay2.override_kernel_check":
+			logrus.Warnf("overlay: override_kernel_check option was specified, but is no longer necessary")
 		case ".mountopt", "overlay.mountopt", "overlay2.mountopt":
 			o.mountOptions = val
 		case ".size", "overlay.size", "overlay2.size":

--- a/store.go
+++ b/store.go
@@ -566,10 +566,10 @@ func GetStore(options StoreOptions) (Store, error) {
 	}
 
 	if options.GraphRoot == "" {
-		return nil, ErrIncompleteOptions
+		return nil, errors.Wrap(ErrIncompleteOptions, "no storage root specified")
 	}
 	if options.RunRoot == "" {
-		return nil, ErrIncompleteOptions
+		return nil, errors.Wrap(ErrIncompleteOptions, "no storage runroot specified")
 	}
 
 	if err := os.MkdirAll(options.RunRoot, 0700); err != nil && !os.IsExist(err) {


### PR DESCRIPTION
When we removed all traces of override_kernel_check in #269, we created a situation where older configuration files would suddenly start causing us to emit an error at startup.  Soften that to a warning, for now at least.