### PR TITLE
GetStore(): resolve passed-in paths to absolute paths

### DIFF
--- a/lockfile.go
+++ b/lockfile.go
@@ -66,7 +66,10 @@ func getLockfile(path string, ro bool) (Locker, error) {
 	if lockfiles == nil {
 		lockfiles = make(map[string]Locker)
 	}
-	cleanPath := filepath.Clean(path)
+	cleanPath, err := filepath.Abs(path)
+	if err != nil {
+		return nil, errors.Wrapf(err, "error ensuring that path %q is an absolute path", path)
+	}
 	if locker, ok := lockfiles[cleanPath]; ok {
 		if ro && locker.IsReadWrite() {
 			return nil, errors.Errorf("lock %q is not a read-only lock", cleanPath)

--- a/store.go
+++ b/store.go
@@ -550,10 +550,18 @@ func GetStore(options StoreOptions) (Store, error) {
 	}
 
 	if options.GraphRoot != "" {
-		options.GraphRoot = filepath.Clean(options.GraphRoot)
+		dir, err := filepath.Abs(options.GraphRoot)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error deriving an absolute path from %q", options.GraphRoot)
+		}
+		options.GraphRoot = dir
 	}
 	if options.RunRoot != "" {
-		options.RunRoot = filepath.Clean(options.RunRoot)
+		dir, err := filepath.Abs(options.RunRoot)
+		if err != nil {
+			return nil, errors.Wrapf(err, "error deriving an absolute path from %q", options.RunRoot)
+		}
+		options.RunRoot = dir
 	}
 
 	storesLock.Lock()

--- a/tests/abs.bats
+++ b/tests/abs.bats
@@ -1,0 +1,9 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "absolute-paths" {
+	cd ${TESTDIR}
+	storage --graph tmp1a/deep/root --run tmp1b/deep/runroot layers
+	storage --graph ./tmp2a/deep/root --run ./tmp2b/deep/runroot layers
+}


### PR DESCRIPTION
Resolve passed-in locations to absolute paths at startup.  This should fix https://github.com/containers/buildah/issues/1345.