### PR TITLE
Clarify Locker.Locked(), and switch some locks to read-only

### DIFF
--- a/cmd/containers-storage/container.go
+++ b/cmd/containers-storage/container.go
@@ -17,7 +17,7 @@ var (
 func container(flags *mflag.FlagSet, action string, m storage.Store, args []string) int {
 	images, err := m.Images()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	matches := []*storage.Container{}
@@ -45,7 +45,7 @@ func container(flags *mflag.FlagSet, action string, m storage.Store, args []stri
 			}
 			size, err := m.ContainerSize(container.ID)
 			if err != nil {
-				fmt.Printf("Size unknown: %v\n", err)
+				fmt.Printf("Size unknown: %+v\n", err)
 			} else {
 				fmt.Printf("Size: %d\n", size)
 			}
@@ -64,7 +64,7 @@ func container(flags *mflag.FlagSet, action string, m storage.Store, args []stri
 func listContainerBigData(flags *mflag.FlagSet, action string, m storage.Store, args []string) int {
 	container, err := m.Container(args[0])
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	d, err := m.ListContainerBigData(container.ID)
@@ -81,7 +81,7 @@ func listContainerBigData(flags *mflag.FlagSet, action string, m storage.Store, 
 func getContainerBigData(flags *mflag.FlagSet, action string, m storage.Store, args []string) int {
 	container, err := m.Container(args[0])
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	output := os.Stdout
@@ -95,7 +95,7 @@ func getContainerBigData(flags *mflag.FlagSet, action string, m storage.Store, a
 	}
 	b, err := m.ContainerBigData(container.ID, args[1])
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	output.Write(b)
@@ -106,12 +106,12 @@ func getContainerBigData(flags *mflag.FlagSet, action string, m storage.Store, a
 func getContainerBigDataSize(flags *mflag.FlagSet, action string, m storage.Store, args []string) int {
 	container, err := m.Container(args[0])
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	size, err := m.ContainerBigDataSize(container.ID, args[1])
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	fmt.Fprintf(os.Stdout, "%d\n", size)
@@ -121,12 +121,12 @@ func getContainerBigDataSize(flags *mflag.FlagSet, action string, m storage.Stor
 func getContainerBigDataDigest(flags *mflag.FlagSet, action string, m storage.Store, args []string) int {
 	container, err := m.Container(args[0])
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	d, err := m.ContainerBigDataDigest(container.ID, args[1])
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	if d.Validate() != nil {
@@ -140,7 +140,7 @@ func getContainerBigDataDigest(flags *mflag.FlagSet, action string, m storage.St
 func setContainerBigData(flags *mflag.FlagSet, action string, m storage.Store, args []string) int {
 	container, err := m.Container(args[0])
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	input := os.Stdin
@@ -159,7 +159,7 @@ func setContainerBigData(flags *mflag.FlagSet, action string, m storage.Store, a
 	}
 	err = m.SetContainerBigData(container.ID, args[1], b)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	return 0
@@ -168,7 +168,7 @@ func setContainerBigData(flags *mflag.FlagSet, action string, m storage.Store, a
 func getContainerDir(flags *mflag.FlagSet, action string, m storage.Store, args []string) int {
 	path, err := m.ContainerDirectory(args[0])
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	fmt.Printf("%s\n", path)
@@ -178,7 +178,7 @@ func getContainerDir(flags *mflag.FlagSet, action string, m storage.Store, args 
 func getContainerRunDir(flags *mflag.FlagSet, action string, m storage.Store, args []string) int {
 	path, err := m.ContainerRunDirectory(args[0])
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	fmt.Printf("%s\n", path)
@@ -195,7 +195,7 @@ func containerParentOwners(flags *mflag.FlagSet, action string, m storage.Store,
 	for _, container := range matched {
 		uids, gids, err := m.ContainerParentOwners(container.ID)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "ContainerParentOwner: %v\n", err)
+			fmt.Fprintf(os.Stderr, "ContainerParentOwner: %+v\n", err)
 			return 1
 		}
 		if jsonOutput {

--- a/cmd/containers-storage/containers.go
+++ b/cmd/containers-storage/containers.go
@@ -12,7 +12,7 @@ import (
 func containers(flags *mflag.FlagSet, action string, m storage.Store, args []string) int {
 	containers, err := m.Containers()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	if jsonOutput {

--- a/cmd/containers-storage/copy.go
+++ b/cmd/containers-storage/copy.go
@@ -49,13 +49,13 @@ func copyContent(flags *mflag.FlagSet, action string, m storage.Store, args []st
 		}
 		targetLayer, err := m.Layer(targetParts[0])
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "error finding layer %q: %v\n", targetParts[0], err)
+			fmt.Fprintf(os.Stderr, "error finding layer %q: %+v\n", targetParts[0], err)
 			return 1
 		}
 		untarIDMappings = idtools.NewIDMappingsFromMaps(targetLayer.UIDMap, targetLayer.GIDMap)
 		targetMount, err := m.Mount(targetLayer.ID, targetLayer.MountLabel)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "error mounting layer %q: %v\n", targetLayer.ID, err)
+			fmt.Fprintf(os.Stderr, "error mounting layer %q: %+v\n", targetLayer.ID, err)
 			return 1
 		}
 		target = filepath.Join(targetMount, targetParts[1])
@@ -73,13 +73,13 @@ func copyContent(flags *mflag.FlagSet, action string, m storage.Store, args []st
 			}
 			sourceLayer, err := m.Layer(sourceParts[0])
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "error finding layer %q: %v\n", sourceParts[0], err)
+				fmt.Fprintf(os.Stderr, "error finding layer %q: %+v\n", sourceParts[0], err)
 				return 1
 			}
 			tarIDMappings = idtools.NewIDMappingsFromMaps(sourceLayer.UIDMap, sourceLayer.GIDMap)
 			sourceMount, err := m.Mount(sourceLayer.ID, sourceLayer.MountLabel)
 			if err != nil {
-				fmt.Fprintf(os.Stderr, "error mounting layer %q: %v\n", sourceLayer.ID, err)
+				fmt.Fprintf(os.Stderr, "error mounting layer %q: %+v\n", sourceLayer.ID, err)
 				return 1
 			}
 			source = filepath.Join(sourceMount, sourceParts[1])
@@ -87,7 +87,7 @@ func copyContent(flags *mflag.FlagSet, action string, m storage.Store, args []st
 		}
 		archiver := chrootarchive.NewArchiverWithChown(tarIDMappings, chownOpts, untarIDMappings)
 		if err := archiver.CopyWithTar(source, target); err != nil {
-			fmt.Fprintf(os.Stderr, "error copying %q to %q: %v\n", source, target, err)
+			fmt.Fprintf(os.Stderr, "error copying %q to %q: %+v\n", source, target, err)
 			return 1
 		}
 	}

--- a/cmd/containers-storage/create.go
+++ b/cmd/containers-storage/create.go
@@ -83,7 +83,7 @@ func createLayer(flags *mflag.FlagSet, action string, m storage.Store, args []st
 	options := &storage.LayerOptions{IDMappingOptions: *mappings}
 	layer, err := m.CreateLayer(paramID, parent, paramNames, paramMountLabel, !paramCreateRO, options)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	if jsonOutput {
@@ -120,7 +120,7 @@ func importLayer(flags *mflag.FlagSet, action string, m storage.Store, args []st
 	options := &storage.LayerOptions{IDMappingOptions: *mappings}
 	layer, _, err := m.PutLayer(paramID, parent, paramNames, paramMountLabel, !paramCreateRO, options, diffStream)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	if jsonOutput {
@@ -157,7 +157,7 @@ func createImage(flags *mflag.FlagSet, action string, m storage.Store, args []st
 	}
 	image, err := m.CreateImage(paramID, paramNames, layer, paramMetadata, imageOptions)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	if jsonOutput {
@@ -193,7 +193,7 @@ func createContainer(flags *mflag.FlagSet, action string, m storage.Store, args 
 	options := &storage.ContainerOptions{IDMappingOptions: *mappings}
 	container, err := m.CreateContainer(paramID, paramNames, args[0], paramLayer, paramMetadata, options)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	if jsonOutput {

--- a/cmd/containers-storage/diff.go
+++ b/cmd/containers-storage/diff.go
@@ -31,7 +31,7 @@ func changes(flags *mflag.FlagSet, action string, m storage.Store, args []string
 	}
 	changes, err := m.Changes(from, to)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	if jsonOutput {
@@ -66,7 +66,7 @@ func diff(flags *mflag.FlagSet, action string, m storage.Store, args []string) i
 	if diffFile != "" {
 		f, err := os.Create(diffFile)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "%v\n", err)
+			fmt.Fprintf(os.Stderr, "%+v\n", err)
 			return 1
 		}
 		diffStream = f
@@ -90,13 +90,13 @@ func diff(flags *mflag.FlagSet, action string, m storage.Store, args []string) i
 
 	reader, err := m.Diff(from, to, &options)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	_, err = io.Copy(diffStream, reader)
 	reader.Close()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	return 0
@@ -110,7 +110,7 @@ func applyDiff(flags *mflag.FlagSet, action string, m storage.Store, args []stri
 	if applyDiffFile != "" {
 		f, err := os.Open(applyDiffFile)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "%v\n", err)
+			fmt.Fprintf(os.Stderr, "%+v\n", err)
 			return 1
 		}
 		diffStream = f
@@ -118,7 +118,7 @@ func applyDiff(flags *mflag.FlagSet, action string, m storage.Store, args []stri
 	}
 	_, err := m.ApplyDiff(args[0], diffStream)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	return 0
@@ -135,7 +135,7 @@ func diffSize(flags *mflag.FlagSet, action string, m storage.Store, args []strin
 	}
 	n, err := m.DiffSize(from, to)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	fmt.Printf("%d\n", n)

--- a/cmd/containers-storage/image.go
+++ b/cmd/containers-storage/image.go
@@ -41,7 +41,7 @@ func image(flags *mflag.FlagSet, action string, m storage.Store, args []string) 
 			}
 			size, err := m.ImageSize(image.ID)
 			if err != nil {
-				fmt.Printf("Size unknown: %v\n", err)
+				fmt.Printf("Size unknown: %+v\n", err)
 			} else {
 				fmt.Printf("Size: %d\n", size)
 			}
@@ -56,7 +56,7 @@ func image(flags *mflag.FlagSet, action string, m storage.Store, args []string) 
 func listImageBigData(flags *mflag.FlagSet, action string, m storage.Store, args []string) int {
 	image, err := m.Image(args[0])
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	d, err := m.ListImageBigData(image.ID)
@@ -73,7 +73,7 @@ func listImageBigData(flags *mflag.FlagSet, action string, m storage.Store, args
 func getImageBigData(flags *mflag.FlagSet, action string, m storage.Store, args []string) int {
 	image, err := m.Image(args[0])
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	output := os.Stdout
@@ -87,7 +87,7 @@ func getImageBigData(flags *mflag.FlagSet, action string, m storage.Store, args 
 	}
 	b, err := m.ImageBigData(image.ID, args[1])
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	output.Write(b)
@@ -98,12 +98,12 @@ func getImageBigData(flags *mflag.FlagSet, action string, m storage.Store, args 
 func getImageBigDataSize(flags *mflag.FlagSet, action string, m storage.Store, args []string) int {
 	image, err := m.Image(args[0])
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	size, err := m.ImageBigDataSize(image.ID, args[1])
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	fmt.Fprintf(os.Stdout, "%d\n", size)
@@ -113,12 +113,12 @@ func getImageBigDataSize(flags *mflag.FlagSet, action string, m storage.Store, a
 func getImageBigDataDigest(flags *mflag.FlagSet, action string, m storage.Store, args []string) int {
 	image, err := m.Image(args[0])
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	d, err := m.ImageBigDataDigest(image.ID, args[1])
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	if d.Validate() != nil {

--- a/cmd/containers-storage/images.go
+++ b/cmd/containers-storage/images.go
@@ -17,7 +17,7 @@ var (
 func images(flags *mflag.FlagSet, action string, m storage.Store, args []string) int {
 	images, err := m.Images()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	if jsonOutput {
@@ -52,7 +52,7 @@ func imagesByDigest(flags *mflag.FlagSet, action string, m storage.Store, args [
 		}
 		matched, err := m.ImagesByDigest(d)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "%v\n", err)
+			fmt.Fprintf(os.Stderr, "%+v\n", err)
 			return 1
 		}
 		for _, match := range matched {

--- a/cmd/containers-storage/layer.go
+++ b/cmd/containers-storage/layer.go
@@ -51,7 +51,7 @@ func layerParentOwners(flags *mflag.FlagSet, action string, m storage.Store, arg
 	for _, layer := range matched {
 		uids, gids, err := m.LayerParentOwners(layer.ID)
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "LayerParentOwner: %v\n", err)
+			fmt.Fprintf(os.Stderr, "LayerParentOwner: %+v\n", err)
 			return 1
 		}
 		if jsonOutput {

--- a/cmd/containers-storage/layers.go
+++ b/cmd/containers-storage/layers.go
@@ -14,7 +14,7 @@ var listLayersTree = false
 func layers(flags *mflag.FlagSet, action string, m storage.Store, args []string) int {
 	layers, err := m.Layers()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	if jsonOutput {

--- a/cmd/containers-storage/main.go
+++ b/cmd/containers-storage/main.go
@@ -117,7 +117,7 @@ func main() {
 				}
 				store, err := storage.GetStore(options)
 				if err != nil {
-					fmt.Printf("error initializing: %v\n", err)
+					fmt.Printf("error initializing: %+v\n", err)
 					os.Exit(1)
 				}
 				os.Exit(command.action(flags, cmd, store, args))

--- a/cmd/containers-storage/metadata.go
+++ b/cmd/containers-storage/metadata.go
@@ -65,7 +65,7 @@ func setMetadata(flags *mflag.FlagSet, action string, m storage.Store, args []st
 		paramMetadata = string(b)
 	}
 	if err := m.SetMetadata(args[0], paramMetadata); err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	return 0

--- a/cmd/containers-storage/name.go
+++ b/cmd/containers-storage/name.go
@@ -16,12 +16,12 @@ func getNames(flags *mflag.FlagSet, action string, m storage.Store, args []strin
 	}
 	id, err := m.Lookup(args[0])
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	names, err := m.Names(id)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	if jsonOutput {
@@ -40,12 +40,12 @@ func addNames(flags *mflag.FlagSet, action string, m storage.Store, args []strin
 	}
 	id, err := m.Lookup(args[0])
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	oldnames, err := m.Names(id)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	newNames := []string{}
@@ -56,12 +56,12 @@ func addNames(flags *mflag.FlagSet, action string, m storage.Store, args []strin
 		newNames = append(newNames, paramNames...)
 	}
 	if err := m.SetNames(id, newNames); err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	names, err := m.Names(id)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	if jsonOutput {
@@ -76,16 +76,16 @@ func setNames(flags *mflag.FlagSet, action string, m storage.Store, args []strin
 	}
 	id, err := m.Lookup(args[0])
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	if err := m.SetNames(id, paramNames); err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	names, err := m.Names(id)
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "%v\n", err)
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
 	}
 	if jsonOutput {

--- a/cmd/containers-storage/shutdown.go
+++ b/cmd/containers-storage/shutdown.go
@@ -23,7 +23,7 @@ func shutdown(flags *mflag.FlagSet, action string, m storage.Store, args []strin
 		}
 	} else {
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "%s: %v\n", action, err)
+			fmt.Fprintf(os.Stderr, "%s: %+v\n", action, err)
 		}
 	}
 	if err != nil {

--- a/cmd/containers-storage/status.go
+++ b/cmd/containers-storage/status.go
@@ -12,7 +12,7 @@ import (
 func status(flags *mflag.FlagSet, action string, m storage.Store, args []string) int {
 	status, err := m.Status()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "status: %v\n", err)
+		fmt.Fprintf(os.Stderr, "status: %+v\n", err)
 		return 1
 	}
 	basics := [][2]string{

--- a/cmd/containers-storage/version.go
+++ b/cmd/containers-storage/version.go
@@ -12,7 +12,7 @@ import (
 func version(flags *mflag.FlagSet, action string, m storage.Store, args []string) int {
 	version, err := m.Version()
 	if err != nil {
-		fmt.Fprintf(os.Stderr, "version: %v\n", err)
+		fmt.Fprintf(os.Stderr, "version: %+v\n", err)
 		return 1
 	}
 	if jsonOutput {

--- a/cmd/containers-storage/wipe.go
+++ b/cmd/containers-storage/wipe.go
@@ -19,7 +19,7 @@ func wipe(flags *mflag.FlagSet, action string, m storage.Store, args []string) i
 		}
 	} else {
 		if err != nil {
-			fmt.Fprintf(os.Stderr, "%s: %v\n", action, err)
+			fmt.Fprintf(os.Stderr, "%s: %+v\n", action, err)
 		}
 	}
 	if err != nil {

--- a/hack/git-validation.sh
+++ b/hack/git-validation.sh
@@ -8,6 +8,6 @@ if ! which git-validation > /dev/null 2> /dev/null ; then
 fi
 if test "$TRAVIS" != true ; then
 	#GITVALIDATE_EPOCH=":/git-validation epoch"
-	GITVALIDATE_EPOCH="7c6ff428c34b49014a14712437c4a93f78e3d043"
+	GITVALIDATE_EPOCH="3c1cea3e424986dc42ebe9884d6d9458d118ba6e"
 fi
 exec git-validation -q -run DCO,short-subject ${GITVALIDATE_EPOCH:+-range "${GITVALIDATE_EPOCH}""..${GITVALIDATE_TIP:-@}"} ${GITVALIDATE_FLAGS}

--- a/images.go
+++ b/images.go
@@ -272,7 +272,7 @@ func (r *imageStore) Load() error {
 			}
 		}
 	}
-	if shouldSave && !r.IsReadWrite() {
+	if shouldSave && (!r.IsReadWrite() || !r.Locked()) {
 		return ErrDuplicateImageNames
 	}
 	r.images = images

--- a/images.go
+++ b/images.go
@@ -291,7 +291,7 @@ func (r *imageStore) Save() error {
 		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to modify the image store at %q", r.imagespath())
 	}
 	if !r.Locked() {
-		return errors.New("image store is not locked")
+		return errors.New("image store is not locked for writing")
 	}
 	rpath := r.imagespath()
 	if err := os.MkdirAll(filepath.Dir(rpath), 0700); err != nil {

--- a/layers.go
+++ b/layers.go
@@ -320,7 +320,7 @@ func (r *layerStore) Load() error {
 			}
 		}
 	}
-	if shouldSave && !r.IsReadWrite() {
+	if shouldSave && (!r.IsReadWrite() || !r.Locked()) {
 		return ErrDuplicateLayerNames
 	}
 	mpath := r.mountspath()
@@ -351,7 +351,7 @@ func (r *layerStore) Load() error {
 	// Last step: if we're writable, try to remove anything that a previous
 	// user of this storage area marked for deletion but didn't manage to
 	// actually delete.
-	if r.IsReadWrite() {
+	if r.IsReadWrite() && r.Locked() {
 		for _, layer := range r.layers {
 			if layer.Flags == nil {
 				layer.Flags = make(map[string]interface{})

--- a/layers.go
+++ b/layers.go
@@ -862,8 +862,9 @@ func (r *layerStore) Delete(id string) error {
 		return ErrLayerUnknown
 	}
 	id = layer.ID
-	// This check is needed for idempotency of delete where the layer could have been
-	// already unmounted (since c/storage gives you that API directly)
+	// The layer may already have been explicitly unmounted, but if not, we
+	// should try to clean that up before we start deleting anything at the
+	// driver level.
 	for layer.MountCount > 0 {
 		if _, err := r.Unmount(id, false); err != nil {
 			return err

--- a/layers.go
+++ b/layers.go
@@ -378,7 +378,7 @@ func (r *layerStore) Save() error {
 		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to modify the layer store at %q", r.layerspath())
 	}
 	if !r.Locked() {
-		return errors.New("layer store is not locked")
+		return errors.New("layer store is not locked for writing")
 	}
 	rpath := r.layerspath()
 	if err := os.MkdirAll(filepath.Dir(rpath), 0700); err != nil {

--- a/layers.go
+++ b/layers.go
@@ -229,6 +229,7 @@ type LayerStore interface {
 
 type layerStore struct {
 	lockfile          Locker
+	mountsLockfile    Locker
 	rundir            string
 	driver            drivers.Driver
 	layerdir          string
@@ -291,7 +292,6 @@ func (r *layerStore) Load() error {
 	idlist := []string{}
 	ids := make(map[string]*Layer)
 	names := make(map[string]*Layer)
-	mounts := make(map[string]*Layer)
 	compressedsums := make(map[digest.Digest][]string)
 	uncompressedsums := make(map[digest.Digest][]string)
 	if r.lockfile.IsReadWrite() {
@@ -319,35 +319,25 @@ func (r *layerStore) Load() error {
 				label.ReserveLabel(layer.MountLabel)
 			}
 		}
+		err = nil
 	}
 	if shouldSave && (!r.IsReadWrite() || !r.Locked()) {
 		return ErrDuplicateLayerNames
-	}
-	mpath := r.mountspath()
-	data, err = ioutil.ReadFile(mpath)
-	if err != nil && !os.IsNotExist(err) {
-		return err
-	}
-	layerMounts := []layerMountPoint{}
-	if err = json.Unmarshal(data, &layerMounts); len(data) == 0 || err == nil {
-		for _, mount := range layerMounts {
-			if mount.MountPoint != "" {
-				if layer, ok := ids[mount.ID]; ok {
-					mounts[mount.MountPoint] = layer
-					layer.MountPoint = mount.MountPoint
-					layer.MountCount = mount.MountCount
-				}
-			}
-		}
 	}
 	r.layers = layers
 	r.idindex = truncindex.NewTruncIndex(idlist)
 	r.byid = ids
 	r.byname = names
-	r.bymount = mounts
 	r.bycompressedsum = compressedsums
 	r.byuncompressedsum = uncompressedsums
-	err = nil
+	// Load and merge information about which layers are mounted, and where.
+	if r.IsReadWrite() {
+		r.mountsLockfile.RLock()
+		defer r.mountsLockfile.Unlock()
+		if err = r.loadMounts(); err != nil {
+			return err
+		}
+	}
 	// Last step: if we're writable, try to remove anything that a previous
 	// user of this storage area marked for deletion but didn't manage to
 	// actually delete.
@@ -373,6 +363,30 @@ func (r *layerStore) Load() error {
 	return err
 }
 
+func (r *layerStore) loadMounts() error {
+	mounts := make(map[string]*Layer)
+	mpath := r.mountspath()
+	data, err := ioutil.ReadFile(mpath)
+	if err != nil && !os.IsNotExist(err) {
+		return err
+	}
+	layerMounts := []layerMountPoint{}
+	if err = json.Unmarshal(data, &layerMounts); len(data) == 0 || err == nil {
+		for _, mount := range layerMounts {
+			if mount.MountPoint != "" {
+				if layer, ok := r.lookup(mount.ID); ok {
+					mounts[mount.MountPoint] = layer
+					layer.MountPoint = mount.MountPoint
+					layer.MountCount = mount.MountCount
+				}
+			}
+		}
+		err = nil
+	}
+	r.bymount = mounts
+	return err
+}
+
 func (r *layerStore) Save() error {
 	if !r.IsReadWrite() {
 		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to modify the layer store at %q", r.layerspath())
@@ -387,6 +401,25 @@ func (r *layerStore) Save() error {
 	jldata, err := json.Marshal(&r.layers)
 	if err != nil {
 		return err
+	}
+	if err := ioutils.AtomicWriteFile(rpath, jldata, 0600); err != nil {
+		return err
+	}
+	if !r.IsReadWrite() {
+		return nil
+	}
+	r.mountsLockfile.Lock()
+	defer r.mountsLockfile.Unlock()
+	defer r.mountsLockfile.Touch()
+	return r.saveMounts()
+}
+
+func (r *layerStore) saveMounts() error {
+	if !r.IsReadWrite() {
+		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to modify the layer store at %q", r.layerspath())
+	}
+	if !r.mountsLockfile.Locked() {
+		return errors.New("layer store mount information is not locked for writing")
 	}
 	mpath := r.mountspath()
 	if err := os.MkdirAll(filepath.Dir(mpath), 0700); err != nil {
@@ -406,11 +439,10 @@ func (r *layerStore) Save() error {
 	if err != nil {
 		return err
 	}
-	if err := ioutils.AtomicWriteFile(rpath, jldata, 0600); err != nil {
+	if err = ioutils.AtomicWriteFile(mpath, jmdata, 0600); err != nil {
 		return err
 	}
-	defer r.Touch()
-	return ioutils.AtomicWriteFile(mpath, jmdata, 0600)
+	return r.loadMounts()
 }
 
 func newLayerStore(rundir string, layerdir string, driver drivers.Driver, uidMap, gidMap []idtools.IDMap) (LayerStore, error) {
@@ -426,16 +458,21 @@ func newLayerStore(rundir string, layerdir string, driver drivers.Driver, uidMap
 	}
 	lockfile.Lock()
 	defer lockfile.Unlock()
+	mountsLockfile, err := GetLockfile(filepath.Join(rundir, "mountpoints.lock"))
+	if err != nil {
+		return nil, err
+	}
 	rlstore := layerStore{
-		lockfile: lockfile,
-		driver:   driver,
-		rundir:   rundir,
-		layerdir: layerdir,
-		byid:     make(map[string]*Layer),
-		bymount:  make(map[string]*Layer),
-		byname:   make(map[string]*Layer),
-		uidMap:   copyIDMap(uidMap),
-		gidMap:   copyIDMap(gidMap),
+		lockfile:       lockfile,
+		mountsLockfile: mountsLockfile,
+		driver:         driver,
+		rundir:         rundir,
+		layerdir:       layerdir,
+		byid:           make(map[string]*Layer),
+		bymount:        make(map[string]*Layer),
+		byname:         make(map[string]*Layer),
+		uidMap:         copyIDMap(uidMap),
+		gidMap:         copyIDMap(gidMap),
 	}
 	if err := rlstore.Load(); err != nil {
 		return nil, err
@@ -451,13 +488,14 @@ func newROLayerStore(rundir string, layerdir string, driver drivers.Driver) (ROL
 	lockfile.Lock()
 	defer lockfile.Unlock()
 	rlstore := layerStore{
-		lockfile: lockfile,
-		driver:   driver,
-		rundir:   rundir,
-		layerdir: layerdir,
-		byid:     make(map[string]*Layer),
-		bymount:  make(map[string]*Layer),
-		byname:   make(map[string]*Layer),
+		lockfile:       lockfile,
+		mountsLockfile: nil,
+		driver:         driver,
+		rundir:         rundir,
+		layerdir:       layerdir,
+		byid:           make(map[string]*Layer),
+		bymount:        make(map[string]*Layer),
+		byname:         make(map[string]*Layer),
 	}
 	if err := rlstore.Load(); err != nil {
 		return nil, err
@@ -673,6 +711,16 @@ func (r *layerStore) Create(id string, parent *Layer, names []string, mountLabel
 }
 
 func (r *layerStore) Mounted(id string) (int, error) {
+	if !r.IsReadWrite() {
+		return 0, errors.Wrapf(ErrStoreIsReadOnly, "no mount information for layers at %q", r.mountspath())
+	}
+	r.mountsLockfile.RLock()
+	defer r.mountsLockfile.Unlock()
+	if modified, err := r.mountsLockfile.Modified(); modified || err != nil {
+		if err = r.loadMounts(); err != nil {
+			return 0, err
+		}
+	}
 	layer, ok := r.lookup(id)
 	if !ok {
 		return 0, ErrLayerUnknown
@@ -684,13 +732,21 @@ func (r *layerStore) Mount(id string, options drivers.MountOpts) (string, error)
 	if !r.IsReadWrite() {
 		return "", errors.Wrapf(ErrStoreIsReadOnly, "not allowed to update mount locations for layers at %q", r.mountspath())
 	}
+	r.mountsLockfile.Lock()
+	defer r.mountsLockfile.Unlock()
+	if modified, err := r.mountsLockfile.Modified(); modified || err != nil {
+		if err = r.loadMounts(); err != nil {
+			return "", err
+		}
+	}
+	defer r.mountsLockfile.Touch()
 	layer, ok := r.lookup(id)
 	if !ok {
 		return "", ErrLayerUnknown
 	}
 	if layer.MountCount > 0 {
 		layer.MountCount++
-		return layer.MountPoint, r.Save()
+		return layer.MountPoint, r.saveMounts()
 	}
 	if options.MountLabel == "" {
 		options.MountLabel = layer.MountLabel
@@ -709,7 +765,7 @@ func (r *layerStore) Mount(id string, options drivers.MountOpts) (string, error)
 		layer.MountPoint = filepath.Clean(mountpoint)
 		layer.MountCount++
 		r.bymount[layer.MountPoint] = layer
-		err = r.Save()
+		err = r.saveMounts()
 	}
 	return mountpoint, err
 }
@@ -718,6 +774,14 @@ func (r *layerStore) Unmount(id string, force bool) (bool, error) {
 	if !r.IsReadWrite() {
 		return false, errors.Wrapf(ErrStoreIsReadOnly, "not allowed to update mount locations for layers at %q", r.mountspath())
 	}
+	r.mountsLockfile.Lock()
+	defer r.mountsLockfile.Unlock()
+	if modified, err := r.mountsLockfile.Modified(); modified || err != nil {
+		if err = r.loadMounts(); err != nil {
+			return false, err
+		}
+	}
+	defer r.mountsLockfile.Touch()
 	layer, ok := r.lookup(id)
 	if !ok {
 		layerByMount, ok := r.bymount[filepath.Clean(id)]
@@ -731,7 +795,7 @@ func (r *layerStore) Unmount(id string, force bool) (bool, error) {
 	}
 	if layer.MountCount > 1 {
 		layer.MountCount--
-		return true, r.Save()
+		return true, r.saveMounts()
 	}
 	err := r.driver.Put(id)
 	if err == nil || os.IsNotExist(err) {
@@ -740,12 +804,22 @@ func (r *layerStore) Unmount(id string, force bool) (bool, error) {
 		}
 		layer.MountCount--
 		layer.MountPoint = ""
-		return false, r.Save()
+		return false, r.saveMounts()
 	}
 	return true, err
 }
 
 func (r *layerStore) ParentOwners(id string) (uids, gids []int, err error) {
+	if !r.IsReadWrite() {
+		return nil, nil, errors.Wrapf(ErrStoreIsReadOnly, "no mount information for layers at %q", r.mountspath())
+	}
+	r.mountsLockfile.RLock()
+	defer r.mountsLockfile.Unlock()
+	if modified, err := r.mountsLockfile.Modified(); modified || err != nil {
+		if err = r.loadMounts(); err != nil {
+			return nil, nil, err
+		}
+	}
 	layer, ok := r.lookup(id)
 	if !ok {
 		return nil, nil, ErrLayerUnknown
@@ -865,12 +939,20 @@ func (r *layerStore) Delete(id string) error {
 	// The layer may already have been explicitly unmounted, but if not, we
 	// should try to clean that up before we start deleting anything at the
 	// driver level.
-	for layer.MountCount > 0 {
+	mountCount, err := r.Mounted(id)
+	if err != nil {
+		return errors.Wrapf(err, "error checking if layer %q is still mounted", id)
+	}
+	for mountCount > 0 {
 		if _, err := r.Unmount(id, false); err != nil {
 			return err
 		}
+		mountCount, err = r.Mounted(id)
+		if err != nil {
+			return errors.Wrapf(err, "error checking if layer %q is still mounted", id)
+		}
 	}
-	err := r.driver.Remove(id)
+	err = r.driver.Remove(id)
 	if err == nil {
 		os.Remove(r.tspath(id))
 		delete(r.byid, id)
@@ -1236,7 +1318,20 @@ func (r *layerStore) Touch() error {
 }
 
 func (r *layerStore) Modified() (bool, error) {
-	return r.lockfile.Modified()
+	var mmodified bool
+	lmodified, err := r.lockfile.Modified()
+	if err != nil {
+		return lmodified, err
+	}
+	if r.IsReadWrite() {
+		r.mountsLockfile.RLock()
+		defer r.mountsLockfile.Unlock()
+		mmodified, err = r.mountsLockfile.Modified()
+		if err != nil {
+			return lmodified, err
+		}
+	}
+	return lmodified || mmodified, nil
 }
 
 func (r *layerStore) IsReadWrite() bool {

--- a/lockfile.go
+++ b/lockfile.go
@@ -35,7 +35,7 @@ type Locker interface {
 	// IsReadWrite() checks if the lock file is read-write
 	IsReadWrite() bool
 
-	// Locked() checks if lock is locked
+	// Locked() checks if lock is locked for writing by a thread in this process
 	Locked() bool
 }
 

--- a/lockfile_unix.go
+++ b/lockfile_unix.go
@@ -32,7 +32,7 @@ func getLockFile(path string, ro bool) (Locker, error) {
 	}
 	return &lockfile{
 		stateMutex: &sync.Mutex{},
-		writeMutex: &sync.Mutex{},
+		rwMutex:    &sync.RWMutex{},
 		file:       path,
 		fd:         uintptr(fd),
 		lw:         stringid.GenerateRandomID(),
@@ -42,10 +42,10 @@ func getLockFile(path string, ro bool) (Locker, error) {
 }
 
 type lockfile struct {
-	// stateMutex is used to synchronize concurrent accesses
+	// rwMutex serializes concurrent reader-writer acquisitions in the same process space
+	rwMutex *sync.RWMutex
+	// stateMutex is used to synchronize concurrent accesses to the state below
 	stateMutex *sync.Mutex
-	// writeMutex is used to serialize and avoid recursive writer locks
-	writeMutex *sync.Mutex
 	counter    int64
 	file       string
 	fd         uintptr
@@ -65,23 +65,21 @@ func (l *lockfile) lock(l_type int16) {
 		Len:    0,
 		Pid:    int32(os.Getpid()),
 	}
-	if l_type == unix.F_WRLCK {
-		// If we try to lock as a writer, lock the writerMutex first to
-		// avoid multiple writer acquisitions of the same process.
-		// Note: it's important to lock it prior to the stateMutex to
-		// avoid a deadlock.
-		l.writeMutex.Lock()
+	if l_type == unix.F_RDLCK {
+		l.rwMutex.RLock()
+	} else {
+		l.rwMutex.Lock()
 	}
 	l.stateMutex.Lock()
-	l.locktype = l_type
 	if l.counter == 0 {
 		// Optimization: only use the (expensive) fcntl syscall when
-		// the counter is 0.  If it's greater than that, we're owning
-		// the lock already and can only be a reader.
+		// the counter is 0.  In this case, we're either the first
+		// reader lock or a writer lock.
 		for unix.FcntlFlock(l.fd, unix.F_SETLKW, &lk) != nil {
 			time.Sleep(10 * time.Millisecond)
 		}
 	}
+	l.locktype = l_type
 	l.locked = true
 	l.counter++
 	l.stateMutex.Unlock()
@@ -133,8 +131,10 @@ func (l *lockfile) Unlock() {
 			time.Sleep(10 * time.Millisecond)
 		}
 	}
-	if l.locktype == unix.F_WRLCK {
-		l.writeMutex.Unlock()
+	if l.locktype == unix.F_RDLCK {
+		l.rwMutex.RUnlock()
+	} else {
+		l.rwMutex.Unlock()
 	}
 	l.stateMutex.Unlock()
 }

--- a/lockfile_unix.go
+++ b/lockfile_unix.go
@@ -139,9 +139,11 @@ func (l *lockfile) Unlock() {
 	l.stateMutex.Unlock()
 }
 
-// Locked checks if lockfile is locked.
+// Locked checks if lockfile is locked for writing by a thread in this process.
 func (l *lockfile) Locked() bool {
-	return l.locked
+	l.stateMutex.Lock()
+	defer l.stateMutex.Unlock()
+	return l.locked && (l.locktype == unix.F_WRLCK)
 }
 
 // Touch updates the lock file with the UID of the user.

--- a/store.go
+++ b/store.go
@@ -1329,7 +1329,7 @@ func (s *store) Metadata(id string) (string, error) {
 	}
 	for _, s := range append([]ROLayerStore{lstore}, lstores...) {
 		store := s
-		store.Lock()
+		store.RLock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
 			if err = store.Load(); err != nil {
@@ -1351,7 +1351,7 @@ func (s *store) Metadata(id string) (string, error) {
 	}
 	for _, s := range append([]ROImageStore{istore}, istores...) {
 		store := s
-		store.Lock()
+		store.RLock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
 			if err = store.Load(); err != nil {
@@ -1367,7 +1367,7 @@ func (s *store) Metadata(id string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	cstore.Lock()
+	cstore.RLock()
 	defer cstore.Unlock()
 	if modified, err := cstore.Modified(); modified || err != nil {
 		if err = cstore.Load(); err != nil {
@@ -1391,7 +1391,7 @@ func (s *store) ListImageBigData(id string) ([]string, error) {
 	}
 	for _, s := range append([]ROImageStore{istore}, istores...) {
 		store := s
-		store.Lock()
+		store.RLock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
 			if err = store.Load(); err != nil {
@@ -1417,7 +1417,7 @@ func (s *store) ImageBigDataSize(id, key string) (int64, error) {
 	}
 	for _, s := range append([]ROImageStore{istore}, istores...) {
 		store := s
-		store.Lock()
+		store.RLock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
 			if err = store.Load(); err != nil {
@@ -1444,7 +1444,7 @@ func (s *store) ImageBigDataDigest(id, key string) (digest.Digest, error) {
 	stores = append([]ROImageStore{ristore}, stores...)
 	for _, r := range stores {
 		ristore := r
-		ristore.Lock()
+		ristore.RLock()
 		defer ristore.Unlock()
 		if modified, err := ristore.Modified(); modified || err != nil {
 			if err = ristore.Load(); err != nil {
@@ -1515,7 +1515,7 @@ func (s *store) ImageSize(id string) (int64, error) {
 	}
 	for _, s := range append([]ROLayerStore{lstore}, lstores...) {
 		store := s
-		store.Lock()
+		store.RLock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
 			if err = store.Load(); err != nil {
@@ -1537,7 +1537,7 @@ func (s *store) ImageSize(id string) (int64, error) {
 	// Look for the image's record.
 	for _, s := range append([]ROImageStore{istore}, istores...) {
 		store := s
-		store.Lock()
+		store.RLock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
 			if err = store.Load(); err != nil {
@@ -1625,7 +1625,7 @@ func (s *store) ContainerSize(id string) (int64, error) {
 	}
 	for _, s := range append([]ROLayerStore{lstore}, lstores...) {
 		store := s
-		store.Lock()
+		store.RLock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
 			if err = store.Load(); err != nil {
@@ -1649,7 +1649,7 @@ func (s *store) ContainerSize(id string) (int64, error) {
 	if err != nil {
 		return -1, err
 	}
-	rcstore.Lock()
+	rcstore.RLock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
 		if err = rcstore.Load(); err != nil {
@@ -1713,7 +1713,7 @@ func (s *store) ListContainerBigData(id string) ([]string, error) {
 		return nil, err
 	}
 
-	rcstore.Lock()
+	rcstore.RLock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
 		if err = rcstore.Load(); err != nil {
@@ -1729,7 +1729,7 @@ func (s *store) ContainerBigDataSize(id, key string) (int64, error) {
 	if err != nil {
 		return -1, err
 	}
-	rcstore.Lock()
+	rcstore.RLock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
 		if err = rcstore.Load(); err != nil {
@@ -1744,7 +1744,7 @@ func (s *store) ContainerBigDataDigest(id, key string) (digest.Digest, error) {
 	if err != nil {
 		return "", err
 	}
-	rcstore.Lock()
+	rcstore.RLock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
 		if err = rcstore.Load(); err != nil {
@@ -1759,7 +1759,7 @@ func (s *store) ContainerBigData(id, key string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	rcstore.Lock()
+	rcstore.RLock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
 		if err = rcstore.Load(); err != nil {
@@ -1795,7 +1795,7 @@ func (s *store) Exists(id string) bool {
 	}
 	for _, s := range append([]ROLayerStore{lstore}, lstores...) {
 		store := s
-		store.Lock()
+		store.RLock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
 			if err = store.Load(); err != nil {
@@ -1817,7 +1817,7 @@ func (s *store) Exists(id string) bool {
 	}
 	for _, s := range append([]ROImageStore{istore}, istores...) {
 		store := s
-		store.Lock()
+		store.RLock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
 			if err = store.Load(); err != nil {
@@ -1833,7 +1833,7 @@ func (s *store) Exists(id string) bool {
 	if err != nil {
 		return false
 	}
-	rcstore.Lock()
+	rcstore.RLock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
 		if err = rcstore.Load(); err != nil {
@@ -1920,7 +1920,7 @@ func (s *store) Names(id string) ([]string, error) {
 	}
 	for _, s := range append([]ROLayerStore{lstore}, lstores...) {
 		store := s
-		store.Lock()
+		store.RLock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
 			if err = store.Load(); err != nil {
@@ -1942,7 +1942,7 @@ func (s *store) Names(id string) ([]string, error) {
 	}
 	for _, s := range append([]ROImageStore{istore}, istores...) {
 		store := s
-		store.Lock()
+		store.RLock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
 			if err = store.Load(); err != nil {
@@ -1958,7 +1958,7 @@ func (s *store) Names(id string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	rcstore.Lock()
+	rcstore.RLock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
 		if err = rcstore.Load(); err != nil {
@@ -1982,7 +1982,7 @@ func (s *store) Lookup(name string) (string, error) {
 	}
 	for _, s := range append([]ROLayerStore{lstore}, lstores...) {
 		store := s
-		store.Lock()
+		store.RLock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
 			if err = store.Load(); err != nil {
@@ -2004,7 +2004,7 @@ func (s *store) Lookup(name string) (string, error) {
 	}
 	for _, s := range append([]ROImageStore{istore}, istores...) {
 		store := s
-		store.Lock()
+		store.RLock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
 			if err = store.Load(); err != nil {
@@ -2020,7 +2020,7 @@ func (s *store) Lookup(name string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	cstore.Lock()
+	cstore.RLock()
 	defer cstore.Unlock()
 	if modified, err := cstore.Modified(); modified || err != nil {
 		if err = cstore.Load(); err != nil {
@@ -2472,7 +2472,7 @@ func (s *store) Mounted(id string) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	rlstore.Lock()
+	rlstore.RLock()
 	defer rlstore.Unlock()
 	if modified, err := rlstore.Modified(); modified || err != nil {
 		if err = rlstore.Load(); err != nil {
@@ -2515,7 +2515,7 @@ func (s *store) Changes(from, to string) ([]archive.Change, error) {
 	}
 	for _, s := range append([]ROLayerStore{lstore}, lstores...) {
 		store := s
-		store.Lock()
+		store.RLock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
 			if err = store.Load(); err != nil {
@@ -2540,7 +2540,7 @@ func (s *store) DiffSize(from, to string) (int64, error) {
 	}
 	for _, s := range append([]ROLayerStore{lstore}, lstores...) {
 		store := s
-		store.Lock()
+		store.RLock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
 			if err = store.Load(); err != nil {
@@ -2620,7 +2620,7 @@ func (s *store) layersByMappedDigest(m func(ROLayerStore, digest.Digest) ([]Laye
 	}
 	for _, s := range append([]ROLayerStore{lstore}, lstores...) {
 		store := s
-		store.Lock()
+		store.RLock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
 			if err = store.Load(); err != nil {
@@ -2667,7 +2667,7 @@ func (s *store) LayerSize(id string) (int64, error) {
 	}
 	for _, s := range append([]ROLayerStore{lstore}, lstores...) {
 		store := s
-		store.Lock()
+		store.RLock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
 			if err = store.Load(); err != nil {
@@ -2686,7 +2686,7 @@ func (s *store) LayerParentOwners(id string) ([]int, []int, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	rlstore.Lock()
+	rlstore.RLock()
 	defer rlstore.Unlock()
 	if modified, err := rlstore.Modified(); modified || err != nil {
 		if err = rlstore.Load(); err != nil {
@@ -2708,14 +2708,14 @@ func (s *store) ContainerParentOwners(id string) ([]int, []int, error) {
 	if err != nil {
 		return nil, nil, err
 	}
-	rlstore.Lock()
+	rlstore.RLock()
 	defer rlstore.Unlock()
 	if modified, err := rlstore.Modified(); modified || err != nil {
 		if err = rlstore.Load(); err != nil {
 			return nil, nil, err
 		}
 	}
-	rcstore.Lock()
+	rcstore.RLock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
 		if err = rcstore.Load(); err != nil {
@@ -2746,7 +2746,7 @@ func (s *store) Layers() ([]Layer, error) {
 
 	for _, s := range append([]ROLayerStore{lstore}, lstores...) {
 		store := s
-		store.Lock()
+		store.RLock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
 			if err = store.Load(); err != nil {
@@ -2775,7 +2775,7 @@ func (s *store) Images() ([]Image, error) {
 	}
 	for _, s := range append([]ROImageStore{istore}, istores...) {
 		store := s
-		store.Lock()
+		store.RLock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
 			if err = store.Load(); err != nil {
@@ -2797,7 +2797,7 @@ func (s *store) Containers() ([]Container, error) {
 		return nil, err
 	}
 
-	rcstore.Lock()
+	rcstore.RLock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
 		if err = rcstore.Load(); err != nil {
@@ -2819,7 +2819,7 @@ func (s *store) Layer(id string) (*Layer, error) {
 	}
 	for _, s := range append([]ROLayerStore{lstore}, lstores...) {
 		store := s
-		store.Lock()
+		store.RLock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
 			if err = store.Load(); err != nil {
@@ -2845,7 +2845,7 @@ func (s *store) Image(id string) (*Image, error) {
 	}
 	for _, s := range append([]ROImageStore{istore}, istores...) {
 		store := s
-		store.Lock()
+		store.RLock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
 			if err = store.Load(); err != nil {
@@ -2878,7 +2878,7 @@ func (s *store) ImagesByTopLayer(id string) ([]*Image, error) {
 	}
 	for _, s := range append([]ROImageStore{istore}, istores...) {
 		store := s
-		store.Lock()
+		store.RLock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
 			if err = store.Load(); err != nil {
@@ -2911,7 +2911,7 @@ func (s *store) ImagesByDigest(d digest.Digest) ([]*Image, error) {
 		return nil, err
 	}
 	for _, store := range append([]ROImageStore{istore}, istores...) {
-		store.Lock()
+		store.RLock()
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
 			if err = store.Load(); err != nil {
@@ -2932,7 +2932,7 @@ func (s *store) Container(id string) (*Container, error) {
 	if err != nil {
 		return nil, err
 	}
-	rcstore.Lock()
+	rcstore.RLock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
 		if err = rcstore.Load(); err != nil {
@@ -2948,7 +2948,7 @@ func (s *store) ContainerLayerID(id string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	rcstore.Lock()
+	rcstore.RLock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
 		if err = rcstore.Load(); err != nil {
@@ -2971,7 +2971,7 @@ func (s *store) ContainerByLayer(id string) (*Container, error) {
 	if err != nil {
 		return nil, err
 	}
-	rcstore.Lock()
+	rcstore.RLock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
 		if err = rcstore.Load(); err != nil {
@@ -2996,7 +2996,7 @@ func (s *store) ContainerDirectory(id string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	rcstore.Lock()
+	rcstore.RLock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
 		if err = rcstore.Load(); err != nil {
@@ -3023,7 +3023,7 @@ func (s *store) ContainerRunDirectory(id string) (string, error) {
 		return "", err
 	}
 
-	rcstore.Lock()
+	rcstore.RLock()
 	defer rcstore.Unlock()
 	if modified, err := rcstore.Modified(); modified || err != nil {
 		if err = rcstore.Load(); err != nil {

--- a/tests/abs.bats
+++ b/tests/abs.bats
@@ -6,4 +6,6 @@ load helpers
 	cd ${TESTDIR}
 	storage --graph tmp1a/deep/root --run tmp1b/deep/runroot layers
 	storage --graph ./tmp2a/deep/root --run ./tmp2b/deep/runroot layers
+	storage --graph tmp1a/deep/root --run tmp1b/deep/runroot shutdown
+	storage --graph ./tmp2a/deep/root --run ./tmp2b/deep/runroot shutdown
 }

--- a/tests/stores.bats
+++ b/tests/stores.bats
@@ -12,10 +12,8 @@ load helpers
 	esac
 	# Initialize a store somewhere that we'll later use as a read-only store.
 	storage --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot layers
-	# Skip this test if we can't initialize the driver with the option.
-	if ! storage --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root layers ; then
-		skip
-	fi
+	# Fail this test if we can't initialize the driver with the option.
+	storage --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root layers
 	# Create a layer in what will become the read-only store.
 	run storage --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot --debug=false create-layer
 	[ "$status" -eq 0 ]


### PR DESCRIPTION
Clarify that our `Locker.Locked()` checks if the calling process is holding a write lock, since that's what we care about in the places where we call it.  Change a number of places where `Store` takes a lock but doesn't expect to be modifying on-disk data to have it take a read-only lock instead.