### PR TITLE
Check if layer is actually mounted if mount count > 0

### DIFF
--- a/drivers/aufs/aufs.go
+++ b/drivers/aufs/aufs.go
@@ -742,3 +742,8 @@ func (a *Driver) UpdateLayerIDMap(id string, toContainer, toHost *idtools.IDMapp
 func (a *Driver) SupportsShifting() bool {
 	return false
 }
+
+// Mounted tells whether the path is mounted
+func (a *Driver) Mounted(path string) (bool, error) {
+	return mountpk.Mounted(path)
+}

--- a/drivers/btrfs/btrfs.go
+++ b/drivers/btrfs/btrfs.go
@@ -685,3 +685,8 @@ func (d *Driver) Exists(id string) bool {
 func (d *Driver) AdditionalImageStores() []string {
 	return nil
 }
+
+// Mounted tells whether the path is mounted
+func (d *Driver) Mounted(path string) (bool, error) {
+	return mount.Mounted(path)
+}

--- a/drivers/devmapper/driver.go
+++ b/drivers/devmapper/driver.go
@@ -242,3 +242,8 @@ func (d *Driver) Exists(id string) bool {
 func (d *Driver) AdditionalImageStores() []string {
 	return nil
 }
+
+// Mounted tells whether the path is mounted
+func (d *Driver) Mounted(path string) (bool, error) {
+	return mount.Mounted(path)
+}

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -100,6 +100,9 @@ type ProtoDriver interface {
 	Cleanup() error
 	// AdditionalImageStores returns additional image stores supported by the driver
 	AdditionalImageStores() []string
+
+	// Mounted tells whether the path is mounted
+	Mounted(path string) (bool, error)
 }
 
 // DiffDriver is the interface to use to implement graph diffs

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -1052,6 +1052,11 @@ func (d *Driver) SupportsShifting() bool {
 	return d.options.mountProgram != ""
 }
 
+// Mounted tells whether the path is mounted
+func (d *Driver) Mounted(path string) (bool, error) {
+	return mount.Mounted(path)
+}
+
 // dumbJoin is more or less a dumber version of filepath.Join, but one which
 // won't Clean() the path, allowing us to append ".." as a component and trust
 // pathname resolution to do some non-obvious work.

--- a/drivers/vfs/driver.go
+++ b/drivers/vfs/driver.go
@@ -219,3 +219,8 @@ func (d *Driver) AdditionalImageStores() []string {
 	}
 	return nil
 }
+
+// Mounted tells whether the path is mounted
+func (d *Driver) Mounted(path string) (bool, error) {
+	return true, nil
+}

--- a/drivers/zfs/zfs.go
+++ b/drivers/zfs/zfs.go
@@ -447,3 +447,8 @@ func (d *Driver) Exists(id string) bool {
 func (d *Driver) AdditionalImageStores() []string {
 	return nil
 }
+
+// Mounted tells whether the path is mounted
+func (d *Driver) Mounted(path string) (bool, error) {
+	return mount.Mounted(path)
+}

--- a/layers.go
+++ b/layers.go
@@ -745,8 +745,16 @@ func (r *layerStore) Mount(id string, options drivers.MountOpts) (string, error)
 		return "", ErrLayerUnknown
 	}
 	if layer.MountCount > 0 {
-		layer.MountCount++
-		return layer.MountPoint, r.saveMounts()
+		mounted, err := r.driver.Mounted(layer.MountPoint)
+		if err != nil {
+			return "", err
+		}
+		if mounted {
+			layer.MountCount++
+			return layer.MountPoint, r.saveMounts()
+		} else {
+			layer.MountCount = 0
+		}
 	}
 	if options.MountLabel == "" {
 		options.MountLabel = layer.MountLabel


### PR DESCRIPTION
We have an issue with zfs on reboots getting this data wrong.

You can cause this situation also if someone goes out an umounts
a mount point manually.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>