### PR TITLE
reexec: add CommandContext()

### DIFF
--- a/pkg/reexec/command_linux.go
+++ b/pkg/reexec/command_linux.go
@@ -3,6 +3,7 @@
 package reexec
 
 import (
+	"context"
 	"os/exec"
 	"syscall"
 
@@ -20,11 +21,23 @@ func Self() string {
 // This will use the in-memory version (/proc/self/exe) of the current binary,
 // it is thus safe to delete or replace the on-disk binary (os.Args[0]).
 func Command(args ...string) *exec.Cmd {
-	return &exec.Cmd{
-		Path: Self(),
-		Args: args,
-		SysProcAttr: &syscall.SysProcAttr{
-			Pdeathsig: unix.SIGTERM,
-		},
+	cmd := exec.Command(Self())
+	cmd.Args = args
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Pdeathsig: unix.SIGTERM,
 	}
+	return cmd
+}
+
+// CommandContext returns *exec.Cmd which has Path as current binary, and also
+// sets SysProcAttr.Pdeathsig to SIGTERM.
+// This will use the in-memory version (/proc/self/exe) of the current binary,
+// it is thus safe to delete or replace the on-disk binary (os.Args[0]).
+func CommandContext(ctx context.Context, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, Self())
+	cmd.Args = args
+	cmd.SysProcAttr = &syscall.SysProcAttr{
+		Pdeathsig: unix.SIGTERM,
+	}
+	return cmd
 }

--- a/pkg/reexec/command_unix.go
+++ b/pkg/reexec/command_unix.go
@@ -3,6 +3,7 @@
 package reexec
 
 import (
+	"context"
 	"os/exec"
 )
 
@@ -16,8 +17,14 @@ func Self() string {
 // For example if current binary is "docker" at "/usr/bin/", then cmd.Path will
 // be set to "/usr/bin/docker".
 func Command(args ...string) *exec.Cmd {
-	return &exec.Cmd{
-		Path: Self(),
-		Args: args,
-	}
+	cmd := exec.Command(Self())
+	cmd.Args = args
+	return cmd
+}
+
+// CommandContext returns *exec.Cmd which has Path as current binary.
+func CommandContext(ctx context.Context, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, Self())
+	cmd.Args = args
+	return cmd
 }

--- a/pkg/reexec/command_unsupported.go
+++ b/pkg/reexec/command_unsupported.go
@@ -3,10 +3,16 @@
 package reexec
 
 import (
+	"context"
 	"os/exec"
 )
 
 // Command is unsupported on operating systems apart from Linux, Windows, Solaris and Darwin.
 func Command(args ...string) *exec.Cmd {
+	return nil
+}
+
+// CommandContext is unsupported on operating systems apart from Linux, Windows, Solaris and Darwin.
+func CommandContext(ctx context.Context, args ...string) *exec.Cmd {
 	return nil
 }

--- a/pkg/reexec/command_windows.go
+++ b/pkg/reexec/command_windows.go
@@ -3,6 +3,7 @@
 package reexec
 
 import (
+	"context"
 	"os/exec"
 )
 
@@ -16,8 +17,16 @@ func Self() string {
 // For example if current binary is "docker.exe" at "C:\", then cmd.Path will
 // be set to "C:\docker.exe".
 func Command(args ...string) *exec.Cmd {
-	return &exec.Cmd{
-		Path: Self(),
-		Args: args,
-	}
+	cmd := exec.Command(Self())
+	cmd.Args = args
+	return cmd
+}
+
+// Command returns *exec.Cmd which has Path as current binary.
+// For example if current binary is "docker.exe" at "C:\", then cmd.Path will
+// be set to "C:\docker.exe".
+func CommandContext(ctx context.Context, args ...string) *exec.Cmd {
+	cmd := exec.CommandContext(ctx, Self())
+	cmd.Args = args
+	return cmd
 }

--- a/pkg/reexec/reexec_test.go
+++ b/pkg/reexec/reexec_test.go
@@ -1,17 +1,28 @@
 package reexec
 
 import (
+	"bytes"
+	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"testing"
+	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
+const sleepMessage = "sleeping"
+
 func init() {
 	Register("reexec", func() {
 		panic("Return Error")
+	})
+	Register("sleep", func() {
+		fmt.Printf(sleepMessage)
+		time.Sleep(time.Hour)
+		fmt.Printf("\nfinished " + sleepMessage)
 	})
 	Init()
 }
@@ -35,6 +46,25 @@ func TestCommand(t *testing.T) {
 	require.NoError(t, err, "Error on re-exec cmd: %v", err)
 	err = cmd.Wait()
 	require.EqualError(t, err, "exit status 2")
+}
+
+func TestCommandContext(t *testing.T) {
+	stdout := &bytes.Buffer{}
+
+	ctx, _ := context.WithDeadline(context.TODO(), time.Now().Add(5*time.Second))
+	cmd := CommandContext(ctx, "sleep")
+	w, err := cmd.StdinPipe()
+	require.NoError(t, err, "Error on pipe creation: %v", err)
+	defer w.Close()
+	cmd.Stdout = stdout
+
+	started := time.Now()
+	err = cmd.Start()
+	require.NoError(t, err, "Error on re-exec cmd: %v", err)
+	err = cmd.Wait()
+	require.NotNil(t, err, "Expected an error when the deadline was exceeded.")
+	require.True(t, time.Since(started) < time.Hour/2, "Subprocess runtime exceeded deadline.")
+	require.Equal(t, stdout.String(), sleepMessage, "error setting args for child process")
 }
 
 func TestNaiveSelf(t *testing.T) {


### PR DESCRIPTION
Add `CommandContext()`, which is like `Command()`, but which also takes a context, very much in keeping with `os/exec.CommandContext()`.