### PR TITLE
storage: make [l]chown errors clearer

### DIFF
--- a/drivers/copy/copy.go
+++ b/drivers/copy/copy.go
@@ -19,6 +19,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/pools"
 	"github.com/containers/storage/pkg/system"
 	rsystem "github.com/opencontainers/runc/libcontainer/system"
@@ -212,7 +213,7 @@ func DirCopy(srcDir, dstDir string, copyMode Mode, copyXattrs bool) error {
 			return nil
 		}
 
-		if err := os.Lchown(dstPath, int(stat.Uid), int(stat.Gid)); err != nil {
+		if err := idtools.SafeLchown(dstPath, int(stat.Uid), int(stat.Gid)); err != nil {
 			return err
 		}
 

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -636,7 +636,7 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, L
 		if chownOpts == nil {
 			chownOpts = &idtools.IDPair{UID: hdr.Uid, GID: hdr.Gid}
 		}
-		if err := os.Lchown(path, chownOpts.UID, chownOpts.GID); err != nil {
+		if err := idtools.SafeLchown(path, chownOpts.UID, chownOpts.GID); err != nil {
 			return err
 		}
 	}

--- a/pkg/archive/archive_linux.go
+++ b/pkg/archive/archive_linux.go
@@ -7,6 +7,7 @@ import (
 	"strings"
 	"syscall"
 
+	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/system"
 	"golang.org/x/sys/unix"
 )
@@ -130,7 +131,7 @@ func (overlayWhiteoutConverter) ConvertRead(hdr *tar.Header, path string) (bool,
 		if err := unix.Mknod(originalPath, unix.S_IFCHR, 0); err != nil {
 			return false, err
 		}
-		if err := os.Chown(originalPath, hdr.Uid, hdr.Gid); err != nil {
+		if err := idtools.SafeChown(originalPath, hdr.Uid, hdr.Gid); err != nil {
 			return false, err
 		}
 

--- a/pkg/idtools/idtools.go
+++ b/pkg/idtools/idtools.go
@@ -7,6 +7,9 @@ import (
 	"sort"
 	"strconv"
 	"strings"
+	"syscall"
+
+	"github.com/pkg/errors"
 )
 
 // IDMap contains a single entry for user namespace range remapping. An array
@@ -276,4 +279,19 @@ func parseSubidFile(path, username string) (ranges, error) {
 		}
 	}
 	return rangeList, nil
+}
+
+func checkChownErr(err error, name string, uid, gid int) error {
+	if e, ok := err.(*os.PathError); ok && e.Err == syscall.EINVAL {
+		return errors.Wrapf(err, "there might not be enough IDs available in the namespace (requested %d:%d for %s)", uid, gid, name)
+	}
+	return err
+}
+
+func SafeChown(name string, uid, gid int) error {
+	return checkChownErr(os.Chown(name, uid, gid), name, uid, gid)
+}
+
+func SafeLchown(name string, uid, gid int) error {
+	return checkChownErr(os.Lchown(name, uid, gid), name, uid, gid)
 }

--- a/pkg/idtools/idtools_unix.go
+++ b/pkg/idtools/idtools_unix.go
@@ -30,7 +30,7 @@ func mkdirAs(path string, mode os.FileMode, ownerUID, ownerGID int, mkAll, chown
 		paths = []string{path}
 	} else if err == nil && chownExisting {
 		// short-circuit--we were called with an existing directory and chown was requested
-		return os.Chown(path, ownerUID, ownerGID)
+		return SafeChown(path, ownerUID, ownerGID)
 	} else if err == nil {
 		// nothing to do; directory path fully exists already and chown was NOT requested
 		return nil
@@ -60,7 +60,7 @@ func mkdirAs(path string, mode os.FileMode, ownerUID, ownerGID int, mkAll, chown
 	// even if it existed, we will chown the requested path + any subpaths that
 	// didn't exist when we called MkdirAll
 	for _, pathComponent := range paths {
-		if err := os.Chown(pathComponent, ownerUID, ownerGID); err != nil {
+		if err := SafeChown(pathComponent, ownerUID, ownerGID); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
if os.[Lc,C]hown are failing with EINVAL, it might be related to an
UID/GID not mapped in the user namespace we are currently using.

It could be possible to detect this issue by inspecting
/proc/self/uid_map or /proc/self/gid_map, but that won't be possible
when we are pulling a new image and extracting it from a chroot where
/proc is not mounted.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>