### PR TITLE
Add build tag to exclude vfs driver

### DIFF
--- a/drivers/register/register_vfs.go
+++ b/drivers/register/register_vfs.go
@@ -1,3 +1,5 @@
+// +build !exclude_graphdriver_vfs
+
 package register
 
 import (


### PR DESCRIPTION
This commit adds a build flag exclude_graphdriver_vfs to allow for
excluding the vfs driver in the same way that this is currently
supported for devicemapper, aufs, overlay, btrfs, and zfs.

This was the one driver lacking this support which was preventing
me from using containers/image (and deps) in a build with CGO_ENABLED=0

Signed-off-by: Scott Seago <sseago@redhat.com>