### PR TITLE
drivers/copy: add a non-cgo fallback

### DIFF
--- a/drivers/copy/copy_linux.go
+++ b/drivers/copy/copy_linux.go
@@ -1,4 +1,4 @@
-// +build linux
+// +build cgo
 
 package copy
 

--- a/drivers/copy/copy_unsupported.go
+++ b/drivers/copy/copy_unsupported.go
@@ -1,0 +1,19 @@
+// +build !linux !cgo
+
+package copy
+
+import "github.com/containers/storage/pkg/chrootarchive"
+
+// Mode indicates whether to use hardlink or copy content
+type Mode int
+
+const (
+	// Content creates a new file, and copies the content of the file
+	Content Mode = iota
+)
+
+// DirCopy copies or hardlinks the contents of one directory to another,
+// properly handling soft links
+func DirCopy(srcDir, dstDir string, _ Mode, _ bool) error {
+	return chrootarchive.NewArchiver(nil).CopyWithTar(srcDir, dstDir)
+}


### PR DESCRIPTION
The vfs driver already has logic that avoids use of the copy package when we're not on Linux, so provide the same fallback in the copy package for non-cgo cases.