### PR TITLE
Add FILES section to containers-storage.5 man page

### DIFF
--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,6 +1,9 @@
 GOMD2MAN = go-md2man
 
-docs: $(patsubst %.md,%.1,$(wildcard *.md))
+docs: $(patsubst %.md,%.1,$(wildcard *.md)) container-storage.conf.5
 
 %.1: %.md
+	$(GOMD2MAN) -in $^ -out $@
+
+container-storage.conf.5: containers-storage.conf.5.md
 	$(GOMD2MAN) -in $^ -out $@

--- a/docs/containers-storage.conf.5.md
+++ b/docs/containers-storage.conf.5.md
@@ -1,16 +1,16 @@
-% storage.conf(5) Container Storage Configuration File
+% containers-storage.conf(5) Container Storage Configuration File
 % Dan Walsh
 % May 2017
 
 # NAME
 storage.conf - Syntax of Container Storage configuration file
 
-# DESCRIPTION
+## DESCRIPTION
 The STORAGE configuration file specifies all of the available container storage options
 for tools using shared container storage, but in a TOML format that can be more easily modified
 and versioned.
 
-# FORMAT
+## FORMAT
 The [TOML format][toml] is used as the encoding of the configuration file.
 Every option and subtable listed here is nested under a global "storage" table.
 No bare options are used. The format of TOML can be simplified to:
@@ -154,6 +154,10 @@ with the correct label.
 ## SEE ALSO
 `semanage(8)`, `restorecon(8)`
 
-# HISTORY
+## FILES
+
+Distributions often provide a /usr/share/containers/storage.conf file to define default storage configuration. Administrators can override this file by creating `/etc/containers/storage.conf` to specify their own configuration. The storage.conf file for rootless users is stored in the $HOME/.config/containers/storage.conf file.
+
+## HISTORY
 May 2017, Originally compiled by Dan Walsh <dwalsh@redhat.com>
 Format copied from crio.conf man page created by Aleksa Sarai <asarai@suse.de>


### PR DESCRIPTION
This helps users figure out where the configuration files are located
and understand how to override them.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>