### PR TITLE
storage: move the logic to detect rootless into utils.go

### DIFF
--- a/cmd/containers-storage/main.go
+++ b/cmd/containers-storage/main.go
@@ -67,7 +67,7 @@ func main() {
 	}
 
 	if options.GraphRoot == "" && options.RunRoot == "" && options.GraphDriverName == "" && len(options.GraphDriverOptions) == 0 {
-		options, _ = storage.DefaultStoreOptions(false, 0)
+		options, _ = storage.DefaultStoreOptionsAutoDetectUID()
 	}
 	args := flags.Args()
 	if len(args) < 1 {

--- a/utils.go
+++ b/utils.go
@@ -6,6 +6,7 @@ import (
 	"os/exec"
 	"os/user"
 	"path/filepath"
+	"strconv"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -156,6 +157,21 @@ func getTomlStorage(storeOptions *StoreOptions) *tomlConfig {
 	}
 
 	return config
+}
+
+func getRootlessUID() int {
+	uidEnv := os.Getenv("_CONTAINERS_ROOTLESS_UID")
+	if uidEnv != "" {
+		u, _ := strconv.Atoi(uidEnv)
+		return u
+	}
+	return os.Geteuid()
+}
+
+// DefaultStoreOptionsAutoDetectUID returns the default storage ops for containers
+func DefaultStoreOptionsAutoDetectUID() (StoreOptions, error) {
+	uid := getRootlessUID()
+	return DefaultStoreOptions(uid != 0, uid)
 }
 
 // DefaultStoreOptions returns the default storage ops for containers


### PR DESCRIPTION
do not expect the caller to know what rootless user is used, but
detect it internally.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>