### PR TITLE
runroot: add check that it is on volatile storage

### DIFF
--- a/errors.go
+++ b/errors.go
@@ -53,4 +53,6 @@ var (
 	ErrDigestUnknown = errors.New("could not compute digest of item")
 	// ErrLayerNotMounted is returned when the requested information can only be computed for a mounted layer, and the layer is not mounted.
 	ErrLayerNotMounted = errors.New("layer is not mounted")
+	// ErrTargetNotVolatile is returned when a path must be on volatile storage.
+	ErrTargetNotVolatile = errors.New("the target is not on tmpfs")
 )

--- a/store_linux.go
+++ b/store_linux.go
@@ -1,0 +1,29 @@
+package storage
+
+import (
+	"os"
+
+	"github.com/containers/storage/drivers"
+	"github.com/pkg/errors"
+)
+
+func isOnVolatileStorage(target string) (bool, error) {
+	magic, err := graphdriver.GetFSMagic(target)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return true, nil
+		}
+		return false, err
+	}
+	return magic == graphdriver.FsMagicTmpFs, nil
+}
+
+func validateRunRoot(runRoot string) error {
+	if onTmpfs, err := isOnVolatileStorage(runRoot); err != nil || !onTmpfs {
+		if err != nil {
+			return errors.Wrapf(err, "cannot check if %s is on tmpfs", runRoot)
+		}
+		return errors.Wrapf(ErrTargetNotVolatile, "%s must be on tmpfs", runRoot)
+	}
+	return nil
+}

--- a/store_unsupported.go
+++ b/store_unsupported.go
@@ -1,0 +1,7 @@
+// +build !linux
+
+package storage
+
+func validateRunRoot(runRoot string) error {
+	return nil
+}


### PR DESCRIPTION
Make sure the runroot won't persist after a reboot, if it happens then
we can carry wrong information on the current active mounts.

Closes: https://github.com/containers/libpod/issues/2150

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>