### PR TITLE
Correctly check permissions on rootless directory

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -74,7 +74,7 @@ func GetRootlessRuntimeDir(rootlessUid int) (string, error) {
 	if runtimeDir == "" {
 		tmpDir := fmt.Sprintf("/run/user/%d", rootlessUid)
 		st, err := system.Stat(tmpDir)
-		if err == nil && int(st.UID()) == os.Getuid() && st.Mode() == 0700 {
+		if err == nil && int(st.UID()) == os.Getuid() && st.Mode()&0700 == 0700 && st.Mode()&0066 == 0000 {
 			return tmpDir, nil
 		}
 	}


### PR DESCRIPTION
We have not been checking the permissions on the rootless directory
this causes issues in tools trying to access the login directory
if XDG_RUNTIME_DIR is not set correctly.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>