### PR TITLE
docs: fix manpage for configuration file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -14,7 +14,7 @@ RUNINVM := vagrant/runinvm.sh
 default all: local-binary docs local-validate local-cross local-gccgo test-unit test-integration ## validate all checks, build and cross-build\nbinaries and docs, run tests in a VM
 
 clean: ## remove all built files
-	$(RM) -f containers-storage containers-storage.* docs/*.1
+	$(RM) -f containers-storage containers-storage.* docs/*.1 docs/*.5
 
 sources := $(wildcard *.go cmd/containers-storage/*.go drivers/*.go drivers/*/*.go pkg/*/*.go pkg/*/*/*.go) layers_ffjson.go images_ffjson.go containers_ffjson.go pkg/archive/archive_ffjson.go
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,9 +1,9 @@
 GOMD2MAN = go-md2man
 
-docs: $(patsubst %.md,%.1,$(wildcard *.md)) container-storage.conf.5
+docs: $(patsubst %.md,%.1,$(wildcard *.md)) containers-storage.conf.5
 
 %.1: %.md
 	$(GOMD2MAN) -in $^ -out $@
 
-container-storage.conf.5: containers-storage.conf.5.md
+containers-storage.conf.5: containers-storage.conf.5.md
 	$(GOMD2MAN) -in $^ -out $@

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,6 +1,6 @@
 GOMD2MAN = go-md2man
 
-docs: $(patsubst %.md,%.1,$(wildcard *.md)) containers-storage.conf.5
+docs: $(patsubst %.md,%.1,$(filter-out %.5.md,$(wildcard *.md))) containers-storage.conf.5
 
 %.1: %.md
 	$(GOMD2MAN) -in $^ -out $@


### PR DESCRIPTION
Manpage for storage.conf is being built as 'container-storage.conf.5'
(notice the missing 's' after 'container'), but it should be
'containers-storage.conf.5' for consistency with the whole project
naming.

Closes #329

Signed-off-by: Silvano Cirujano Cuesta <silvano.cirujano-cuesta@siemens.com>