### PR TITLE
Add MountTemp and RemoveTemp interfaces

### DIFF
--- a/cmd/containers-storage/container.go
+++ b/cmd/containers-storage/container.go
@@ -165,6 +165,25 @@ func setContainerBigData(flags *mflag.FlagSet, action string, m storage.Store, a
 	return 0
 }
 
+func MountTemp(flags *mflag.FlagSet, action string, m storage.Store, args []string) int {
+	mountpoint, err := m.MountTemp(args[0], args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
+		return 1
+	}
+	fmt.Fprintf(os.Stdout, "%s\n", mountpoint)
+	return 0
+}
+
+func RemoveTemp(flags *mflag.FlagSet, action string, m storage.Store, args []string) int {
+
+	if err := m.RemoveTemp(args[0]); err != nil {
+		fmt.Fprintf(os.Stderr, "%+v\n", err)
+		return 1
+	}
+	return 0
+}
+
 func getContainerDir(flags *mflag.FlagSet, action string, m storage.Store, args []string) int {
 	path, err := m.ContainerDirectory(args[0])
 	if err != nil {
@@ -305,5 +324,19 @@ func init() {
 			addFlags: func(flags *mflag.FlagSet, cmd *command) {
 				flags.BoolVar(&jsonOutput, []string{"-json", "j"}, jsonOutput, "Prefer JSON output")
 			},
+		},
+		command{
+			names:       []string{"mount-temp"},
+			optionsHelp: "[options [...]] containerNameOrID srcdir",
+			usage:       "Mount srcdir for use by the container",
+			action:      MountTemp,
+			minArgs:     2,
+		},
+		command{
+			names:       []string{"remove-temp"},
+			optionsHelp: "[options [...]] mountdir",
+			usage:       "Remove mount from use by the container",
+			action:      RemoveTemp,
+			minArgs:     1,
 		})
 }

--- a/drivers/aufs/aufs.go
+++ b/drivers/aufs/aufs.go
@@ -742,3 +742,16 @@ func (a *Driver) UpdateLayerIDMap(id string, toContainer, toHost *idtools.IDMapp
 func (a *Driver) SupportsShifting() bool {
 	return false
 }
+
+// MountTemp creates a subdir of the contentDir based on the source directory
+// from the source system.  It then mounds up the source directory on to the
+// generated mount point and returns the mount point to the caller.
+func (a *Driver) MountTemp(contentdir, source, mountLabel string) (string, error) {
+	return "", fmt.Errorf("aufs driver does not support mount temp options")
+}
+
+// RemoveTemp removes temporary mountpoint and all content from its parent
+// directory
+func (a *Driver) RemoveTemp(mountpoint string) error {
+	return fmt.Errorf("aufs driver does not support mount temp options")
+}

--- a/drivers/btrfs/btrfs.go
+++ b/drivers/btrfs/btrfs.go
@@ -685,3 +685,16 @@ func (d *Driver) Exists(id string) bool {
 func (d *Driver) AdditionalImageStores() []string {
 	return nil
 }
+
+// MountTemp creates a subdir of the contentDir based on the source directory
+// from the source system.  It then mounds up the source directory on to the
+// generated mount point and returns the mount point to the caller.
+func (d *Driver) MountTemp(contentdir, source, mountLabel string) (string, error) {
+	return "", fmt.Errorf("btrfs driver does not support mount temp options")
+}
+
+// RemoveTemp removes temporary mountpoint and all content from its parent
+// directory
+func (d *Driver) RemoveTemp(source string) error {
+	return fmt.Errorf("btrfs driver does not support mount temp options")
+}

--- a/drivers/devmapper/driver.go
+++ b/drivers/devmapper/driver.go
@@ -242,3 +242,15 @@ func (d *Driver) Exists(id string) bool {
 func (d *Driver) AdditionalImageStores() []string {
 	return nil
 }
+
+// MountTemp mounts a source directory from the host using
+// graphdriver and returns the mountpoint
+func (d *Driver) MountTemp(id, source, mountLabel string) (string, error) {
+	return "", fmt.Errorf("devmapper driver does not support mount temp options")
+}
+
+// RemoveTemp removes temporary mountpoint and all content from its parent
+// directory
+func (d *Driver) RemoveTemp(mountpoint string) error {
+	return fmt.Errorf("devmapper driver does not support mount temp options")
+}

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -100,6 +100,13 @@ type ProtoDriver interface {
 	Cleanup() error
 	// AdditionalImageStores returns additional image stores supported by the driver
 	AdditionalImageStores() []string
+
+	// MountTemp mounts a source directory from the host using
+	// graphdriver and returns the mountpoint
+	MountTemp(sourcedir, source, mountLabel string) (string, error)
+
+	// RemoveTemp removes temporary mountpoint from host using graphdriver
+	RemoveTemp(mountpoint string) error
 }
 
 // DiffDriver is the interface to use to implement graph diffs

--- a/drivers/vfs/driver.go
+++ b/drivers/vfs/driver.go
@@ -219,3 +219,16 @@ func (d *Driver) AdditionalImageStores() []string {
 	}
 	return nil
 }
+
+// MountTemp creates a subdir of the contentDir based on the source directory
+// from the source system.  It then mounds up the source directory on to the
+// generated mount point and returns the mount point to the caller.
+func (a *Driver) MountTemp(contentdir, source, mountLabel string) (string, error) {
+	return "", fmt.Errorf("vfs driver does not support mount temp options")
+}
+
+// RemoveTemp removes temporary mountpoint and all content from its parent
+// directory
+func (d *Driver) RemoveTemp(mountpoint string) error {
+	return fmt.Errorf("vfs driver does not support mount temp options")
+}

--- a/drivers/zfs/zfs.go
+++ b/drivers/zfs/zfs.go
@@ -447,3 +447,16 @@ func (d *Driver) Exists(id string) bool {
 func (d *Driver) AdditionalImageStores() []string {
 	return nil
 }
+
+// MountTemp creates a subdir of the contentDir based on the source directory
+// from the source system.  It then mounds up the source directory on to the
+// generated mount point and returns the mount point to the caller.
+func (d *Driver) MountTemp(contentdir, source, mountLabel string) (string, error) {
+	return "", fmt.Errorf("zfs driver does not support mount temp options")
+}
+
+// RemoveTemp removes temporary mountpoint and all content from its parent
+// directory
+func (d *Driver) RemoveTemp(mountpoint string) error {
+	return fmt.Errorf("zfs driver does not support mount temp options")
+}

--- a/store.go
+++ b/store.go
@@ -446,6 +446,15 @@ type Store interface {
 	// GID maps (if any are defined) don't contain corresponding IDs.
 	ContainerParentOwners(id string) ([]int, []int, error)
 
+	// MountTemp creates a temporarily mount of a source directory from the
+	// host using graphdriver in the container `id` private storage.
+	// MountTemp then mounts up the storage on the system and returns
+	// the mountpoint
+	MountTemp(id, source string) (string, error)
+
+	// RemoveTemp removes temporary mountpoint and any content written to it
+	RemoveTemp(mountpoint string) error
+
 	// Lookup returns the ID of a layer, image, or container with the specified
 	// name or ID.
 	Lookup(name string) (string, error)
@@ -1453,6 +1462,47 @@ func (s *store) ImageBigDataSize(id, key string) (int64, error) {
 		}
 	}
 	return -1, ErrSizeUnknown
+}
+
+func (s *store) MountTemp(id, source string) (string, error) {
+	rcstore, err := s.ContainerStore()
+	if err != nil {
+		return "", err
+	}
+	rcstore.RLock()
+	defer rcstore.Unlock()
+	container, err := rcstore.Get(id)
+	if err != nil {
+		return "", err
+	}
+	if modified, err := rcstore.Modified(); modified || err != nil {
+		if err = rcstore.Load(); err != nil {
+			return "", err
+		}
+	}
+	driver, err := s.GraphDriver()
+	if err != nil {
+		return "", err
+	}
+	middleDir := s.graphDriverName + "-containers"
+	sourcedir := filepath.Join(s.GraphRoot(), middleDir, id, strings.Replace(source, "/", "_", -1))
+
+	return driver.MountTemp(sourcedir, source, container.MountLabel())
+}
+
+func (s *store) RemoveTemp(source string) error {
+	rcstore, err := s.ContainerStore()
+	if err != nil {
+		return err
+	}
+	rcstore.RLock()
+	defer rcstore.Unlock()
+	driver, err := s.GraphDriver()
+	if err != nil {
+		return err
+	}
+
+	return driver.RemoveTemp(source)
 }
 
 func (s *store) ImageBigDataDigest(id, key string) (digest.Digest, error) {


### PR DESCRIPTION
These interfaces can be used to setup a graphdriver mountpoint
of the source directory for use within a container.
The RemoveTemp interface umounts the mountpoint and then removes
all of the modified data in the graphdriver for this source directory.

The primary use case of these interfaces is for container engines that
want to mount a directory from the host system into the container. The
source dirctory then can be modified without actually changing the
directory on the host.

Containers will use these interfaces for sharing packaing cache directories
like /var/cache/dnf, to help speed up container builds.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>