### PR TITLE
layers: use the correct idmapping when creating a layer

### DIFF
--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -40,6 +40,7 @@ var (
 type CreateOpts struct {
 	MountLabel string
 	StorageOpt map[string]string
+	*idtools.IDMappings
 }
 
 // MountOpts contains optional arguments for LayerStope.Mount() methods.

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -474,7 +474,15 @@ func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) (retErr
 func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts) (retErr error) {
 	dir := d.dir(id)
 
-	rootUID, rootGID, err := idtools.GetRootUIDGID(d.uidMaps, d.gidMaps)
+	uidMaps := d.uidMaps
+	gidMaps := d.gidMaps
+
+	if opts.IDMappings {
+		uidMaps = opts.IDMappings.UIDs()
+		gidMaps = opts.IDMappings.GIDs()
+	}
+
+	rootUID, rootGID, err := idtools.GetRootUIDGID(uidMaps, gidMaps)
 	if err != nil {
 		return err
 	}

--- a/drivers/vfs/driver.go
+++ b/drivers/vfs/driver.go
@@ -123,8 +123,13 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts, ro bool
 		return fmt.Errorf("--storage-opt is not supported for vfs")
 	}
 
+	idMappings := opts.IDMappings()
+	if idMappings == nil {
+		idMappings = d.idMappings
+	}
+
 	dir := d.dir(id)
-	rootIDs := d.idMappings.RootPair()
+	rootIDs := idMappings.RootPair()
 	if err := idtools.MkdirAllAndChown(filepath.Dir(dir), 0700, rootIDs); err != nil {
 		return err
 	}

--- a/layers.go
+++ b/layers.go
@@ -614,6 +614,7 @@ func (r *layerStore) Put(id string, parentLayer *Layer, names []string, mountLab
 	opts := drivers.CreateOpts{
 		MountLabel: mountLabel,
 		StorageOpt: options,
+		IDMappings: idMappings,
 	}
 	if moreOptions.TemplateLayer != "" {
 		if err = r.driver.CreateFromTemplate(id, moreOptions.TemplateLayer, templateIDMappings, parent, parentMappings, &opts, writeable); err != nil {


### PR DESCRIPTION
prefer the custom idmapping specified for the layer instead of using the global one configured for the driver.

Closes: https://github.com/containers/libpod/issues/2960
