### PR TITLE
CreateContainer: don't worry about mapping layers unless necessary

### DIFF
--- a/cmd/containers-storage/create.go
+++ b/cmd/containers-storage/create.go
@@ -148,10 +148,7 @@ func createImage(flags *mflag.FlagSet, action string, m storage.Store, args []st
 		}
 		paramMetadata = string(b)
 	}
-	layer := ""
-	if len(args) > 0 {
-		layer = args[0]
-	}
+	layer := args[0]
 	imageOptions := &storage.ImageOptions{
 		Digest: digest.Digest(paramDigest),
 	}
@@ -191,7 +188,8 @@ func createContainer(flags *mflag.FlagSet, action string, m storage.Store, args 
 		return 1
 	}
 	options := &storage.ContainerOptions{IDMappingOptions: *mappings}
-	container, err := m.CreateContainer(paramID, paramNames, args[0], paramLayer, paramMetadata, options)
+	image := args[0]
+	container, err := m.CreateContainer(paramID, paramNames, image, paramLayer, paramMetadata, options)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "%+v\n", err)
 		return 1
@@ -253,7 +251,7 @@ func init() {
 		names:       []string{"create-image", "createimage"},
 		optionsHelp: "[options [...]] topLayerNameOrID",
 		usage:       "Create a new image using layers",
-		minArgs:     0,
+		minArgs:     1,
 		maxArgs:     1,
 		action:      createImage,
 		addFlags: func(flags *mflag.FlagSet, cmd *command) {

--- a/store.go
+++ b/store.go
@@ -1197,18 +1197,20 @@ func (s *store) CreateContainer(id string, names []string, image, layer, metadat
 		}
 		imageID = cimage.ID
 
-		createMappedLayer := imageHomeStore == istore
+		if cimage.TopLayer != "" {
+			createMappedLayer := imageHomeStore == istore
+			ilayer, err := s.imageTopLayerForMapping(cimage, imageHomeStore, createMappedLayer, rlstore, lstores, idMappingsOptions)
+			if err != nil {
+				return nil, err
+			}
+			imageTopLayer = ilayer
 
-		ilayer, err := s.imageTopLayerForMapping(cimage, imageHomeStore, createMappedLayer, rlstore, lstores, idMappingsOptions)
-		if err != nil {
-			return nil, err
-		}
-		imageTopLayer = ilayer
-		if !options.HostUIDMapping && len(options.UIDMap) == 0 {
-			uidMap = ilayer.UIDMap
-		}
-		if !options.HostGIDMapping && len(options.GIDMap) == 0 {
-			gidMap = ilayer.GIDMap
+			if !options.HostUIDMapping && len(options.UIDMap) == 0 {
+				uidMap = ilayer.UIDMap
+			}
+			if !options.HostGIDMapping && len(options.GIDMap) == 0 {
+				gidMap = ilayer.GIDMap
+			}
 		}
 	} else {
 		rlstore.Lock()

--- a/tests/create-container.bats
+++ b/tests/create-container.bats
@@ -3,6 +3,25 @@
 load helpers
 
 @test "create-container" {
+	# Create a container based on no image.
+	run storage --debug=false create-container ""
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	zerothcontainer=${output%%	*}
+
+	# Create an image using no layer.
+	run storage --debug=false create-image ""
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	image=${output%%	*}
+
+	# Create a container based on that image.
+	run storage --debug=false create-container $image
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	thirdcontainer=${output%%	*}
+
 	# Create a layer.
 	run storage --debug=false create-layer
 	[ "$status" -eq 0 ]
@@ -37,8 +56,15 @@ load helpers
 	run storage --debug=false containers
 	echo :"$output":
 	[ "$status" -eq 0 ]
-	[ "${#lines[*]}" -eq 2 ]
+	[ "${#lines[*]}" -eq 4 ]
 	[ "${lines[0]}" != "${lines[1]}" ]
-	[ "${lines[0]}" = "$firstcontainer" ] || [ "${lines[0]}" = "$secondcontainer" ]
-	[ "${lines[1]}" = "$firstcontainer" ] || [ "${lines[1]}" = "$secondcontainer" ]
+	[ "${lines[0]}" != "${lines[2]}" ]
+	[ "${lines[0]}" != "${lines[3]}" ]
+	[ "${lines[1]}" != "${lines[2]}" ]
+	[ "${lines[1]}" != "${lines[3]}" ]
+	[ "${lines[2]}" != "${lines[3]}" ]
+	[ "${lines[0]}" = "$zerothcontainer" ] || [ "${lines[0]}" = "$firstcontainer" ] || [ "${lines[0]}" = "$secondcontainer" ] || [ "${lines[0]}" = "$thirdcontainer" ]
+	[ "${lines[1]}" = "$zerothcontainer" ] || [ "${lines[1]}" = "$firstcontainer" ] || [ "${lines[1]}" = "$secondcontainer" ] || [ "${lines[1]}" = "$thirdcontainer" ]
+	[ "${lines[2]}" = "$zerothcontainer" ] || [ "${lines[2]}" = "$firstcontainer" ] || [ "${lines[2]}" = "$secondcontainer" ] || [ "${lines[2]}" = "$thirdcontainer" ]
+	[ "${lines[3]}" = "$zerothcontainer" ] || [ "${lines[3]}" = "$firstcontainer" ] || [ "${lines[3]}" = "$secondcontainer" ] || [ "${lines[3]}" = "$thirdcontainer" ]
 }

--- a/tests/create-image.bats
+++ b/tests/create-image.bats
@@ -3,6 +3,12 @@
 load helpers
 
 @test "create-image" {
+	# Create an image using no layer.
+	run storage --debug=false create-image ""
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	zerothimage=${output%%	*}
+
 	# Create a layer.
 	run storage --debug=false create-layer
 	[ "$status" -eq 0 ]
@@ -31,8 +37,11 @@ load helpers
 	run storage --debug=false images
 	[ "$status" -eq 0 ]
 	echo :"$output":
-	[ "${#lines[*]}" -eq 2 ]
+	[ "${#lines[*]}" -eq 3 ]
 	[ "${lines[0]}" != "${lines[1]}" ]
-	[ "${lines[0]}" = "$firstimage" ] || [ "${lines[0]}" = "$secondimage" ]
-	[ "${lines[1]}" = "$firstimage" ] || [ "${lines[1]}" = "$secondimage" ]
+	[ "${lines[1]}" != "${lines[2]}" ]
+	[ "${lines[0]}" != "${lines[2]}" ]
+	[ "${lines[0]}" = "$zerothimage" ] || [ "${lines[0]}" = "$firstimage" ] || [ "${lines[0]}" = "$secondimage" ]
+	[ "${lines[1]}" = "$zerothimage" ] || [ "${lines[1]}" = "$firstimage" ] || [ "${lines[1]}" = "$secondimage" ]
+	[ "${lines[2]}" = "$zerothimage" ] || [ "${lines[2]}" = "$firstimage" ] || [ "${lines[2]}" = "$secondimage" ]
 }


### PR DESCRIPTION
When creating a container, don't worry about whether or not the base image's top layer has the right ID mappings in cases where the base image doesn't have a top layer.
