### PR TITLE
tests: fix regression when using idmapping

### DIFF
--- a/drivers/chown.go
+++ b/drivers/chown.go
@@ -55,6 +55,9 @@ func chownByMapsMain() {
 		if err != nil {
 			return fmt.Errorf("error walking to %q: %v", path, err)
 		}
+		if path == "." {
+			return nil
+		}
 		return platformLChown(path, info, toHost, toContainer)
 	}
 	if err := filepath.Walk(".", chown); err != nil {

--- a/tests/idmaps.bats
+++ b/tests/idmaps.bats
@@ -10,6 +10,12 @@ load helpers
 		skip "not supported by driver $STORAGE_DRIVER"
 		;;
 	esac
+	case "$STORAGE_OPTION" in
+	*mount_program*)
+		skip "test not supported when using mount_program"
+		;;
+	esac
+
 	n=5
 	host=2
 	# Create some temporary files.
@@ -97,6 +103,11 @@ load helpers
 		skip "not supported by driver $STORAGE_DRIVER"
 		;;
 	esac
+	case "$STORAGE_OPTION" in
+	*mount_program*)
+		skip "test not supported when using mount_program"
+		;;
+	esac
 	n=5
 	host=2
 	# Create some temporary files.
@@ -181,6 +192,11 @@ load helpers
 		;;
 	*)
 		skip "not supported by driver $STORAGE_DRIVER"
+		;;
+	esac
+	case "$STORAGE_OPTION" in
+	*mount_program*)
+		skip "test not supported when using mount_program"
 		;;
 	esac
 	n=5
@@ -309,6 +325,11 @@ load helpers
 		skip "not supported by driver $STORAGE_DRIVER"
 		;;
 	esac
+	case "$STORAGE_OPTION" in
+	*mount_program*)
+		skip "test not supported when using mount_program"
+		;;
+	esac
 	n=5
 	# Create some temporary files.
 	for i in $(seq $n) ; do
@@ -368,6 +389,11 @@ load helpers
 		;;
 	*)
 		skip "not supported by driver $STORAGE_DRIVER"
+		;;
+	esac
+	case "$STORAGE_OPTION" in
+	*mount_program*)
+		skip "test not supported when using mount_program"
 		;;
 	esac
 	n=5
@@ -531,6 +557,11 @@ load helpers
 		skip "not supported by driver $STORAGE_DRIVER"
 		;;
 	esac
+	case "$STORAGE_OPTION" in
+	*mount_program*)
+		skip "test not supported when using mount_program"
+		;;
+	esac
 	n=5
 	host=2
 	# Create some temporary files.
@@ -663,6 +694,11 @@ load helpers
 		;;
 	*)
 		skip "not supported by driver $STORAGE_DRIVER"
+		;;
+	esac
+	case "$STORAGE_OPTION" in
+	*mount_program*)
+		skip "test not supported when using mount_program"
 		;;
 	esac
 	n=5
@@ -802,6 +838,11 @@ load helpers
 		;;
 	*)
 		skip "not supported by driver $STORAGE_DRIVER"
+		;;
+	esac
+	case "$STORAGE_OPTION" in
+	*mount_program*)
+		skip "test not supported when using mount_program"
 		;;
 	esac
 


### PR DESCRIPTION
fix a regression introduced with d1554f0dcd6a74eaade2181239f8df7df975f7b1 and 7c6d502e9bd4e485eeb291ed3c8f7b44dcecb34d that broke some tests.

Also, skip some tests that are not valid when using fuse-overlayfs as it supports ID shifting.

With this patch for fuse-overlayfs: https://github.com/containers/fuse-overlayfs/pull/76

I was able to run the tests suite as:

```
# export STORAGE_OPTION=overlay.mount_program=/usr/local/bin/fuse-overlayfs
# export STORAGE_DRIVER=overlay
# cd tests
# ./test_runner.bash
```