### PR TITLE
Make chown tolerant of errors when doing single user mapping

### DIFF
--- a/drivers/aufs/aufs.go
+++ b/drivers/aufs/aufs.go
@@ -35,7 +35,7 @@ import (
 	"sync"
 	"time"
 
-	"github.com/containers/storage/drivers"
+	graphdriver "github.com/containers/storage/drivers"
 	"github.com/containers/storage/pkg/archive"
 	"github.com/containers/storage/pkg/chrootarchive"
 	"github.com/containers/storage/pkg/directory"
@@ -526,13 +526,14 @@ func (a *Driver) DiffGetter(id string) (graphdriver.FileGetCloser, error) {
 	return fileGetNilCloser{storage.NewPathFileGetter(p)}, nil
 }
 
-func (a *Driver) applyDiff(id string, idMappings *idtools.IDMappings, diff io.Reader) error {
+func (a *Driver) applyDiff(id string, idMappings *idtools.IDMappings, diff io.Reader, ignoreChownErrors bool) error {
 	if idMappings == nil {
 		idMappings = &idtools.IDMappings{}
 	}
 	return chrootarchive.UntarUncompressed(diff, path.Join(a.rootPath(), "diff", id), &archive.TarOptions{
-		UIDMaps: idMappings.UIDs(),
-		GIDMaps: idMappings.GIDs(),
+		UIDMaps:           idMappings.UIDs(),
+		GIDMaps:           idMappings.GIDs(),
+		IgnoreChownErrors: ignoreChownErrors,
 	})
 }
 
@@ -550,13 +551,13 @@ func (a *Driver) DiffSize(id string, idMappings *idtools.IDMappings, parent stri
 // ApplyDiff extracts the changeset from the given diff into the
 // layer with the specified id and parent, returning the size of the
 // new layer in bytes.
-func (a *Driver) ApplyDiff(id string, idMappings *idtools.IDMappings, parent, mountLabel string, diff io.Reader) (size int64, err error) {
+func (a *Driver) ApplyDiff(id string, idMappings *idtools.IDMappings, parent, mountLabel string, diff io.Reader, ignoreChownErrors bool) (size int64, err error) {
 	if !a.isParent(id, parent) {
-		return a.naiveDiff.ApplyDiff(id, idMappings, parent, mountLabel, diff)
+		return a.naiveDiff.ApplyDiff(id, idMappings, parent, mountLabel, diff, ignoreChownErrors)
 	}
 
 	// AUFS doesn't need the parent id to apply the diff if it is the direct parent.
-	if err = a.applyDiff(id, idMappings, diff); err != nil {
+	if err = a.applyDiff(id, idMappings, diff, ignoreChownErrors); err != nil {
 		return
 	}
 

--- a/drivers/aufs/aufs_test.go
+++ b/drivers/aufs/aufs_test.go
@@ -13,7 +13,7 @@ import (
 	"sync"
 	"testing"
 
-	"github.com/containers/storage/drivers"
+	graphdriver "github.com/containers/storage/drivers"
 	"github.com/containers/storage/drivers/graphtest"
 	"github.com/containers/storage/pkg/archive"
 	"github.com/containers/storage/pkg/reexec"
@@ -624,7 +624,7 @@ func TestApplyDiff(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if err := d.applyDiff("3", nil, diff); err != nil {
+	if err := d.applyDiff("3", nil, diff, false); err != nil {
 		t.Fatal(err)
 	}
 

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -115,7 +115,7 @@ type DiffDriver interface {
 	// layer with the specified id and parent, returning the size of the
 	// new layer in bytes.
 	// The io.Reader must be an uncompressed stream.
-	ApplyDiff(id string, idMappings *idtools.IDMappings, parent string, mountLabel string, diff io.Reader) (size int64, err error)
+	ApplyDiff(id string, idMappings *idtools.IDMappings, parent string, mountLabel string, diff io.Reader, ignoreChownErrors bool) (size int64, err error)
 	// DiffSize calculates the changes between the specified id
 	// and its parent and returns the size in bytes of the changes
 	// relative to its base filesystem directory.

--- a/drivers/fsdiff.go
+++ b/drivers/fsdiff.go
@@ -151,7 +151,7 @@ func (gdw *NaiveDiffDriver) Changes(id string, idMappings *idtools.IDMappings, p
 // ApplyDiff extracts the changeset from the given diff into the
 // layer with the specified id and parent, returning the size of the
 // new layer in bytes.
-func (gdw *NaiveDiffDriver) ApplyDiff(id string, applyMappings *idtools.IDMappings, parent, mountLabel string, diff io.Reader) (size int64, err error) {
+func (gdw *NaiveDiffDriver) ApplyDiff(id string, applyMappings *idtools.IDMappings, parent, mountLabel string, diff io.Reader, ignoreChownErrors bool) (size int64, err error) {
 	driver := gdw.ProtoDriver
 
 	if applyMappings == nil {
@@ -169,7 +169,8 @@ func (gdw *NaiveDiffDriver) ApplyDiff(id string, applyMappings *idtools.IDMappin
 	defer driver.Put(id)
 
 	options := &archive.TarOptions{
-		InUserNS: rsystem.RunningInUserNS(),
+		InUserNS:          rsystem.RunningInUserNS(),
+		IgnoreChownErrors: ignoreChownErrors,
 	}
 	if applyMappings != nil {
 		options.UIDMaps = applyMappings.UIDs()

--- a/drivers/graphtest/graphbench_unix.go
+++ b/drivers/graphtest/graphbench_unix.go
@@ -9,7 +9,7 @@ import (
 	"path/filepath"
 	"testing"
 
-	"github.com/containers/storage/drivers"
+	graphdriver "github.com/containers/storage/drivers"
 	"github.com/containers/storage/pkg/stringid"
 )
 
@@ -165,7 +165,7 @@ func DriverBenchDiffApplyN(b *testing.B, fileCount int, drivername string, drive
 			b.Fatal(err)
 		}
 
-		applyDiffSize, err := driver.ApplyDiff(diff, nil, "", "", arch)
+		applyDiffSize, err := driver.ApplyDiff(diff, nil, "", "", arch, false)
 		if err != nil {
 			b.Fatal(err)
 		}

--- a/drivers/graphtest/graphtest_unix.go
+++ b/drivers/graphtest/graphtest_unix.go
@@ -14,7 +14,7 @@ import (
 	"testing"
 	"unsafe"
 
-	"github.com/containers/storage/drivers"
+	graphdriver "github.com/containers/storage/drivers"
 	"github.com/containers/storage/pkg/archive"
 	"github.com/containers/storage/pkg/stringid"
 	"github.com/docker/go-units"
@@ -336,7 +336,7 @@ func DriverTestDiffApply(t testing.TB, fileCount int, drivername string, driverO
 		t.Fatal(err)
 	}
 
-	applyDiffSize, err := driver.ApplyDiff(diff, nil, base, "", bytes.NewReader(buf.Bytes()))
+	applyDiffSize, err := driver.ApplyDiff(diff, nil, base, "", bytes.NewReader(buf.Bytes()), false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -967,9 +967,9 @@ func (d *Driver) getWhiteoutFormat() archive.WhiteoutFormat {
 }
 
 // ApplyDiff applies the new layer into a root
-func (d *Driver) ApplyDiff(id string, idMappings *idtools.IDMappings, parent string, mountLabel string, diff io.Reader) (size int64, err error) {
+func (d *Driver) ApplyDiff(id string, idMappings *idtools.IDMappings, parent string, mountLabel string, diff io.Reader, ignoreChownErrors bool) (size int64, err error) {
 	if !d.isParent(id, parent) {
-		return d.naiveDiff.ApplyDiff(id, idMappings, parent, mountLabel, diff)
+		return d.naiveDiff.ApplyDiff(id, idMappings, parent, mountLabel, diff, ignoreChownErrors)
 	}
 
 	if idMappings == nil {
@@ -981,10 +981,11 @@ func (d *Driver) ApplyDiff(id string, idMappings *idtools.IDMappings, parent str
 	logrus.Debugf("Applying tar in %s", applyDir)
 	// Overlay doesn't need the parent id to apply the diff
 	if err := untar(diff, applyDir, &archive.TarOptions{
-		UIDMaps:        idMappings.UIDs(),
-		GIDMaps:        idMappings.GIDs(),
-		WhiteoutFormat: d.getWhiteoutFormat(),
-		InUserNS:       rsystem.RunningInUserNS(),
+		UIDMaps:           idMappings.UIDs(),
+		GIDMaps:           idMappings.GIDs(),
+		IgnoreChownErrors: ignoreChownErrors,
+		WhiteoutFormat:    d.getWhiteoutFormat(),
+		InUserNS:          rsystem.RunningInUserNS(),
 	}); err != nil {
 		return 0, err
 	}

--- a/drivers/template.go
+++ b/drivers/template.go
@@ -35,7 +35,7 @@ func NaiveCreateFromTemplate(d TemplateDriver, id, template string, templateIDMa
 		}
 		return err
 	}
-	if _, err = d.ApplyDiff(id, templateIDMappings, parent, opts.MountLabel, diff); err != nil {
+	if _, err = d.ApplyDiff(id, templateIDMappings, parent, opts.MountLabel, diff, false); err != nil {
 		if err2 := d.Remove(id); err2 != nil {
 			logrus.Errorf("error removing layer %q: %v", id, err2)
 		}

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -36,14 +36,15 @@ type (
 
 	// TarOptions wraps the tar options.
 	TarOptions struct {
-		IncludeFiles     []string
-		ExcludePatterns  []string
-		Compression      Compression
-		NoLchown         bool
-		UIDMaps          []idtools.IDMap
-		GIDMaps          []idtools.IDMap
-		ChownOpts        *idtools.IDPair
-		IncludeSourceDir bool
+		IncludeFiles      []string
+		ExcludePatterns   []string
+		Compression       Compression
+		NoLchown          bool
+		UIDMaps           []idtools.IDMap
+		GIDMaps           []idtools.IDMap
+		IgnoreChownErrors bool
+		ChownOpts         *idtools.IDPair
+		IncludeSourceDir  bool
 		// WhiteoutFormat is the expected on disk format for whiteout files.
 		// This format will be converted to the standard format on pack
 		// and from the standard format on unpack.
@@ -554,7 +555,7 @@ func (ta *tarAppender) addTarFile(path, name string) error {
 	return nil
 }
 
-func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, Lchown bool, chownOpts *idtools.IDPair, inUserns bool) error {
+func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, Lchown bool, chownOpts *idtools.IDPair, inUserns, ignoreChownErrors bool) error {
 	// hdr.Mode is in linux format, which we can use for sycalls,
 	// but for os.Foo() calls we need the mode converted to os.FileMode,
 	// so use hdrInfo.Mode() (they differ for e.g. setuid bits)
@@ -636,8 +637,13 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, L
 		if chownOpts == nil {
 			chownOpts = &idtools.IDPair{UID: hdr.Uid, GID: hdr.Gid}
 		}
-		if err := idtools.SafeLchown(path, chownOpts.UID, chownOpts.GID); err != nil {
-			return err
+		err := idtools.SafeLchown(path, chownOpts.UID, chownOpts.GID)
+		if err != nil {
+			if ignoreChownErrors {
+				fmt.Fprintf(os.Stderr, "Chown error detected. Ignoring due to ignoreChownErrors flag: %v\n", err)
+			} else {
+				return err
+			}
 		}
 	}
 
@@ -984,7 +990,7 @@ loop:
 			chownOpts = &idtools.IDPair{UID: hdr.Uid, GID: hdr.Gid}
 		}
 
-		if err := createTarFile(path, dest, hdr, trBuf, !options.NoLchown, chownOpts, options.InUserNS); err != nil {
+		if err := createTarFile(path, dest, hdr, trBuf, !options.NoLchown, chownOpts, options.InUserNS, options.IgnoreChownErrors); err != nil {
 			return err
 		}
 

--- a/pkg/archive/archive_ffjson.go
+++ b/pkg/archive/archive_ffjson.go
@@ -445,6 +445,11 @@ func (j *TarOptions) MarshalJSONBuf(buf fflib.EncodingBuffer) error {
 	} else {
 		buf.WriteString(`null`)
 	}
+	if j.IgnoreChownErrors {
+		buf.WriteString(`,"IgnoreChownErrors":true`)
+	} else {
+		buf.WriteString(`,"IgnoreChownErrors":false`)
+	}
 	if j.ChownOpts != nil {
 		/* Struct fall back. type=idtools.IDPair kind=struct */
 		buf.WriteString(`,"ChownOpts":`)
@@ -516,6 +521,8 @@ const (
 
 	ffjtTarOptionsGIDMaps
 
+	ffjtTarOptionsIgnoreChownErrors
+
 	ffjtTarOptionsChownOpts
 
 	ffjtTarOptionsIncludeSourceDir
@@ -544,6 +551,8 @@ var ffjKeyTarOptionsNoLchown = []byte("NoLchown")
 var ffjKeyTarOptionsUIDMaps = []byte("UIDMaps")
 
 var ffjKeyTarOptionsGIDMaps = []byte("GIDMaps")
+
+var ffjKeyTarOptionsIgnoreChownErrors = []byte("IgnoreChownErrors")
 
 var ffjKeyTarOptionsChownOpts = []byte("ChownOpts")
 
@@ -663,6 +672,11 @@ mainparse:
 						state = fflib.FFParse_want_colon
 						goto mainparse
 
+					} else if bytes.Equal(ffjKeyTarOptionsIgnoreChownErrors, kn) {
+						currentKey = ffjtTarOptionsIgnoreChownErrors
+						state = fflib.FFParse_want_colon
+						goto mainparse
+
 					} else if bytes.Equal(ffjKeyTarOptionsIncludeSourceDir, kn) {
 						currentKey = ffjtTarOptionsIncludeSourceDir
 						state = fflib.FFParse_want_colon
@@ -766,6 +780,12 @@ mainparse:
 					goto mainparse
 				}
 
+				if fflib.EqualFoldRight(ffjKeyTarOptionsIgnoreChownErrors, kn) {
+					currentKey = ffjtTarOptionsIgnoreChownErrors
+					state = fflib.FFParse_want_colon
+					goto mainparse
+				}
+
 				if fflib.EqualFoldRight(ffjKeyTarOptionsGIDMaps, kn) {
 					currentKey = ffjtTarOptionsGIDMaps
 					state = fflib.FFParse_want_colon
@@ -836,6 +856,9 @@ mainparse:
 
 				case ffjtTarOptionsGIDMaps:
 					goto handle_GIDMaps
+
+				case ffjtTarOptionsIgnoreChownErrors:
+					goto handle_IgnoreChownErrors
 
 				case ffjtTarOptionsChownOpts:
 					goto handle_ChownOpts
@@ -1218,6 +1241,41 @@ handle_GIDMaps:
 
 				wantVal = false
 			}
+		}
+	}
+
+	state = fflib.FFParse_after_value
+	goto mainparse
+
+handle_IgnoreChownErrors:
+
+	/* handler: j.IgnoreChownErrors type=bool kind=bool quoted=false*/
+
+	{
+		if tok != fflib.FFTok_bool && tok != fflib.FFTok_null {
+			return fs.WrapErr(fmt.Errorf("cannot unmarshal %s into Go value for bool", tok))
+		}
+	}
+
+	{
+		if tok == fflib.FFTok_null {
+
+		} else {
+			tmpb := fs.Output.Bytes()
+
+			if bytes.Compare([]byte{'t', 'r', 'u', 'e'}, tmpb) == 0 {
+
+				j.IgnoreChownErrors = true
+
+			} else if bytes.Compare([]byte{'f', 'a', 'l', 's', 'e'}, tmpb) == 0 {
+
+				j.IgnoreChownErrors = false
+
+			} else {
+				err = errors.New("unexpected bytes for true/false value")
+				return fs.WrapErr(err)
+			}
+
 		}
 	}
 

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -828,7 +828,7 @@ func TestTypeXGlobalHeaderDoesNotFail(t *testing.T) {
 		t.Fatal(err)
 	}
 	defer os.RemoveAll(tmpDir)
-	err = createTarFile(filepath.Join(tmpDir, "pax_global_header"), tmpDir, &hdr, nil, true, nil, false)
+	err = createTarFile(filepath.Join(tmpDir, "pax_global_header"), tmpDir, &hdr, nil, true, nil, false, false)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/archive/diff.go
+++ b/pkg/archive/diff.go
@@ -105,7 +105,7 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 					}
 					defer os.RemoveAll(aufsTempdir)
 				}
-				if err := createTarFile(filepath.Join(aufsTempdir, basename), dest, hdr, tr, true, nil, options.InUserNS); err != nil {
+				if err := createTarFile(filepath.Join(aufsTempdir, basename), dest, hdr, tr, true, nil, options.InUserNS, options.IgnoreChownErrors); err != nil {
 					return 0, err
 				}
 			}
@@ -196,7 +196,7 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 				return 0, err
 			}
 
-			if err := createTarFile(path, dest, srcHdr, srcData, true, nil, options.InUserNS); err != nil {
+			if err := createTarFile(path, dest, srcHdr, srcData, true, nil, options.InUserNS, options.IgnoreChownErrors); err != nil {
 				return 0, err
 			}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -73,6 +73,9 @@ type OptionsConfig struct {
 	RemapUIDs string `toml:"remap-uids"`
 	// RemapGIDs is a list of default GID mappings to use for layers.
 	RemapGIDs string `toml:"remap-gids"`
+	// IgnoreChownErrors is a flag for whether chown errors should be
+	// ignored when building an image.
+	IgnoreChownErrors bool `toml:"ignore-chown-errors"`
 
 	// RemapUser is the name of one or more entries in /etc/subuid which
 	// should be used to set up default UID mappings.


### PR DESCRIPTION
**Linked to this PR:** https://github.com/containers/buildah/pull/1645

### Problem:
When building a container as an unprivileged user and without uidmap tools, buildah will fail when chowning system files. This patch ignores those chown errors if buildah has fallen back to single user mapping mode.

### What this patch changes:
**Buildah side:**
unshare.go checks if newuidmap and newgidmap is installed by running "which newuidmap". If uidmap tools are not installed it sets an environment variable to pass down to the child.

**containers/storage side:**
diff_unix.go passes in the hosts environment variables (including the single user mapping environment variable) to the "storage-applyLayer" command. This allows checkChownErr in idtools.go to check if it needs to ignore the chown errors.

### Notes:
I'm not completely sure if using environment variables is the best way to get this information down to checkChownErr, but it seemed to work best in terms minimal code change. I would love to hear feedback on better solutions.