### PR TITLE
Add function to parse out mount options from graphdriver

### DIFF
--- a/store.go
+++ b/store.go
@@ -3398,12 +3398,18 @@ func init() {
 	ReloadConfigurationFile(defaultConfigFile, &defaultStoreOptions)
 }
 
+// GetDefaultMountOptions returns the default mountoptions defined in container/storage
 func GetDefaultMountOptions() ([]string, error) {
+	return GetMountOptions(defaultStoreOptions.GraphDriverName, defaultStoreOptions.GraphDriverOptions)
+}
+
+// GetMountOptions returns the mountoptions for the specified driver and graphDriverOptions
+func GetMountOptions(driver string, graphDriverOptions []string) ([]string, error) {
 	mountOpts := []string{
 		".mountopt",
-		fmt.Sprintf("%s.mountopt", defaultStoreOptions.GraphDriverName),
+		fmt.Sprintf("%s.mountopt", driver),
 	}
-	for _, option := range defaultStoreOptions.GraphDriverOptions {
+	for _, option := range graphDriverOptions {
 		key, val, err := parsers.ParseKeyValueOpt(option)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
We have a bug in podman that uses the defaultGraphDriver options
for returning the MountOptions rather then the driver overrides
from the user.

This PR adds a new interface GetMountOptions which parses the callers
graphdriveroptions and return the mountoptions

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>