### PR TITLE
overlay: cache the results of feature tests

### DIFF
--- a/drivers/aufs/aufs.go
+++ b/drivers/aufs/aufs.go
@@ -83,7 +83,7 @@ type Driver struct {
 
 // Init returns a new AUFS driver.
 // An error is returned if AUFS is not supported.
-func Init(root string, options []string, uidMaps, gidMaps []idtools.IDMap) (graphdriver.Driver, error) {
+func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) {
 
 	// Try to load the aufs kernel module
 	if err := supportsAufs(); err != nil {
@@ -91,7 +91,7 @@ func Init(root string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 
 	}
 
-	fsMagic, err := graphdriver.GetFSMagic(root)
+	fsMagic, err := graphdriver.GetFSMagic(home)
 	if err != nil {
 		return nil, err
 	}
@@ -106,7 +106,7 @@ func Init(root string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 	}
 
 	var mountOptions string
-	for _, option := range options {
+	for _, option := range options.DriverOptions {
 		key, val, err := parsers.ParseKeyValueOpt(option)
 		if err != nil {
 			return nil, err
@@ -126,36 +126,36 @@ func Init(root string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 	}
 
 	a := &Driver{
-		root:         root,
-		uidMaps:      uidMaps,
-		gidMaps:      gidMaps,
+		root:         home,
+		uidMaps:      options.UIDMaps,
+		gidMaps:      options.GIDMaps,
 		pathCache:    make(map[string]string),
 		ctr:          graphdriver.NewRefCounter(graphdriver.NewFsChecker(graphdriver.FsMagicAufs)),
 		locker:       locker.New(),
 		mountOptions: mountOptions,
 	}
 
-	rootUID, rootGID, err := idtools.GetRootUIDGID(uidMaps, gidMaps)
+	rootUID, rootGID, err := idtools.GetRootUIDGID(options.UIDMaps, options.GIDMaps)
 	if err != nil {
 		return nil, err
 	}
 	// Create the root aufs driver dir and return
 	// if it already exists
 	// If not populate the dir structure
-	if err := idtools.MkdirAllAs(root, 0700, rootUID, rootGID); err != nil {
+	if err := idtools.MkdirAllAs(home, 0700, rootUID, rootGID); err != nil {
 		if os.IsExist(err) {
 			return a, nil
 		}
 		return nil, err
 	}
 
-	if err := mountpk.MakePrivate(root); err != nil {
+	if err := mountpk.MakePrivate(home); err != nil {
 		return nil, err
 	}
 
 	// Populate the dir structure
 	for _, p := range paths {
-		if err := idtools.MkdirAllAs(path.Join(root, p), 0700, rootUID, rootGID); err != nil {
+		if err := idtools.MkdirAllAs(path.Join(home, p), 0700, rootUID, rootGID); err != nil {
 			return nil, err
 		}
 	}
@@ -165,7 +165,7 @@ func Init(root string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 	})
 
 	for _, path := range []string{"mnt", "diff"} {
-		p := filepath.Join(root, path)
+		p := filepath.Join(home, path)
 		entries, err := ioutil.ReadDir(p)
 		if err != nil {
 			logger.WithError(err).WithField("dir", p).Error("error reading dir entries")

--- a/drivers/aufs/aufs_test.go
+++ b/drivers/aufs/aufs_test.go
@@ -33,7 +33,7 @@ func init() {
 }
 
 func testInit(dir string, t testing.TB) graphdriver.Driver {
-	d, err := Init(dir, nil, nil, nil)
+	d, err := Init(dir, graphdriver.Options{})
 	if err != nil {
 		if errors.Cause(err) == graphdriver.ErrNotSupported {
 			t.Skip(err)

--- a/drivers/btrfs/btrfs.go
+++ b/drivers/btrfs/btrfs.go
@@ -49,7 +49,7 @@ type btrfsOptions struct {
 
 // Init returns a new BTRFS driver.
 // An error is returned if BTRFS is not supported.
-func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (graphdriver.Driver, error) {
+func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) {
 
 	fsMagic, err := graphdriver.GetFSMagic(home)
 	if err != nil {
@@ -60,7 +60,7 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 		return nil, errors.Wrapf(graphdriver.ErrPrerequisites, "%q is not on a btrfs filesystem", home)
 	}
 
-	rootUID, rootGID, err := idtools.GetRootUIDGID(uidMaps, gidMaps)
+	rootUID, rootGID, err := idtools.GetRootUIDGID(options.UIDMaps, options.GIDMaps)
 	if err != nil {
 		return nil, err
 	}
@@ -72,15 +72,15 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 		return nil, err
 	}
 
-	opt, userDiskQuota, err := parseOptions(options)
+	opt, userDiskQuota, err := parseOptions(options.DriverOptions)
 	if err != nil {
 		return nil, err
 	}
 
 	driver := &Driver{
 		home:    home,
-		uidMaps: uidMaps,
-		gidMaps: gidMaps,
+		uidMaps: options.UIDMaps,
+		gidMaps: options.GIDMaps,
 		options: opt,
 	}
 

--- a/drivers/devmapper/devmapper_test.go
+++ b/drivers/devmapper/devmapper_test.go
@@ -115,11 +115,11 @@ func testChangeLoopBackSize(t *testing.T, delta, expectDataSize, expectMetaDataS
 		t.Fatal(err)
 	}
 	//Reload
-	d, err := Init(driver.home, []string{
+	d, err := Init(driver.home, graphdriver.Options{DriverOptions: []string{
 		fmt.Sprintf("dm.loopdatasize=%d", defaultDataLoopbackSize+delta),
 		fmt.Sprintf("dm.loopmetadatasize=%d", defaultMetaDataLoopbackSize+delta),
 		"test=1",
-	}, nil, nil)
+	}})
 	if err != nil {
 		t.Fatalf("error creating devicemapper driver: %v", err)
 	}

--- a/drivers/devmapper/driver.go
+++ b/drivers/devmapper/driver.go
@@ -34,8 +34,8 @@ type Driver struct {
 }
 
 // Init creates a driver with the given home and the set of options.
-func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (graphdriver.Driver, error) {
-	deviceSet, err := NewDeviceSet(home, true, options, uidMaps, gidMaps)
+func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) {
+	deviceSet, err := NewDeviceSet(home, true, options.DriverOptions, options.UIDMaps, options.GIDMaps)
 	if err != nil {
 		return nil, err
 	}
@@ -47,8 +47,8 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 	d := &Driver{
 		DeviceSet: deviceSet,
 		home:      home,
-		uidMaps:   uidMaps,
-		gidMaps:   gidMaps,
+		uidMaps:   options.UIDMaps,
+		gidMaps:   options.GIDMaps,
 		ctr:       graphdriver.NewRefCounter(graphdriver.NewDefaultChecker()),
 		locker:    locker.New(),
 	}

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -54,7 +54,7 @@ type MountOpts struct {
 }
 
 // InitFunc initializes the storage driver.
-type InitFunc func(root string, options []string, uidMaps, gidMaps []idtools.IDMap) (Driver, error)
+type InitFunc func(homedir string, options Options) (Driver, error)
 
 // ProtoDriver defines the basic capabilities of a driver.
 // This interface exists solely to be a minimum set of methods
@@ -203,7 +203,7 @@ func Register(name string, initFunc InitFunc) error {
 // GetDriver initializes and returns the registered driver
 func GetDriver(name string, config Options) (Driver, error) {
 	if initFunc, exists := drivers[name]; exists {
-		return initFunc(filepath.Join(config.Root, name), config.DriverOptions, config.UIDMaps, config.GIDMaps)
+		return initFunc(filepath.Join(config.Root, name), config)
 	}
 
 	logrus.Errorf("Failed to GetDriver graph %s %s", name, config.Root)
@@ -211,9 +211,9 @@ func GetDriver(name string, config Options) (Driver, error) {
 }
 
 // getBuiltinDriver initializes and returns the registered driver, but does not try to load from plugins
-func getBuiltinDriver(name, home string, options []string, uidMaps, gidMaps []idtools.IDMap) (Driver, error) {
+func getBuiltinDriver(name, home string, options Options) (Driver, error) {
 	if initFunc, exists := drivers[name]; exists {
-		return initFunc(filepath.Join(home, name), options, uidMaps, gidMaps)
+		return initFunc(filepath.Join(home, name), options)
 	}
 	logrus.Errorf("Failed to built-in GetDriver graph %s %s", name, home)
 	return nil, errors.Wrapf(ErrNotSupported, "failed to built-in GetDriver graph %s %s", name, home)
@@ -245,7 +245,7 @@ func New(name string, config Options) (Driver, error) {
 		if _, prior := driversMap[name]; prior {
 			// of the state found from prior drivers, check in order of our priority
 			// which we would prefer
-			driver, err := getBuiltinDriver(name, config.Root, config.DriverOptions, config.UIDMaps, config.GIDMaps)
+			driver, err := getBuiltinDriver(name, config.Root, config)
 			if err != nil {
 				// unlike below, we will return error here, because there is prior
 				// state, and now it is no longer supported/prereq/compatible, so
@@ -273,7 +273,7 @@ func New(name string, config Options) (Driver, error) {
 
 	// Check for priority drivers first
 	for _, name := range priority {
-		driver, err := getBuiltinDriver(name, config.Root, config.DriverOptions, config.UIDMaps, config.GIDMaps)
+		driver, err := getBuiltinDriver(name, config.Root, config)
 		if err != nil {
 			if isDriverNotSupported(err) {
 				continue
@@ -285,7 +285,7 @@ func New(name string, config Options) (Driver, error) {
 
 	// Check all registered drivers if no priority driver is found
 	for name, initFunc := range drivers {
-		driver, err := initFunc(filepath.Join(config.Root, name), config.DriverOptions, config.UIDMaps, config.GIDMaps)
+		driver, err := initFunc(filepath.Join(config.Root, name), config)
 		if err != nil {
 			if isDriverNotSupported(err) {
 				continue

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -222,6 +222,7 @@ func getBuiltinDriver(name, home string, options Options) (Driver, error) {
 // Options is used to initialize a graphdriver
 type Options struct {
 	Root                string
+	RunRoot             string
 	DriverOptions       []string
 	UIDMaps             []idtools.IDMap
 	GIDMaps             []idtools.IDMap

--- a/drivers/graphtest/graphtest_unix.go
+++ b/drivers/graphtest/graphtest_unix.go
@@ -34,15 +34,18 @@ var (
 type Driver struct {
 	graphdriver.Driver
 	root     string
+	runroot  string
 	refCount int
 }
 
 func newDriver(t testing.TB, name string, options []string) *Driver {
 	root, err := ioutil.TempDir("", "storage-graphtest-")
 	require.NoError(t, err)
+	runroot, err := ioutil.TempDir("", "storage-graphtest-")
+	require.NoError(t, err)
 
 	require.NoError(t, os.MkdirAll(root, 0755))
-	d, err := graphdriver.GetDriver(name, graphdriver.Options{DriverOptions: options, Root: root})
+	d, err := graphdriver.GetDriver(name, graphdriver.Options{DriverOptions: options, Root: root, RunRoot: runroot})
 	if err != nil {
 		t.Logf("graphdriver: %v\n", err)
 		cause := errors.Cause(err)
@@ -51,13 +54,14 @@ func newDriver(t testing.TB, name string, options []string) *Driver {
 		}
 		t.Fatal(err)
 	}
-	return &Driver{d, root, 1}
+	return &Driver{d, root, runroot, 1}
 }
 
 func cleanup(t testing.TB, d *Driver) {
 	if err := drv.Cleanup(); err != nil {
 		t.Fatal(err)
 	}
+	os.RemoveAll(d.runroot)
 	os.RemoveAll(d.root)
 }
 

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -293,6 +293,36 @@ func parseOptions(options []string) (*overlayOptions, error) {
 	return o, nil
 }
 
+func cachedFeatureSet(feature string, set bool) string {
+	if set {
+		return fmt.Sprintf("%s-true", feature)
+	}
+	return fmt.Sprintf("%s-false", feature)
+}
+
+func cachedFeatureCheck(runhome, feature string) (supported bool, text string, err error) {
+	content, err := ioutil.ReadFile(filepath.Join(runhome, cachedFeatureSet(feature, true)))
+	if err == nil {
+		return true, string(content), nil
+	}
+	content, err = ioutil.ReadFile(filepath.Join(runhome, cachedFeatureSet(feature, false)))
+	if err == nil {
+		return false, string(content), nil
+	}
+	return false, "", err
+}
+
+func cachedFeatureRecord(runhome, feature string, supported bool, text string) (err error) {
+	f, err := os.Create(filepath.Join(runhome, cachedFeatureSet(feature, supported)))
+	if f != nil {
+		if text != "" {
+			fmt.Fprintf(f, "%s", text)
+		}
+		f.Close()
+	}
+	return err
+}
+
 func supportsOverlay(home string, homeMagic graphdriver.FsMagic, rootUID, rootGID int) (supportsDType bool, err error) {
 	// We can try to modprobe overlay first
 

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -125,8 +125,8 @@ func init() {
 // Init returns the a native diff driver for overlay filesystem.
 // If overlay filesystem is not supported on the host, a wrapped graphdriver.ErrNotSupported is returned as error.
 // If an overlay filesystem is not supported over an existing filesystem then a wrapped graphdriver.ErrIncompatibleFS is returned.
-func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (graphdriver.Driver, error) {
-	opts, err := parseOptions(options)
+func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) {
+	opts, err := parseOptions(options.DriverOptions)
 	if err != nil {
 		return nil, err
 	}
@@ -148,7 +148,7 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 		}
 	}
 
-	rootUID, rootGID, err := idtools.GetRootUIDGID(uidMaps, gidMaps)
+	rootUID, rootGID, err := idtools.GetRootUIDGID(options.UIDMaps, options.GIDMaps)
 	if err != nil {
 		return nil, err
 	}
@@ -201,8 +201,8 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 	d := &Driver{
 		name:          "overlay",
 		home:          home,
-		uidMaps:       uidMaps,
-		gidMaps:       gidMaps,
+		uidMaps:       options.UIDMaps,
+		gidMaps:       options.GIDMaps,
 		ctr:           graphdriver.NewRefCounter(graphdriver.NewFsChecker(graphdriver.FsMagicOverlay)),
 		supportsDType: supportsDType,
 		usingMetacopy: usingMetacopy,

--- a/drivers/vfs/driver.go
+++ b/drivers/vfs/driver.go
@@ -24,16 +24,16 @@ func init() {
 
 // Init returns a new VFS driver.
 // This sets the home directory for the driver and returns NaiveDiffDriver.
-func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (graphdriver.Driver, error) {
+func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) {
 	d := &Driver{
 		homes:      []string{home},
-		idMappings: idtools.NewIDMappingsFromMaps(uidMaps, gidMaps),
+		idMappings: idtools.NewIDMappingsFromMaps(options.UIDMaps, options.GIDMaps),
 	}
 	rootIDs := d.idMappings.RootPair()
 	if err := idtools.MkdirAllAndChown(home, 0700, rootIDs); err != nil {
 		return nil, err
 	}
-	for _, option := range options {
+	for _, option := range options.DriverOptions {
 		if strings.HasPrefix(option, "vfs.imagestore=") {
 			d.homes = append(d.homes, strings.Split(option[15:], ",")...)
 			continue
@@ -59,7 +59,7 @@ func Init(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (grap
 		}
 	}
 	if d.ostreeRepo != "" {
-		rootUID, rootGID, err := idtools.GetRootUIDGID(uidMaps, gidMaps)
+		rootUID, rootGID, err := idtools.GetRootUIDGID(options.UIDMaps, options.GIDMaps)
 		if err != nil {
 			return nil, err
 		}

--- a/drivers/windows/windows.go
+++ b/drivers/windows/windows.go
@@ -83,10 +83,10 @@ type Driver struct {
 }
 
 // InitFilter returns a new Windows storage filter driver.
-func InitFilter(home string, options []string, uidMaps, gidMaps []idtools.IDMap) (graphdriver.Driver, error) {
+func InitFilter(home string, options graphdriver.Options) (graphdriver.Driver, error) {
 	logrus.Debugf("WindowsGraphDriver InitFilter at %s", home)
 
-	for _, option := range options {
+	for _, option := range options.DriverOptions {
 		if strings.HasPrefix(option, "windows.mountopt=") {
 			return nil, fmt.Errorf("windows driver does not support mount options")
 		} else {

--- a/store.go
+++ b/store.go
@@ -722,6 +722,7 @@ func (s *store) getGraphDriver() (drivers.Driver, error) {
 	}
 	config := drivers.Options{
 		Root:          s.graphRoot,
+		RunRoot:       s.runRoot,
 		DriverOptions: s.graphOptions,
 		UIDMaps:       s.uidMap,
 		GIDMaps:       s.gidMap,


### PR DESCRIPTION
Instead of passing the driver-specific directory and assorted fields from a `Config` struct to lower-level drivers when we initialize them, pass them the directory and the `Config` struct.  Add the `runroot` to the `Config` struct.  Have the overlay driver use cache files under the runroot to track whether or not overlay is supported, whether or not metacopy is on (for a specific set of mount options), and whether or not we can use native diff (again, for a specific set of mount options).  This attempts to fix #368.