### PR TITLE
utils: fix check for missing conf file

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -195,15 +195,15 @@ func DefaultStoreOptions(rootless bool, rootlessUid int) (StoreOptions, error) {
 	if err != nil {
 		return storageOpts, err
 	}
-	if _, err = os.Stat(storageConf); err == nil {
+	_, err = os.Stat(storageConf)
+	if err != nil && !os.IsNotExist(err) {
+		return storageOpts, errors.Wrapf(err, "cannot stat %s", storageConf)
+	}
+	if err == nil {
 		defaultRootlessRunRoot = storageOpts.RunRoot
 		defaultRootlessGraphRoot = storageOpts.GraphRoot
 		storageOpts = StoreOptions{}
 		ReloadConfigurationFile(storageConf, &storageOpts)
-	}
-
-	if !os.IsNotExist(err) {
-		return storageOpts, errors.Wrapf(err, "cannot stat %s", storageConf)
 	}
 
 	if rootless && rootlessUid != 0 {


### PR DESCRIPTION
the previous error condition was causing an early failure when the
configuration file existed.  It prevented some additional checks and
to correctly set the RunRoot and GraphRoot to their default values
when they are not overriden in the configuration file.

We have not noticed it earlier as Podman would still use the
configuration from the DB in this case, so the issue is visible with
Podman only when the RunRoot is not specified in the configuration
file and in the libpod DB as well.

Closes: https://github.com/containers/libpod/issues/3274

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>