### PR TITLE
Add support for UID Matching in /etc/subuid and /etc/subgid

### DIFF
--- a/pkg/idtools/idtools.go
+++ b/pkg/idtools/idtools.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"os"
+	"os/user"
 	"sort"
 	"strconv"
 	"strings"
@@ -244,7 +245,13 @@ func parseSubgid(username string) (ranges, error) {
 // and return all found ranges for a specified username. If the special value
 // "ALL" is supplied for username, then all ranges in the file will be returned
 func parseSubidFile(path, username string) (ranges, error) {
-	var rangeList ranges
+	var (
+		rangeList ranges
+		uidstr    string
+	)
+	if u, err := user.Lookup(username); err == nil {
+		uidstr = u.Uid
+	}
 
 	subidFile, err := os.Open(path)
 	if err != nil {
@@ -266,7 +273,7 @@ func parseSubidFile(path, username string) (ranges, error) {
 		if len(parts) != 3 {
 			return rangeList, fmt.Errorf("Cannot parse subuid/gid information: Format not correct for %s file", path)
 		}
-		if parts[0] == username || username == "ALL" {
+		if parts[0] == username || username == "ALL" || (parts[0] == uidstr && parts[0] != "") {
 			startid, err := strconv.Atoi(parts[1])
 			if err != nil {
 				return rangeList, fmt.Errorf("String to int conversion failed during subuid/gid parsing of %s: %v", path, err)


### PR DESCRIPTION
Administrators can add records to /etc/subuid and /etc/subgid based
on username or UID.  Currently we only support lookup based on username.

This patch will lookup based on UID, if it is available in the /etc/passwd
file on the host.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>