### PR TITLE
Remove unfinished VFS layer if its creation fails.

### DIFF
--- a/drivers/vfs/driver.go
+++ b/drivers/vfs/driver.go
@@ -118,7 +118,7 @@ func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) error {
 	return d.create(id, parent, opts, true)
 }
 
-func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts, ro bool) error {
+func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts, ro bool) (retErr error) {
 	if opts != nil && len(opts.StorageOpt) != 0 {
 		return fmt.Errorf("--storage-opt is not supported for vfs")
 	}
@@ -133,6 +133,13 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts, ro bool
 	if err := idtools.MkdirAllAndChown(filepath.Dir(dir), 0700, rootIDs); err != nil {
 		return err
 	}
+
+	defer func() {
+		if retErr != nil {
+			os.RemoveAll(dir)
+		}
+	}()
+
 	if parent != "" {
 		st, err := system.Stat(d.dir(parent))
 		if err != nil {


### PR DESCRIPTION
Current implementation of VFS driver performs the copy of the parent layer during the creation of new (child) layer, but does not clean the destination if the copy process fails.

From the consuming application perspective, this make storage leaks possible, e.g. an attempt to create new container with `podman`, if failed in the middle of the copy due to disk overflow, leaves unfinished container layer stray.

To avoid obliging the application (or the end user) to take care of such possible leaks, cleanup is added.

The exact scenario of reproducing the leak with current implementation is simple (and in my case the leak was fast, as my disk is almost always close to full):

1. Fill almost all disk (e.g. with `dd`).
2. Try to start new container using the image whose size larger than the remaining disk space. Observe the failure.
3. Check, that disk is now completely full.
4. Check, that you can not simply reclaim the space used by the unfinished layer with `podman`:
* `podman ps` does not know about unfinished container, so you can not delete it with `podman rm`;
* `podman system prune -a` cleans everything... But the leaked layer.
5. Free some space, retry. If freed space is not enough, it again will leak.