### PR TITLE
WIP - pkg/flock package

### DIFF
--- a/pkg/flock/flock.go
+++ b/pkg/flock/flock.go
@@ -1,0 +1,63 @@
+// flock exposes an API around flock(2) but allows for synchronizing within and
+// across process spaces, making it suitable for currently running threads and
+// processes alike. To support long-running daemons, the locks' file descriptors
+// are closed when the lock is being released via Unlock() or RUnlock().
+//
+// Note that the flock package supports UNIX-only but compiles on Windows for
+// compatibility reasons.
+
+package flock
+
+import (
+	"sync"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sync/semaphore"
+)
+
+var (
+	errInternal       = errors.New("internal error: flock")
+	errNotImplemented = errors.New("internal error: flock: not implemented")
+)
+
+// Flock implements a flock(2)-based file lock. It can be used to synchronize
+// within the same process space and across process spaces.
+type Flock interface {
+	// Lock locks the exclusive Flock for writing.
+	Lock() error
+	// TryLock locks the exclusive Flock without blocking. The first return
+	// value indicates if the Flock has been acquired.
+	TryLock() (bool, error)
+	// RLock locks the shared Flock for reading.  Note that RLock is busy
+	// looping for acquiring the Flock.
+	RLock() error
+	// Unlock unlocks the Flock. If it's a shared Flock, unlock must be called
+	// by the number of RLock() calls for the underlying lock file to be
+	// unlocked.
+	Unlock() error
+	// Locked indicates if the Flock is locked.
+	Locked() bool
+}
+
+// flockType indicates the type of the Flock.
+type flockType int
+
+const (
+	// flockUnlocked indicates an unlock flock
+	flockUnlocked flockType = iota
+	// flockShared indicates a shared flock (i.e., reader)
+	flockShared
+	// flockExclusive indicates an exclusive flock (i.e., writer)
+	flockExclusive
+)
+
+// flock implements the Flock interface
+type flock struct {
+	path string              // path to the lock file
+	sem  *semaphore.Weighted // process-space internal flock implementation
+
+	mutex     *sync.Mutex // synchronization of state below
+	flockType flockType   // current type of the lock
+	fd        int         // file descriptor
+	refs      uint        // reference counting
+}

--- a/pkg/flock/flock_unix.go
+++ b/pkg/flock/flock_unix.go
@@ -1,0 +1,176 @@
+// +build linux solaris darwin freebsd
+
+package flock
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/pkg/errors"
+	"golang.org/x/sync/semaphore"
+	"golang.org/x/sys/unix"
+)
+
+// New returns a Flock for path.
+func New(path string) (flock, error) {
+	// Make sure we can operate on the path.
+	fd, err := unix.Open(path, os.O_RDWR|os.O_CREATE, unix.S_IRUSR|unix.S_IWUSR)
+	if err != nil {
+		return flock{}, err
+	}
+	if err := unix.Close(fd); err != nil {
+		return flock{}, err
+	}
+	return flock{
+		flockType: flockUnlocked,
+		fd:        -1,
+		path:      path,
+		mutex:     new(sync.Mutex),
+		sem:       semaphore.NewWeighted(1),
+	}, nil
+}
+
+// open opens the flock's path and sets the file descriptor. State must be
+// synchronized by the caller.
+func (f *flock) open() error {
+	if f.fd != -1 || f.flockType != flockUnlocked {
+		return fmt.Errorf("%v: trying to open improper Flock %q %d %d", errInternal, f.path, f.fd, f.flockType)
+	}
+	fd, err := unix.Open(f.path, os.O_RDWR|os.O_CREATE, unix.S_IRUSR|unix.S_IWUSR)
+	if err != nil {
+		return err
+	}
+	f.fd = fd
+	return nil
+}
+
+func (f *flock) Locked() bool {
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+	return f.refs > 0
+}
+
+func (f *flock) Lock() (err error) {
+	if err := f.sem.Acquire(context.Background(), 1); err != nil {
+		return err
+	}
+
+	defer func() {
+		if err != nil {
+			return
+		}
+		f.mutex.Lock()
+		f.refs++
+		f.flockType = flockExclusive
+		f.mutex.Unlock()
+	}()
+
+	f.mutex.Lock()
+	if err := f.open(); err != nil {
+		f.mutex.Unlock()
+		return err
+	}
+	f.mutex.Unlock()
+
+	return unix.Flock(f.fd, unix.LOCK_EX)
+}
+
+func (f *flock) TryLock() (acquired bool, err error) {
+	if acquired := f.sem.TryAcquire(1); !acquired {
+		return false, nil
+	}
+
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	defer func() { // Deferred clean-ups.
+		if err == nil {
+			// No error, so we acquired the lock.
+			f.refs++
+			acquired = true
+			f.flockType = flockExclusive
+			return
+		}
+		if errors.Cause(err) == unix.EWOULDBLOCK {
+			// If it's a blocking error, nil the error.
+			err = nil
+		}
+		// Now, we still need to clean-up and close the file descriptor.
+		if closeErr := unix.Close(f.fd); closeErr != nil {
+			// Note: errors.Wrap*(nil, ...) is always nil
+			if err == nil {
+				err = closeErr
+			} else {
+				errors.Wrap(err, closeErr.Error())
+			}
+		}
+		f.fd = -1
+		f.sem.Release(1)
+	}()
+
+	if err := f.open(); err != nil {
+		return false, err
+	}
+	return acquired, unix.Flock(f.fd, unix.LOCK_EX|unix.LOCK_NB)
+}
+
+func (f *flock) RLock() error {
+	for { // Busy loop to avoid dead locks.
+		f.mutex.Lock()
+		// Unlock requires owning the mutex, so we will increment the ref conter
+		// **before** any concurrent threads may unlock underlying file.
+		if f.flockType == flockShared {
+			break
+		}
+		// If we don't already own the flock (see upper case), we fight with
+		// other threads for the semaphore.
+		if f.sem.TryAcquire(1) {
+			break
+		}
+		f.mutex.Unlock()
+	}
+
+	f.refs++
+	if f.refs > 1 {
+		f.mutex.Unlock()
+		return nil
+	}
+
+	if err := f.open(); err != nil {
+		f.mutex.Unlock()
+		return err
+	}
+
+	f.flockType = flockShared
+	f.mutex.Unlock()
+	return unix.Flock(f.fd, unix.LOCK_SH)
+}
+
+func (f *flock) Unlock() error {
+	// Note: it's crucial we own the mutex for the entire unlock() procedure.
+	// RLock() depends on it.
+	f.mutex.Lock()
+	defer f.mutex.Unlock()
+
+	if f.refs == 0 {
+		return fmt.Errorf("%v: unlocking unlocked Flock %q", errInternal, f.path)
+	}
+
+	f.refs--
+	if f.refs == 0 {
+		defer func() {
+			f.flockType = flockUnlocked
+			f.fd = -1
+			f.sem.Release(1)
+		}()
+		if err := unix.Flock(f.fd, unix.LOCK_UN); err != nil {
+			return err
+		}
+		if err := unix.Close(f.fd); err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/pkg/flock/flock_unix_test.go
+++ b/pkg/flock/flock_unix_test.go
@@ -1,0 +1,812 @@
+// build unix
+
+package flock
+
+import (
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/containers/storage/pkg/reexec"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMain(m *testing.M) {
+	if reexec.Init() {
+		return
+	}
+	os.Exit(m.Run())
+}
+
+// subTouchMain is a child process which opens the lock file, closes stdout to
+// indicate that it has acquired the lock, waits for stdin to get closed,
+// updates the last-writer for the lockfile, and then unlocks the file.
+func subTouchMain() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "expected two args, got %d", len(os.Args))
+		os.Exit(1)
+	}
+	tf, err := New(os.Args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error opening lock file %q: %v", os.Args[1], err)
+		os.Exit(2)
+	}
+	if err := tf.Lock(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v", err)
+		os.Exit(3)
+	}
+	os.Stdout.Close()
+	if _, err := io.Copy(ioutil.Discard, os.Stdin); err != nil {
+		fmt.Fprintf(os.Stderr, "%v", err)
+		os.Exit(4)
+	}
+	if err := tf.Unlock(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v", err)
+		os.Exit(5)
+	}
+}
+
+// subLockMain is a child process which opens the lock file, closes stdout to
+// indicate that it has acquired the lock, waits for stdin to get closed, and
+// then unlocks the file.
+func subLockMain() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "expected two args, got %d", len(os.Args))
+		os.Exit(1)
+	}
+	tf, err := New(os.Args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error opening lock file %q: %v", os.Args[1], err)
+		os.Exit(2)
+	}
+	if err := tf.Lock(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v", err)
+		os.Exit(3)
+	}
+	os.Stdout.Close()
+	if _, err := io.Copy(ioutil.Discard, os.Stdin); err != nil {
+		fmt.Fprintf(os.Stderr, "%v", err)
+		os.Exit(4)
+	}
+	if err := tf.Unlock(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v", err)
+		os.Exit(5)
+	}
+}
+
+// subLock starts a child process.  If it doesn't return an error, the caller
+// should wait for the first ReadCloser by reading it until it receives an EOF.
+// At that point, the child will have acquired the lock.  It can then signal
+// that the child should release the lock by closing the WriteCloser.
+func subLock(l *namedFlock) (io.WriteCloser, io.ReadCloser, error) {
+	cmd := reexec.Command("subLock", l.name)
+	wc, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, nil, err
+	}
+	rc, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, nil, err
+	}
+
+	go func() {
+		if err = cmd.Run(); err != nil {
+			slurp, _ := ioutil.ReadAll(rc)
+			panic(fmt.Sprintf("error running subLock: %s: %s", err.Error(), string(slurp)))
+		}
+	}()
+	return wc, rc, nil
+}
+
+// subRLockMain is a child process which opens the lock file, closes stdout to
+// indicate that it has acquired the read lock, waits for stdin to get closed,
+// and then unlocks the file.
+func subRLockMain() {
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "expected two args, got %d", len(os.Args))
+		os.Exit(1)
+	}
+	tf, err := New(os.Args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error opening lock file %q: %v", os.Args[1], err)
+		os.Exit(2)
+	}
+	if err := tf.RLock(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v", err)
+		os.Exit(3)
+	}
+	os.Stdout.Close()
+	if _, err := io.Copy(ioutil.Discard, os.Stdin); err != nil {
+		fmt.Fprintf(os.Stderr, "%v", err)
+		os.Exit(4)
+	}
+	if err := tf.Unlock(); err != nil {
+		fmt.Fprintf(os.Stderr, "%v", err)
+		os.Exit(5)
+	}
+}
+
+// subRLock starts a child process.  If it doesn't return an error, the caller
+// should wait for the first ReadCloser by reading it until it receives an EOF.
+// At that point, the child will have acquired a read lock.  It can then signal
+// that the child should release the lock by closing the WriteCloser.
+func subRLock(l *namedFlock) (io.WriteCloser, io.ReadCloser, error) {
+	cmd := reexec.Command("subRLock", l.name)
+	wc, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, nil, err
+	}
+	rc, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, nil, err
+	}
+	go func() {
+		if err = cmd.Run(); err != nil {
+			panic(fmt.Sprintf("error running subRLock: %v", err))
+		}
+	}()
+	return wc, rc, nil
+}
+
+// subTryLockMain is a child process which opens the lock file, closes stdout to
+// indicate that it has acquired the lock, waits for stdin to get closed, and
+// then unlocks the file.
+func subTryLockMain() {
+	fmt.Fprintf(os.Stdout, "expected two args, got %d", len(os.Args))
+
+	if len(os.Args) != 2 {
+		fmt.Fprintf(os.Stderr, "expected two args, got %d", len(os.Args))
+		os.Exit(1)
+	}
+	tf, err := New(os.Args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "error opening lock file %q: %v", os.Args[1], err)
+		os.Exit(2)
+	}
+	for {
+		if acquired, err := tf.TryLock(); err != nil {
+			fmt.Fprintf(os.Stderr, "1 %v", err)
+			os.Exit(3)
+		} else if acquired {
+			break
+		}
+	}
+	os.Stdout.Close()
+	if _, err := io.Copy(ioutil.Discard, os.Stdin); err != nil {
+		fmt.Fprintf(os.Stderr, "2 %v", err)
+		os.Exit(4)
+	}
+	if err := tf.Unlock(); err != nil {
+		fmt.Fprintf(os.Stderr, "3 %v", err)
+		os.Exit(5)
+	}
+}
+
+// subTryLock starts a child process.  If it doesn't return an error, the caller
+// should wait for the first ReadCloser by reading it until it receives an EOF.
+// At that point, the child will have acquired the lock.  It can then signal
+// that the child should release the lock by closing the WriteCloser.
+func subTryLock(l *namedFlock) (io.WriteCloser, io.ReadCloser, error) {
+	cmd := reexec.Command("subTryLock", l.name)
+	wc, err := cmd.StdinPipe()
+	if err != nil {
+		return nil, nil, err
+	}
+	rc, err := cmd.StdoutPipe()
+	if err != nil {
+		return nil, nil, err
+	}
+	go func() {
+		if err = cmd.Run(); err != nil {
+			slurp, _ := ioutil.ReadAll(rc)
+			panic(fmt.Sprintf("error running subTryLock: %v: %v", err, string(slurp)))
+		}
+	}()
+	return wc, rc, nil
+}
+
+func init() {
+	reexec.Register("subRLock", subRLockMain)
+	reexec.Register("subLock", subLockMain)
+	reexec.Register("subTryLock", subTryLockMain)
+}
+
+type namedFlock struct {
+	Flock
+	name string
+}
+
+func getTempLockfile() (*namedFlock, error) {
+	tf, err := ioutil.TempFile("", "lockfile")
+	if err != nil {
+		return nil, err
+	}
+	name := tf.Name()
+	tf.Close()
+
+	l, err := New(name)
+	if err != nil {
+		return nil, err
+	}
+	return &namedFlock{Flock: &l, name: name}, nil
+}
+
+func TestLockfileName(t *testing.T) {
+	l, err := getTempLockfile()
+	require.Nil(t, err, "error getting temporary lock file")
+	defer os.Remove(l.name)
+
+	assert.NotEmpty(t, l.name, "lockfile name should be recorded correctly")
+
+	assert.False(t, l.Locked())
+
+	assert.Nil(t, l.RLock())
+	assert.True(t, l.Locked())
+	assert.Nil(t, l.Unlock())
+
+	assert.NotEmpty(t, l.name, "lockfile name should be recorded correctly")
+
+	assert.Nil(t, l.Lock())
+	assert.True(t, l.Locked())
+	assert.Nil(t, l.Unlock())
+
+	assert.NotEmpty(t, l.name, "lockfile name should be recorded correctly")
+}
+
+func TestRLock(t *testing.T) {
+	l, err := getTempLockfile()
+	require.Nil(t, err, "error getting temporary lock file")
+	defer os.Remove(l.name)
+
+	assert.Nil(t, l.RLock())
+	assert.True(t, l.Locked())
+
+	acquired, err := l.TryLock()
+	assert.Nil(t, err)
+	assert.False(t, acquired)
+
+	assert.Nil(t, l.Unlock())
+	assert.False(t, l.Locked())
+}
+
+func TestLock(t *testing.T) {
+	l, err := getTempLockfile()
+	require.Nil(t, err, "error getting temporary lock file")
+	defer os.Remove(l.name)
+
+	assert.Nil(t, l.Lock())
+	assert.True(t, l.Locked())
+
+	acquired, err := l.TryLock()
+	assert.Nil(t, err)
+	assert.False(t, acquired)
+
+	assert.Nil(t, l.Unlock())
+	assert.False(t, l.Locked())
+}
+
+func TestTryLock(t *testing.T) {
+	l, err := getTempLockfile()
+	require.Nil(t, err, "error getting temporary lock file")
+	defer os.Remove(l.name)
+
+	acquired, err := l.TryLock()
+	assert.Nil(t, err)
+	assert.True(t, acquired)
+	assert.True(t, l.Locked())
+
+	acquired, err = l.TryLock()
+	assert.Nil(t, err)
+	assert.False(t, acquired)
+
+	assert.Nil(t, l.Unlock())
+	assert.False(t, l.Locked())
+}
+
+func TestConcurrentLock(t *testing.T) {
+	l, err := getTempLockfile()
+	require.Nil(t, err, "error getting temporary lock file")
+	defer os.Remove(l.name)
+	var wg sync.WaitGroup
+	var highestMutex sync.Mutex
+	var counter, highest int64
+	for i := 0; i < 100000; i++ {
+		wg.Add(1)
+		go func() {
+			assert.Nil(t, l.Lock())
+			tmp := atomic.AddInt64(&counter, 1)
+			assert.True(t, tmp >= 0, "counter should never be less than zero")
+			highestMutex.Lock()
+			if tmp > highest {
+				// multiple writers should not be able to hold
+				// this lock at the same time, so there should
+				// be no point at which two goroutines are
+				// between the AddInt64() above and the one
+				// below
+				highest = tmp
+			}
+			highestMutex.Unlock()
+			atomic.AddInt64(&counter, -1)
+			assert.Nil(t, l.Unlock())
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	assert.True(t, highest == 1, "counter should never have gone above 1, got to %d", highest)
+}
+
+func TestConcurrentTryLock(t *testing.T) {
+	// It's basically the same test as TestConcurrentLock but only executes the
+	// critical section, if we acquired the lock.  It also spawns more
+	// goroutines to stress the locks a bit more.
+	l, err := getTempLockfile()
+	require.Nil(t, err, "error getting temporary lock file")
+	defer os.Remove(l.name)
+	var wg sync.WaitGroup
+	var highestMutex sync.Mutex
+	var counter, highest int64
+	for i := 0; i < 10000000; i++ {
+		wg.Add(1)
+		go func() {
+			acquired, err := l.TryLock()
+			assert.Nil(t, err)
+			if acquired {
+				tmp := atomic.AddInt64(&counter, 1)
+				assert.True(t, tmp >= 0, "counter should never be less than zero")
+				highestMutex.Lock()
+				if tmp > highest {
+					// multiple writers should not be able to hold
+					// this lock at the same time, so there should
+					// be no point at which two goroutines are
+					// between the AddInt64() above and the one
+					// below
+					highest = tmp
+				}
+				highestMutex.Unlock()
+				atomic.AddInt64(&counter, -1)
+				assert.Nil(t, l.Unlock())
+			}
+			wg.Done()
+		}()
+	}
+	wg.Wait()
+	assert.True(t, highest == 1, "counter should never have gone above 1, got to %d", highest)
+}
+
+func TestConcurrentRLock(t *testing.T) {
+	l, err := getTempLockfile()
+	require.Nil(t, err, "error getting temporary lock file")
+	defer os.Remove(l.name)
+
+	// the test below is inspired by the stdlib's rwmutex tests
+	numReaders := 1000
+	locked := make(chan bool)
+	unlocked := make(chan bool)
+	done := make(chan bool)
+
+	for i := 0; i < numReaders; i++ {
+		go func() {
+			assert.Nil(t, l.RLock())
+			locked <- true
+			<-unlocked
+			assert.Nil(t, l.Unlock())
+			done <- true
+		}()
+	}
+
+	// Wait for all parallel locks to succeed
+	for i := 0; i < numReaders; i++ {
+		<-locked
+	}
+	// Instruct all parallel locks to unlock
+	for i := 0; i < numReaders; i++ {
+		unlocked <- true
+	}
+	// Wait for all parallel locks to be unlocked
+	for i := 0; i < numReaders; i++ {
+		<-done
+	}
+}
+
+func TestConcurrentMixedLockRLock(t *testing.T) {
+	l, err := getTempLockfile()
+	require.Nil(t, err, "error getting temporary lock file")
+	defer os.Remove(l.name)
+
+	counter := int32(0)
+	diff := int32(10000)
+	numIterations := 10
+	numReaders := 100
+	numWriters := 50
+
+	done := make(chan bool)
+
+	// A writer always adds `diff` to the counter. Hence, `diff` is the
+	// only valid value in the critical section.
+	writer := func(c *int32) {
+		for i := 0; i < numIterations; i++ {
+			assert.Nil(t, l.Lock())
+			tmp := atomic.AddInt32(c, diff)
+			assert.True(t, tmp == diff, "counter should be %d but instead is %d", diff, tmp)
+			time.Sleep(100 * time.Millisecond)
+			atomic.AddInt32(c, diff*(-1))
+			assert.Nil(t, l.Unlock())
+		}
+		done <- true
+	}
+
+	// A reader always adds `1` to the counter. Hence,
+	// [1,`numReaders*numIterations`] are valid values.
+	reader := func(c *int32) {
+		for i := 0; i < numIterations; i++ {
+			assert.Nil(t, l.RLock())
+			tmp := atomic.AddInt32(c, 1)
+			assert.True(t, tmp >= 1 && tmp < diff)
+			time.Sleep(100 * time.Millisecond)
+			atomic.AddInt32(c, -1)
+			assert.Nil(t, l.Unlock())
+		}
+		done <- true
+	}
+
+	for i := 0; i < numReaders; i++ {
+		go reader(&counter)
+		// schedule a writer every 2nd iteration
+		if i%2 == 1 {
+			go writer(&counter)
+		}
+	}
+
+	for i := 0; i < numReaders+numWriters; i++ {
+		<-done
+	}
+}
+
+func TestMultiprocessRLock(t *testing.T) {
+	l, err := getTempLockfile()
+	require.Nil(t, err, "error getting temporary lock file")
+	defer os.Remove(l.name)
+	var wg sync.WaitGroup
+	var rcounter, rhighest int64
+	var highestMutex sync.Mutex
+	subs := make([]struct {
+		stdin  io.WriteCloser
+		stdout io.ReadCloser
+	}, 100)
+	for i := range subs {
+		stdin, stdout, err := subRLock(l)
+		require.Nil(t, err, "error starting subprocess %d to take a read lock", i+1)
+		subs[i].stdin = stdin
+		subs[i].stdout = stdout
+	}
+	for i := range subs {
+		wg.Add(1)
+		go func(i int) {
+			_, err := io.Copy(ioutil.Discard, subs[i].stdout)
+			assert.Nil(t, err)
+			if testing.Verbose() {
+				fmt.Printf("\tchild %4d acquired the read lock\n", i+1)
+			}
+			atomic.AddInt64(&rcounter, 1)
+			highestMutex.Lock()
+			if rcounter > rhighest {
+				rhighest = rcounter
+			}
+			highestMutex.Unlock()
+			time.Sleep(1 * time.Second)
+			atomic.AddInt64(&rcounter, -1)
+			if testing.Verbose() {
+				fmt.Printf("\ttelling child %4d to release the read lock\n", i+1)
+			}
+			subs[i].stdin.Close()
+			wg.Done()
+		}(i)
+	}
+	wg.Wait()
+	assert.True(t, rhighest > 1, "expected to have multiple reader locks at least once, only had %d", rhighest)
+}
+
+func TestMultiprocessLock(t *testing.T) {
+	l, err := getTempLockfile()
+	require.Nil(t, err, "error getting temporary lock file")
+	defer os.Remove(l.name)
+	var wg sync.WaitGroup
+	var wcounter, whighest int64
+	var highestMutex sync.Mutex
+	subs := make([]struct {
+		stdin  io.WriteCloser
+		stdout io.ReadCloser
+	}, 10)
+	for i := range subs {
+		stdin, stdout, err := subLock(l)
+		require.Nil(t, err, "error starting subprocess %d to take a write lock", i+1)
+		subs[i].stdin = stdin
+		subs[i].stdout = stdout
+	}
+	for i := range subs {
+		wg.Add(1)
+		go func(i int) {
+			_, err := io.Copy(ioutil.Discard, subs[i].stdout)
+			assert.Nil(t, err)
+			if testing.Verbose() {
+				fmt.Printf("\tchild %4d acquired the write lock\n", i+1)
+			}
+			atomic.AddInt64(&wcounter, 1)
+			highestMutex.Lock()
+			if wcounter > whighest {
+				whighest = wcounter
+			}
+			highestMutex.Unlock()
+			time.Sleep(1 * time.Second)
+			atomic.AddInt64(&wcounter, -1)
+			if testing.Verbose() {
+				fmt.Printf("\ttelling child %4d to release the write lock\n", i+1)
+			}
+			subs[i].stdin.Close()
+			wg.Done()
+		}(i)
+	}
+	wg.Wait()
+	assert.True(t, whighest == 1, "expected to have no more than one writer lock active at a time, had %d", whighest)
+}
+
+func TestMultiprocessTryLock(t *testing.T) {
+	l, err := getTempLockfile()
+	require.Nil(t, err, "error getting temporary lock file")
+	defer os.Remove(l.name)
+	var wg sync.WaitGroup
+	var wcounter, whighest int64
+	var highestMutex sync.Mutex
+	subs := make([]struct {
+		stdin  io.WriteCloser
+		stdout io.ReadCloser
+	}, 10)
+	for i := range subs {
+		stdin, stdout, err := subTryLock(l)
+		require.Nil(t, err, "error starting subprocess %d to take a write lock", i+1)
+		subs[i].stdin = stdin
+		subs[i].stdout = stdout
+	}
+	for i := range subs {
+		wg.Add(1)
+		go func(i int) {
+			_, err := io.Copy(ioutil.Discard, subs[i].stdout)
+			assert.Nil(t, err)
+			if testing.Verbose() {
+				fmt.Printf("\tchild %4d acquired the write lock\n", i+1)
+			}
+			atomic.AddInt64(&wcounter, 1)
+			highestMutex.Lock()
+			if wcounter > whighest {
+				whighest = wcounter
+			}
+			highestMutex.Unlock()
+			time.Sleep(1 * time.Second)
+			atomic.AddInt64(&wcounter, -1)
+			if testing.Verbose() {
+				fmt.Printf("\ttelling child %4d to release the write lock\n", i+1)
+			}
+			subs[i].stdin.Close()
+			wg.Done()
+		}(i)
+	}
+	wg.Wait()
+	assert.True(t, whighest == 1, "expected to have no more than one writer lock active at a time, had %d", whighest)
+}
+
+func TestMultiprocessLockTryLock(t *testing.T) {
+	l, err := getTempLockfile()
+	require.Nil(t, err, "error getting temporary lock file")
+	defer os.Remove(l.name)
+	var wg sync.WaitGroup
+	var wcounter, whighest int64
+	var highestMutex sync.Mutex
+	subs := make([]struct {
+		stdin  io.WriteCloser
+		stdout io.ReadCloser
+	}, 10)
+	for i := range subs {
+		if i%2 == 0 {
+			stdin, stdout, err := subLock(l)
+			require.Nil(t, err, "error starting subprocess %d to take a write via Lock", i+1)
+			subs[i].stdin = stdin
+			subs[i].stdout = stdout
+		} else {
+			stdin, stdout, err := subTryLock(l)
+			require.Nil(t, err, "error starting subprocess %d to take a write via TryLock", i+1)
+			subs[i].stdin = stdin
+			subs[i].stdout = stdout
+		}
+	}
+	for i := range subs {
+		wg.Add(1)
+		go func(i int) {
+			_, err := io.Copy(ioutil.Discard, subs[i].stdout)
+			assert.Nil(t, err)
+			if testing.Verbose() {
+				fmt.Printf("\tchild %4d acquired the write lock\n", i+1)
+			}
+			atomic.AddInt64(&wcounter, 1)
+			highestMutex.Lock()
+			if wcounter > whighest {
+				whighest = wcounter
+			}
+			highestMutex.Unlock()
+			time.Sleep(1 * time.Second)
+			atomic.AddInt64(&wcounter, -1)
+			if testing.Verbose() {
+				fmt.Printf("\ttelling child %4d to release the write lock\n", i+1)
+			}
+			subs[i].stdin.Close()
+			wg.Done()
+		}(i)
+	}
+	wg.Wait()
+	assert.True(t, whighest == 1, "expected to have no more than one writer lock active at a time, had %d", whighest)
+}
+
+func TestMultiprocessLockRLock(t *testing.T) {
+	l, err := getTempLockfile()
+	require.Nil(t, err, "error getting temporary lock file")
+	defer os.Remove(l.name)
+	var wg sync.WaitGroup
+	var rcounter, wcounter, rhighest, whighest int64
+	var rhighestMutex, whighestMutex sync.Mutex
+	biasP := 1
+	biasQ := 10
+	groups := 15
+	writer := func(i int) bool { return (i % biasQ) < biasP }
+	subs := make([]struct {
+		stdin  io.WriteCloser
+		stdout io.ReadCloser
+	}, biasQ*groups)
+	for i := range subs {
+		var stdin io.WriteCloser
+		var stdout io.ReadCloser
+		if writer(i) {
+			stdin, stdout, err = subLock(l)
+			require.Nil(t, err, "error starting subprocess %d to take a write lock", i+1)
+		} else {
+			stdin, stdout, err = subRLock(l)
+			require.Nil(t, err, "error starting subprocess %d to take a read lock", i+1)
+		}
+		subs[i].stdin = stdin
+		subs[i].stdout = stdout
+	}
+	for i := range subs {
+		wg.Add(1)
+		go func(i int) {
+			// wait for the child to acquire whatever lock it wants
+			_, err := io.Copy(ioutil.Discard, subs[i].stdout)
+			assert.Nil(t, err)
+			if writer(i) {
+				// child acquired a write lock
+				if testing.Verbose() {
+					fmt.Printf("\tchild %4d acquired the write lock\n", i+1)
+				}
+				atomic.AddInt64(&wcounter, 1)
+				whighestMutex.Lock()
+				if wcounter > whighest {
+					whighest = wcounter
+				}
+				require.Zero(t, rcounter, "acquired a write lock while we appear to have read locks")
+				whighestMutex.Unlock()
+			} else {
+				// child acquired a read lock
+				if testing.Verbose() {
+					fmt.Printf("\tchild %4d acquired the read lock\n", i+1)
+				}
+				atomic.AddInt64(&rcounter, 1)
+				rhighestMutex.Lock()
+				if rcounter > rhighest {
+					rhighest = rcounter
+				}
+				require.Zero(t, wcounter, "acquired a read lock while we appear to have write locks")
+				rhighestMutex.Unlock()
+			}
+			time.Sleep(1 * time.Second)
+			if writer(i) {
+				atomic.AddInt64(&wcounter, -1)
+				if testing.Verbose() {
+					fmt.Printf("\ttelling child %4d to release the write lock\n", i+1)
+				}
+			} else {
+				atomic.AddInt64(&rcounter, -1)
+				if testing.Verbose() {
+					fmt.Printf("\ttelling child %4d to release the read lock\n", i+1)
+				}
+			}
+			subs[i].stdin.Close()
+			wg.Done()
+		}(i)
+	}
+	wg.Wait()
+	assert.True(t, rhighest > 1, "expected to have more than one reader lock active at a time at least once, only had %d", rhighest)
+	assert.True(t, whighest == 1, "expected to have no more than one writer lock active at a time, had %d", whighest)
+}
+
+func TestMultiprocessTryLockRLock(t *testing.T) {
+	l, err := getTempLockfile()
+	require.Nil(t, err, "error getting temporary lock file")
+	defer os.Remove(l.name)
+	var wg sync.WaitGroup
+	var rcounter, wcounter, rhighest, whighest int64
+	var rhighestMutex, whighestMutex sync.Mutex
+	biasP := 1
+	biasQ := 10
+	groups := 15
+	writer := func(i int) bool { return (i % biasQ) < biasP }
+	subs := make([]struct {
+		stdin  io.WriteCloser
+		stdout io.ReadCloser
+	}, biasQ*groups)
+	for i := range subs {
+		var stdin io.WriteCloser
+		var stdout io.ReadCloser
+		if writer(i) {
+			stdin, stdout, err = subTryLock(l)
+			require.Nil(t, err, "error starting subprocess %d to take a write lock", i+1)
+		} else {
+			stdin, stdout, err = subRLock(l)
+			require.Nil(t, err, "error starting subprocess %d to take a read lock", i+1)
+		}
+		subs[i].stdin = stdin
+		subs[i].stdout = stdout
+	}
+	for i := range subs {
+		wg.Add(1)
+		go func(i int) {
+			// wait for the child to acquire whatever lock it wants
+			_, err := io.Copy(ioutil.Discard, subs[i].stdout)
+			assert.Nil(t, err)
+			if writer(i) {
+				// child acquired a write lock
+				if testing.Verbose() {
+					fmt.Printf("\tchild %4d acquired the write lock\n", i+1)
+				}
+				atomic.AddInt64(&wcounter, 1)
+				whighestMutex.Lock()
+				if wcounter > whighest {
+					whighest = wcounter
+				}
+				require.Zero(t, rcounter, "acquired a write lock while we appear to have read locks")
+				whighestMutex.Unlock()
+			} else {
+				// child acquired a read lock
+				if testing.Verbose() {
+					fmt.Printf("\tchild %4d acquired the read lock\n", i+1)
+				}
+				atomic.AddInt64(&rcounter, 1)
+				rhighestMutex.Lock()
+				if rcounter > rhighest {
+					rhighest = rcounter
+				}
+				require.Zero(t, wcounter, "acquired a read lock while we appear to have write locks")
+				rhighestMutex.Unlock()
+			}
+			time.Sleep(1 * time.Second)
+			if writer(i) {
+				atomic.AddInt64(&wcounter, -1)
+				if testing.Verbose() {
+					fmt.Printf("\ttelling child %4d to release the write lock\n", i+1)
+				}
+			} else {
+				atomic.AddInt64(&rcounter, -1)
+				if testing.Verbose() {
+					fmt.Printf("\ttelling child %4d to release the read lock\n", i+1)
+				}
+			}
+			subs[i].stdin.Close()
+			wg.Done()
+		}(i)
+	}
+	wg.Wait()
+	assert.True(t, rhighest > 1, "expected to have more than one reader lock active at a time at least once, only had %d", rhighest)
+	assert.True(t, whighest == 1, "expected to have no more than one writer lock active at a time, had %d", whighest)
+}

--- a/pkg/flock/flock_windows.go
+++ b/pkg/flock/flock_windows.go
@@ -1,0 +1,27 @@
+// +build !unix
+
+package flock
+
+func New(path string) (flock, error) {
+	return flock{}, errNotImplemented
+}
+
+func (f *flock) Locked() bool {
+	return false
+}
+
+func (f *flock) Lock() error {
+	return errNotImplemented
+}
+
+func (f *flock) TryLock() (bool, error) {
+	return false, errNotImplemented
+}
+
+func (f *flock) RLock() error {
+	return errNotImplemented
+}
+
+func (f *flock) Unlock() error {
+	return errNotImplemented
+}

--- a/vendor.conf
+++ b/vendor.conf
@@ -24,6 +24,7 @@ github.com/tchap/go-patricia v2.2.6
 github.com/vbatts/tar-split v0.10.2
 golang.org/x/net 7dcfb8076726a3fdd9353b6b8a1f1b6be6811bd6
 golang.org/x/sys 07c182904dbd53199946ba614a412c61d3c548f5
+golang.org/x/sync 112230192c580c3556b8cee6403af37a4fc5f28c
 gotest.tools master
 github.com/google/go-cmp master
 github.com/DataDog/zstd 1.x

--- a/vendor/golang.org/x/sync/LICENSE
+++ b/vendor/golang.org/x/sync/LICENSE
@@ -1,0 +1,27 @@
+Copyright (c) 2009 The Go Authors. All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are
+met:
+
+   * Redistributions of source code must retain the above copyright
+notice, this list of conditions and the following disclaimer.
+   * Redistributions in binary form must reproduce the above
+copyright notice, this list of conditions and the following disclaimer
+in the documentation and/or other materials provided with the
+distribution.
+   * Neither the name of Google Inc. nor the names of its
+contributors may be used to endorse or promote products derived from
+this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+"AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/vendor/golang.org/x/sync/PATENTS
+++ b/vendor/golang.org/x/sync/PATENTS
@@ -1,0 +1,22 @@
+Additional IP Rights Grant (Patents)
+
+"This implementation" means the copyrightable works distributed by
+Google as part of the Go project.
+
+Google hereby grants to You a perpetual, worldwide, non-exclusive,
+no-charge, royalty-free, irrevocable (except as stated in this section)
+patent license to make, have made, use, offer to sell, sell, import,
+transfer and otherwise run, modify and propagate the contents of this
+implementation of Go, where such license applies only to those patent
+claims, both currently owned or controlled by Google and acquired in
+the future, licensable by Google that are necessarily infringed by this
+implementation of Go.  This grant does not include claims that would be
+infringed only as a consequence of further modification of this
+implementation.  If you or your agent or exclusive licensee institute or
+order or agree to the institution of patent litigation against any
+entity (including a cross-claim or counterclaim in a lawsuit) alleging
+that this implementation of Go or any code incorporated within this
+implementation of Go constitutes direct or contributory patent
+infringement, or inducement of patent infringement, then any patent
+rights granted to you under this License for this implementation of Go
+shall terminate as of the date such litigation is filed.

--- a/vendor/golang.org/x/sync/README.md
+++ b/vendor/golang.org/x/sync/README.md
@@ -1,0 +1,18 @@
+# Go Sync
+
+This repository provides Go concurrency primitives in addition to the
+ones provided by the language and "sync" and "sync/atomic" packages.
+
+## Download/Install
+
+The easiest way to install is to run `go get -u golang.org/x/sync`. You can
+also manually git clone the repository to `$GOPATH/src/golang.org/x/sync`.
+
+## Report Issues / Send Patches
+
+This repository uses Gerrit for code changes. To learn how to submit changes to
+this repository, see https://golang.org/doc/contribute.html.
+
+The main issue tracker for the sync repository is located at
+https://github.com/golang/go/issues. Prefix your issue with "x/sync:" in the
+subject line, so it is easy to find.

--- a/vendor/golang.org/x/sync/go.mod
+++ b/vendor/golang.org/x/sync/go.mod
@@ -1,0 +1,1 @@
+module golang.org/x/sync

--- a/vendor/golang.org/x/sync/semaphore/semaphore.go
+++ b/vendor/golang.org/x/sync/semaphore/semaphore.go
@@ -1,0 +1,127 @@
+// Copyright 2017 The Go Authors. All rights reserved.
+// Use of this source code is governed by a BSD-style
+// license that can be found in the LICENSE file.
+
+// Package semaphore provides a weighted semaphore implementation.
+package semaphore // import "golang.org/x/sync/semaphore"
+
+import (
+	"container/list"
+	"context"
+	"sync"
+)
+
+type waiter struct {
+	n     int64
+	ready chan<- struct{} // Closed when semaphore acquired.
+}
+
+// NewWeighted creates a new weighted semaphore with the given
+// maximum combined weight for concurrent access.
+func NewWeighted(n int64) *Weighted {
+	w := &Weighted{size: n}
+	return w
+}
+
+// Weighted provides a way to bound concurrent access to a resource.
+// The callers can request access with a given weight.
+type Weighted struct {
+	size    int64
+	cur     int64
+	mu      sync.Mutex
+	waiters list.List
+}
+
+// Acquire acquires the semaphore with a weight of n, blocking until resources
+// are available or ctx is done. On success, returns nil. On failure, returns
+// ctx.Err() and leaves the semaphore unchanged.
+//
+// If ctx is already done, Acquire may still succeed without blocking.
+func (s *Weighted) Acquire(ctx context.Context, n int64) error {
+	s.mu.Lock()
+	if s.size-s.cur >= n && s.waiters.Len() == 0 {
+		s.cur += n
+		s.mu.Unlock()
+		return nil
+	}
+
+	if n > s.size {
+		// Don't make other Acquire calls block on one that's doomed to fail.
+		s.mu.Unlock()
+		<-ctx.Done()
+		return ctx.Err()
+	}
+
+	ready := make(chan struct{})
+	w := waiter{n: n, ready: ready}
+	elem := s.waiters.PushBack(w)
+	s.mu.Unlock()
+
+	select {
+	case <-ctx.Done():
+		err := ctx.Err()
+		s.mu.Lock()
+		select {
+		case <-ready:
+			// Acquired the semaphore after we were canceled.  Rather than trying to
+			// fix up the queue, just pretend we didn't notice the cancelation.
+			err = nil
+		default:
+			s.waiters.Remove(elem)
+		}
+		s.mu.Unlock()
+		return err
+
+	case <-ready:
+		return nil
+	}
+}
+
+// TryAcquire acquires the semaphore with a weight of n without blocking.
+// On success, returns true. On failure, returns false and leaves the semaphore unchanged.
+func (s *Weighted) TryAcquire(n int64) bool {
+	s.mu.Lock()
+	success := s.size-s.cur >= n && s.waiters.Len() == 0
+	if success {
+		s.cur += n
+	}
+	s.mu.Unlock()
+	return success
+}
+
+// Release releases the semaphore with a weight of n.
+func (s *Weighted) Release(n int64) {
+	s.mu.Lock()
+	s.cur -= n
+	if s.cur < 0 {
+		s.mu.Unlock()
+		panic("semaphore: released more than held")
+	}
+	for {
+		next := s.waiters.Front()
+		if next == nil {
+			break // No more waiters blocked.
+		}
+
+		w := next.Value.(waiter)
+		if s.size-s.cur < w.n {
+			// Not enough tokens for the next waiter.  We could keep going (to try to
+			// find a waiter with a smaller request), but under load that could cause
+			// starvation for large requests; instead, we leave all remaining waiters
+			// blocked.
+			//
+			// Consider a semaphore used as a read-write lock, with N tokens, N
+			// readers, and one writer.  Each reader can Acquire(1) to obtain a read
+			// lock.  The writer can Acquire(N) to obtain a write lock, excluding all
+			// of the readers.  If we allow the readers to jump ahead in the queue,
+			// the writer will starve — there is always one token available for every
+			// reader.
+			break
+		}
+
+		s.cur += w.n
+		s.waiters.Remove(next)
+		close(w.ready)
+	}
+	s.mu.Unlock()
+}


### PR DESCRIPTION
Introduce the pkg/flock package, a flock(2)-based implementation in
golang that can be used within and across process spaces. The main
motivation for this package is to benefit from the TryLock-semantics
offered by flock(2), which is not possible with c/storage.Locker file
lock since they are based on fcntl(2).

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>