### PR TITLE
Use same variable name on both commands

### DIFF
--- a/docs/containers-storage.conf.5.md
+++ b/docs/containers-storage.conf.5.md
@@ -174,7 +174,7 @@ under `/var/lib/containers/storage`.
 
 ```
 semanage fcontext -a -e /var/lib/containers NEWSTORAGEPATH
-restorecon -R -v /src/containers
+restorecon -R -v NEWSTORAGEPATH
 ```
 
 The semanage command above tells SELinux to setup the default labeling of


### PR DESCRIPTION
On the relabeling instructions, it's quite confusing to use a variable
on the first command, and then a literal location on the second one.

Signed-off-by: Cleber Rosa <crosa@redhat.com>