### PR TITLE
Keep track of the UIDs and GIDs used in applied layers

### DIFF
--- a/pkg/tarlog/tarlogger.go
+++ b/pkg/tarlog/tarlogger.go
@@ -1,0 +1,34 @@
+package tarlog
+
+import (
+	"archive/tar"
+	"io"
+)
+
+type tarLogger struct {
+	w *io.PipeWriter
+}
+
+// NewLogger returns a writer that, when a tar archive is written to it, calls
+// `logger` for each file header it encounters in the archive.
+func NewLogger(logger func(*tar.Header)) io.WriteCloser {
+	reader, writer := io.Pipe()
+	go func() {
+		r := tar.NewReader(reader)
+		hdr, err := r.Next()
+		for err == nil {
+			logger(hdr)
+			hdr, err = r.Next()
+		}
+		reader.Close()
+	}()
+	return &tarLogger{w: writer}
+}
+
+func (t *tarLogger) Write(b []byte) (int, error) {
+	return t.w.Write(b)
+}
+
+func (t *tarLogger) Close() error {
+	return t.w.Close()
+}

--- a/pkg/tarlog/tarlogger_test.go
+++ b/pkg/tarlog/tarlogger_test.go
@@ -1,0 +1,47 @@
+package tarlog
+
+import (
+	"archive/tar"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestTarLogger(t *testing.T) {
+	cases := make([]struct {
+		name string
+		data []byte
+	}, 32)
+	for i := range cases {
+		cases[i].name = "ext"
+		if i > 0 {
+			cases[i].name = cases[i-1].name + "." + cases[i].name
+		}
+		cases[i].data = make([]byte, i*64)
+	}
+
+	loggedNames := []string{}
+	logNames := func(h *tar.Header) {
+		loggedNames = append(loggedNames, h.Name)
+	}
+	logger := NewLogger(logNames)
+	writer := tar.NewWriter(logger)
+
+	for i := range cases {
+		h := &tar.Header{
+			Name:     cases[i].name,
+			Typeflag: tar.TypeReg,
+			Size:     int64(len(cases[i].data)),
+		}
+		err := writer.WriteHeader(h)
+		require.NoError(t, err, "error writing header to tar buffer")
+		n, err := writer.Write(cases[i].data)
+		require.NoError(t, err, "error writing data to tar buffer")
+		require.Equal(t, n, len(cases[i].data), "expected to write %d bytes, wrote %d", len(cases[i].data), n)
+	}
+	logger.Close()
+	require.Equal(t, len(loggedNames), len(cases), "expected to log %d names, logged %d", len(cases), len(loggedNames))
+	for i := range cases {
+		require.Equal(t, loggedNames[i], cases[i].name, "expected to see name %q, got name %q", cases[i].name, loggedNames[i])
+	}
+}


### PR DESCRIPTION
Add a field to the `Layer` structure that lets us make note of the set of UIDs and GIDs which own files in the layer, populated by scanning the diff that we used to populate the layer, if there was one.  This could eventually be used to decide how many UIDs and GIDs we need to map into a container in order to start a container based on a given image.