### PR TITLE
Add support for installing man pages

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -108,6 +108,11 @@ validate: ## validate DCO, gofmt, ./pkg/ isolation, golint,\ngo vet and vendor u
 install.tools:
 	make -C tests/tools
 
+install.docs: docs
+	make -C docs install
+
+install: install.docs
+
 lint: install.tools
 	tests/tools/build/golangci-lint run
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,4 +1,8 @@
 GOMD2MAN = ../tests/tools/build/go-md2man
+PREFIX ?= ${DESTDIR}/usr
+MANINSTALLDIR=${PREFIX}/share/man
+MANPAGES_MD = $(wildcard docs/*.5.md)
+MANPAGES ?= $(MANPAGES_MD:%.md=%)
 
 docs: $(patsubst %.md,%.1,$(filter-out %.5.md,$(wildcard *.md))) containers-storage.conf.5
 
@@ -7,3 +11,7 @@ docs: $(patsubst %.md,%.1,$(filter-out %.5.md,$(wildcard *.md))) containers-stor
 
 containers-storage.conf.5: containers-storage.conf.5.md
 	$(GOMD2MAN) -in $^ -out $@
+
+install:
+	install -d -m 755 ${MANINSTALLDIR}/man5
+	install -m 644 *.5 ${MANINSTALLDIR}/man5/


### PR DESCRIPTION
We want to create a containers-storage package which can install the man pages.
This package will be pulled in via containers-common.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>