### PR TITLE
overlay: fix small piece of repeated work

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -1005,7 +1005,7 @@ func (d *Driver) Put(id string) error {
 	if _, err := os.Stat(dir); err != nil {
 		return err
 	}
-	mountpoint := path.Join(d.dir(id), "merged")
+	mountpoint := path.Join(dir, "merged")
 	if count := d.ctr.Decrement(mountpoint); count > 0 {
 		return nil
 	}


### PR DESCRIPTION
we compute d.dir(id) twice, but store the value the first time. use the cached value instead.

Signed-off-by: Peter Hunt <pehunt@redhat.com>