### PR TITLE
[CRI-O 1.14] loadMounts(): reset counts before merging just-loaded data

### DIFF
--- a/layers.go
+++ b/layers.go
@@ -377,6 +377,19 @@ func (r *layerStore) loadMounts() error {
 	}
 	layerMounts := []layerMountPoint{}
 	if err = json.Unmarshal(data, &layerMounts); len(data) == 0 || err == nil {
+		// Clear all of our mount information.  If another process
+		// unmounted something, it (along with its zero count) won't
+		// have been encoded into the version of mountpoints.json that
+		// we're loading, so our count could fall out of sync with it
+		// if we don't, and if we subsequently change something else,
+		// we'd pass that error along to other process that reloaded
+		// the data after we saved it.
+		for _, layer := range r.layers {
+			layer.MountPoint = ""
+			layer.MountCount = 0
+		}
+		// All of the non-zero count values will have been encoded, so
+		// we reset the still-mounted ones based on the contents.
 		for _, mount := range layerMounts {
 			if mount.MountPoint != "" {
 				if layer, ok := r.lookup(mount.ID); ok {


### PR DESCRIPTION
Before applying mount counts that we've just loaded, reset all of the
counts.

If a layer that we thought was mounted was unmounted by another process,
there won't be a record of it in the mounts list any more, so we
wouldn't reset the mount count on our record for that layer.

Signed-off-by: Nalin Dahyabhai <nalin@redhat.com>

pick of: https://github.com/containers/storage/pull/399
per: https://github.com/containers/storage/pull/399#issuecomment-516153182