### PR TITLE
Don't chown unless you have to

### DIFF
--- a/drivers/fsdiff.go
+++ b/drivers/fsdiff.go
@@ -82,6 +82,7 @@ func (gdw *NaiveDiffDriver) Diff(id string, idMappings *idtools.IDMappings, pare
 		}), nil
 	}
 
+	options.Options = append(options.Options, "ro")
 	parentFs, err := driver.Get(parent, options)
 	if err != nil {
 		return nil, err

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -839,6 +839,16 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 	if _, err := os.Stat(dir); err != nil {
 		return "", err
 	}
+	readWrite := true
+	// fuse-overlayfs doesn't support working without an upperdir.
+	if d.options.mountProgram == "" {
+		for _, o := range options.Options {
+			if o == "ro" {
+				readWrite = false
+				break
+			}
+		}
+	}
 
 	lowers, err := ioutil.ReadFile(path.Join(dir, lowerFile))
 	if err != nil && !os.IsNotExist(err) {
@@ -910,20 +920,31 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 
 	// If the lowers list is still empty, use an empty lower so that we can still force an
 	// SELinux context for the mount.
+
+	// if we are doing a readOnly mount, and there is only one lower
+	// We should just return the lower directory, no reason to mount.
+	if !readWrite {
+		if len(absLowers) == 0 {
+			return path.Join(dir, "empty"), nil
+		}
+		if len(absLowers) == 1 {
+			return absLowers[0], nil
+		}
+	}
 	if len(absLowers) == 0 {
 		absLowers = append(absLowers, path.Join(dir, "empty"))
 		relLowers = append(relLowers, path.Join(id, "empty"))
 	}
-
 	// user namespace requires this to move a directory from lower to upper.
 	rootUID, rootGID, err := idtools.GetRootUIDGID(d.uidMaps, d.gidMaps)
 	if err != nil {
 		return "", err
 	}
-
 	diffDir := path.Join(dir, "diff")
-	if err := idtools.MkdirAs(diffDir, 0755, rootUID, rootGID); err != nil && !os.IsExist(err) {
-		return "", err
+	if readWrite {
+		if err := idtools.MkdirAllAs(diffDir, 0755, rootUID, rootGID); err != nil && !os.IsExist(err) {
+			return "", err
+		}
 	}
 
 	mergedDir := path.Join(dir, "merged")
@@ -944,8 +965,12 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 		}
 	}()
 
-	workDir := path.Join(dir, "work")
-	opts := fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", strings.Join(absLowers, ":"), diffDir, workDir)
+	var opts string
+	if readWrite {
+		opts = fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", strings.Join(absLowers, ":"), diffDir, path.Join(dir, "work"))
+	} else {
+		opts = fmt.Sprintf("lowerdir=%s", strings.Join(absLowers, ":"))
+	}
 	if len(options.Options) > 0 {
 		opts = fmt.Sprintf("%s,%s", strings.Join(options.Options, ","), opts)
 	} else if d.options.mountOptions != "" {
@@ -983,7 +1008,12 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 		}
 	} else if len(mountData) > pageSize {
 		//FIXME: We need to figure out to get this to work with additional stores
-		opts = fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", strings.Join(relLowers, ":"), path.Join(id, "diff"), path.Join(id, "work"))
+		if readWrite {
+			diffDir := path.Join(id, "diff")
+			opts = fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", strings.Join(relLowers, ":"), diffDir, path.Join(id, "work"))
+		} else {
+			opts = fmt.Sprintf("lowerdir=%s", strings.Join(absLowers, ":"))
+		}
 		mountData = label.FormatMountLabel(opts, options.MountLabel)
 		if len(mountData) > pageSize {
 			return "", fmt.Errorf("cannot mount layer, mount label too large %d", len(mountData))

--- a/drivers/vfs/driver.go
+++ b/drivers/vfs/driver.go
@@ -226,7 +226,15 @@ func (d *Driver) Remove(id string) error {
 // Get returns the directory for the given id.
 func (d *Driver) Get(id string, options graphdriver.MountOpts) (_ string, retErr error) {
 	dir := d.dir(id)
-	if len(options.Options) > 0 {
+	switch len(options.Options) {
+	case 0:
+	case 1:
+		if options.Options[0] == "ro" {
+			// ignore "ro" option
+			break
+		}
+		fallthrough
+	default:
 		return "", fmt.Errorf("vfs driver does not support mount options")
 	}
 	if st, err := os.Stat(dir); err != nil {


### PR DESCRIPTION
When running with readonly additional stores, containers/storage is trying to
create directories that already exists with the correct UIDs. This causes
buildah/podman to throw an error when committing an image.

This fix will allow buildah/podman to work with readonly additional image stores.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>