### PR TITLE
We should not be touching internal work dir

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -840,7 +840,6 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 		return "", err
 	}
 
-	diffDir := path.Join(dir, "diff")
 	lowers, err := ioutil.ReadFile(path.Join(dir, lowerFile))
 	if err != nil && !os.IsNotExist(err) {
 		return "", err
@@ -922,6 +921,11 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 		return "", err
 	}
 
+	diffDir := path.Join(dir, "diff")
+	if err := idtools.MkdirAs(diffDir, 0755, rootUID, rootGID); err != nil && !os.IsExist(err) {
+		return "", err
+	}
+
 	mergedDir := path.Join(dir, "merged")
 	// Create the driver merged dir
 	if err := idtools.MkdirAs(mergedDir, 0700, rootUID, rootGID); err != nil && !os.IsExist(err) {
@@ -993,11 +997,6 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 	logrus.Debugf("overlay: mount_data=%s", mountData)
 	if err := mountFunc("overlay", mountTarget, "overlay", uintptr(flags), data); err != nil {
 		return "", fmt.Errorf("error creating overlay mount to %s: %v", mountTarget, err)
-	}
-
-	// chown "workdir/work" to the remapped root UID/GID. Overlay fs inside a
-	if err := os.Chown(path.Join(workDir, "work"), rootUID, rootGID); err != nil {
-		return "", err
 	}
 
 	return mergedDir, nil


### PR DESCRIPTION
Vivek Goyal says that we should not be touching the internal WorkDir/work directory.
This is internal to the kernel and should not be modified.  I believe this was done
to make sure that the "/" of the container is writable by the root user of the user
namespace that is running the container.  Changing the ownership of the diffDir
should give us the same behavior and is safe to do.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>