### PR TITLE
Nonspecific storage driver for ignore_chown_errors option

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -322,7 +322,7 @@ func parseOptions(options []string) (*overlayOptions, error) {
 				return nil, fmt.Errorf("overlay: ostree_repo specified but support for ostree is missing")
 			}
 			o.ostreeRepo = val
-		case "overlay2.ignore_chown_errors", "overlay.ignore_chown_errors":
+		case ".ignore_chown_errors", "overlay2.ignore_chown_errors", "overlay.ignore_chown_errors":
 			logrus.Debugf("overlay: ignore_chown_errors=%s", val)
 			o.ignoreChownErrors, err = strconv.ParseBool(val)
 			if err != nil {

--- a/drivers/vfs/driver.go
+++ b/drivers/vfs/driver.go
@@ -58,7 +58,7 @@ func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) 
 			d.ostreeRepo = val
 		case "vfs.mountopt":
 			return nil, fmt.Errorf("vfs driver does not support mount options")
-		case "vfs.ignore_chown_errors":
+		case ".ignore_chown_errors", "vfs.ignore_chown_errors":
 			logrus.Debugf("vfs: ignore_chown_errors=%s", val)
 			var err error
 			d.ignoreChownErrors, err = strconv.ParseBool(val)


### PR DESCRIPTION
This pull request allows a user to not have to specify the storage driver for the ignore_chown_errors option.

Signed-off-by: Kevin Pelzel <kevinpelzel22@gmail.com>