### PR TITLE
Cirrus: Update VM images

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -19,9 +19,9 @@ env:
     ####
     # GCE project where images live
     IMAGE_PROJECT: "libpod-218412"
-    FEDORA_CACHE_IMAGE_NAME: "fedora-cloud-base-30-1-2-1556821664"
-    PRIOR_FEDORA_CACHE_IMAGE_NAME: "fedora-cloud-base-29-1-2-1541789245"
-    UBUNTU_CACHE_IMAGE_NAME: "ubuntu-1904-disco-v20190514"
+    FEDORA_CACHE_IMAGE_NAME: "fedora-cloud-base-30-1-2-1565360543"
+    PRIOR_FEDORA_CACHE_IMAGE_NAME: "fedora-cloud-base-29-1-2-1565360543"
+    UBUNTU_CACHE_IMAGE_NAME: "ubuntu-1904-disco-v20190724"
 
     ####
     #### Command variables to help avoid duplication


### PR DESCRIPTION
These were produced as an intended byproduct of:
https://github.com/containers/libpod/pull/3754

Where 'systemd_banish.sh' was run during base-image production.

This is a short-term fix, as there is much setup duplication
here which can (hopefully) be avoided with:
https://github.com/containers/storage/pull/408

Signed-off-by: Chris Evich <cevich@redhat.com>