### PR TITLE
Ignore ro mount options in btrfs and windows drivers

### DIFF
--- a/drivers/btrfs/btrfs.go
+++ b/drivers/btrfs/btrfs.go
@@ -645,7 +645,15 @@ func (d *Driver) Get(id string, options graphdriver.MountOpts) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	if len(options.Options) > 0 {
+	switch len(options.Options) {
+	case 0:
+	case 1:
+		if options.Options[0] == "ro" {
+			// ignore "ro" option
+			break
+		}
+		fallthrough
+	default:
 		return "", fmt.Errorf("btrfs driver does not support mount options")
 	}
 

--- a/drivers/windows/windows.go
+++ b/drivers/windows/windows.go
@@ -372,7 +372,15 @@ func (d *Driver) Get(id string, options graphdriver.MountOpts) (string, error) {
 	logrus.Debugf("WindowsGraphDriver Get() id %s mountLabel %s", id, options.MountLabel)
 	var dir string
 
-	if len(options.Options) > 0 {
+	switch len(options.Options) {
+	case 0:
+	case 1:
+		if options.Options[0] == "ro" {
+			// ignore "ro" option
+			break
+		}
+		fallthrough
+	default:
 		return "", fmt.Errorf("windows driver does not support mount options")
 	}
 	rID, err := d.resolveID(id)


### PR DESCRIPTION
Since now we always set the "ro" mount option, we need to ignore
these options on drivers that do not support them.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>