### PR TITLE
Add names-history support

### DIFF
--- a/images_test.go
+++ b/images_test.go
@@ -1,0 +1,94 @@
+package storage
+
+import (
+	"io/ioutil"
+	"testing"
+	"time"
+
+	digest "github.com/opencontainers/go-digest"
+	"github.com/stretchr/testify/require"
+)
+
+func newTestImageStore(t *testing.T) ImageStore {
+	dir, err := ioutil.TempDir("", "storage")
+	require.Nil(t, err)
+	store, err := newImageStore(dir)
+	require.Nil(t, err)
+	return store
+}
+
+func addTestImage(t *testing.T, store ImageStore, id string, names []string) {
+	store.Lock()
+	defer store.Unlock()
+
+	_, err := store.Create(
+		id, []string{}, "", "", time.Now(), digest.FromString(""),
+	)
+
+	require.Nil(t, err)
+	require.Nil(t, store.SetNames(id, names))
+}
+
+func TestAddNameToHistorySuccess(t *testing.T) {
+	// Given
+	image := Image{}
+
+	// When
+	image.addNameToHistory("first")
+	image.addNameToHistory("first")
+	image.addNameToHistory("second")
+
+	// Then
+	require.Len(t, image.NamesHistory, 2)
+}
+
+func TestHistoryNames(t *testing.T) {
+	// Given
+	store := newTestImageStore(t)
+
+	// When
+	const firstImageID = "first"
+	addTestImage(t, store, firstImageID, []string{"1", "2"})
+
+	const secondImageID = "second"
+	addTestImage(t, store, secondImageID, []string{"2", "3"})
+
+	// Then
+	firstImage, err := store.Get(firstImageID)
+	require.Nil(t, err)
+	require.Len(t, firstImage.Names, 1)
+	require.Equal(t, firstImage.Names[0], "1")
+	require.Len(t, firstImage.NamesHistory, 2)
+	require.Equal(t, firstImage.NamesHistory[0], "2")
+	require.Equal(t, firstImage.NamesHistory[1], "1")
+
+	secondImage, err := store.Get(secondImageID)
+	require.Nil(t, err)
+	require.Len(t, secondImage.Names, 2)
+	require.Equal(t, secondImage.Names[0], "2")
+	require.Equal(t, secondImage.Names[1], "3")
+	require.Len(t, secondImage.NamesHistory, 2)
+	require.Equal(t, secondImage.NamesHistory[0], "3")
+	require.Equal(t, secondImage.NamesHistory[1], "2")
+
+	// And When
+	store.Lock()
+	defer store.Unlock()
+	require.Nil(t, store.SetNames(firstImageID, []string{"1", "2", "3", "4"}))
+
+	// Then
+	firstImage, err = store.Get(firstImageID)
+	require.Nil(t, err)
+	require.Len(t, firstImage.NamesHistory, 4)
+	require.Equal(t, firstImage.NamesHistory[0], "4")
+	require.Equal(t, firstImage.NamesHistory[1], "3")
+	require.Equal(t, firstImage.NamesHistory[2], "2")
+	require.Equal(t, firstImage.NamesHistory[3], "1")
+
+	secondImage, err = store.Get(secondImageID)
+	require.Nil(t, err)
+	require.Len(t, secondImage.Names, 0)
+	require.Len(t, secondImage.NamesHistory, 2)
+	require.Equal(t, secondImage.NamesHistory[0], "3")
+	require.Equal(t, secondImage.NamesHistory[1], "2")
+}


### PR DESCRIPTION
This commit adds a new `NamesHistory` field to the `images.json`, which
is basically a deduped list of names the image had in the past. The
first entry of the list is the latest history entry.

The main use case for this feature is to tell the end-user which
names/tags an image had in the past if it does not contain any `names`
any more.

Detailed use case:
1. Pulling `image:v1` into the local registry: `names: [ "image:v1" ]`
2. Pushing a new image as `image:v1` into the remote registry
3. Pulling `image:v1` again into the local registry:
    - first image: `names: [ "image:v1" ]`
    - previous v1 image: `names: [], names-history: [ "image:v1" ]`
4. An consumer of the storage API can now process the image name and
   still display `image` as REPOSITORY, like:
   Before:
   ```
   > podman images
   REPOSITORY      TAG      IMAGE ID       CREATED          SIZE
   image           v1       25b62d1b654a   13 seconds ago   2.07 kB
   <none>          <none>   b134eff7b955   17 seconds ago   2.07 kB
   ```
   After:
   ```
   > podman images
   REPOSITORY      TAG      IMAGE ID       CREATED          SIZE
   image           v1       25b62d1b654a   13 seconds ago   2.07 kB
   image           <none>   b134eff7b955   17 seconds ago   2.07 kB
   ```
5. Since the `NamesHistory` is a slice we would be able to tell the
   end-user which names an image ID had before.

The change should be backwards compatible with previous versions of
containers/storage.

/cc @mtrmac 