### PR TITLE
wrap ID or digest to ErrImageUnkown errors

### DIFF
--- a/images.go
+++ b/images.go
@@ -372,7 +372,7 @@ func (r *imageStore) ClearFlag(id string, flag string) error {
 	}
 	image, ok := r.lookup(id)
 	if !ok {
-		return ErrImageUnknown
+		return errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
 	}
 	delete(image.Flags, flag)
 	return r.Save()
@@ -384,7 +384,7 @@ func (r *imageStore) SetFlag(id string, flag string, value interface{}) error {
 	}
 	image, ok := r.lookup(id)
 	if !ok {
-		return ErrImageUnknown
+		return errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
 	}
 	if image.Flags == nil {
 		image.Flags = make(map[string]interface{})
@@ -456,14 +456,14 @@ func (r *imageStore) addMappedTopLayer(id, layer string) error {
 		image.MappedTopLayers = append(image.MappedTopLayers, layer)
 		return r.Save()
 	}
-	return ErrImageUnknown
+	return errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
 }
 
 func (r *imageStore) Metadata(id string) (string, error) {
 	if image, ok := r.lookup(id); ok {
 		return image.Metadata, nil
 	}
-	return "", ErrImageUnknown
+	return "", errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
 }
 
 func (r *imageStore) SetMetadata(id, metadata string) error {
@@ -474,7 +474,7 @@ func (r *imageStore) SetMetadata(id, metadata string) error {
 		image.Metadata = metadata
 		return r.Save()
 	}
-	return ErrImageUnknown
+	return errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
 }
 
 func (r *imageStore) removeName(image *Image, name string) {
@@ -499,7 +499,7 @@ func (r *imageStore) SetNames(id string, names []string) error {
 		image.Names = names
 		return r.Save()
 	}
-	return ErrImageUnknown
+	return errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
 }
 
 func (r *imageStore) Delete(id string) error {
@@ -508,7 +508,7 @@ func (r *imageStore) Delete(id string) error {
 	}
 	image, ok := r.lookup(id)
 	if !ok {
-		return ErrImageUnknown
+		return errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
 	}
 	id = image.ID
 	toDeleteIndex := -1
@@ -551,14 +551,14 @@ func (r *imageStore) Get(id string) (*Image, error) {
 	if image, ok := r.lookup(id); ok {
 		return copyImage(image), nil
 	}
-	return nil, ErrImageUnknown
+	return nil, errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
 }
 
 func (r *imageStore) Lookup(name string) (id string, err error) {
 	if image, ok := r.lookup(name); ok {
 		return image.ID, nil
 	}
-	return "", ErrImageUnknown
+	return "", errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
 }
 
 func (r *imageStore) Exists(id string) bool {
@@ -570,7 +570,7 @@ func (r *imageStore) ByDigest(d digest.Digest) ([]*Image, error) {
 	if images, ok := r.bydigest[d]; ok {
 		return copyImageSlice(images), nil
 	}
-	return nil, ErrImageUnknown
+	return nil, errors.Wrapf(ErrImageUnknown, "error locating image with digest %q", d)
 }
 
 func (r *imageStore) BigData(id, key string) ([]byte, error) {
@@ -579,7 +579,7 @@ func (r *imageStore) BigData(id, key string) ([]byte, error) {
 	}
 	image, ok := r.lookup(id)
 	if !ok {
-		return nil, ErrImageUnknown
+		return nil, errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
 	}
 	return ioutil.ReadFile(r.datapath(image.ID, key))
 }
@@ -590,7 +590,7 @@ func (r *imageStore) BigDataSize(id, key string) (int64, error) {
 	}
 	image, ok := r.lookup(id)
 	if !ok {
-		return -1, ErrImageUnknown
+		return -1, errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
 	}
 	if image.BigDataSizes == nil {
 		image.BigDataSizes = make(map[string]int64)
@@ -610,7 +610,7 @@ func (r *imageStore) BigDataDigest(id, key string) (digest.Digest, error) {
 	}
 	image, ok := r.lookup(id)
 	if !ok {
-		return "", ErrImageUnknown
+		return "", errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
 	}
 	if image.BigDataDigests == nil {
 		image.BigDataDigests = make(map[string]digest.Digest)
@@ -624,7 +624,7 @@ func (r *imageStore) BigDataDigest(id, key string) (digest.Digest, error) {
 func (r *imageStore) BigDataNames(id string) ([]string, error) {
 	image, ok := r.lookup(id)
 	if !ok {
-		return nil, ErrImageUnknown
+		return nil, errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
 	}
 	return copyStringSlice(image.BigDataNames), nil
 }
@@ -649,7 +649,7 @@ func (r *imageStore) SetBigData(id, key string, data []byte, digestManifest func
 	}
 	image, ok := r.lookup(id)
 	if !ok {
-		return ErrImageUnknown
+		return errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
 	}
 	err := os.MkdirAll(r.datadir(image.ID), 0700)
 	if err != nil {

--- a/store.go
+++ b/store.go
@@ -1202,7 +1202,7 @@ func (s *store) CreateContainer(id string, names []string, image, layer, metadat
 			}
 		}
 		if cimage == nil {
-			return nil, ErrImageUnknown
+			return nil, errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
 		}
 		imageID = cimage.ID
 
@@ -1437,7 +1437,7 @@ func (s *store) ListImageBigData(id string) ([]string, error) {
 			return bigDataNames, err
 		}
 	}
-	return nil, ErrImageUnknown
+	return nil, errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
 }
 
 func (s *store) ImageBigDataSize(id, key string) (int64, error) {
@@ -1516,7 +1516,7 @@ func (s *store) ImageBigData(id, key string) ([]byte, error) {
 			return data, nil
 		}
 	}
-	return nil, ErrImageUnknown
+	return nil, errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
 }
 
 func (s *store) SetImageBigData(id, key string, data []byte, digestManifest func([]byte) (digest.Digest, error)) error {
@@ -2891,7 +2891,7 @@ func (s *store) Image(id string) (*Image, error) {
 			return image, nil
 		}
 	}
-	return nil, ErrImageUnknown
+	return nil, errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
 }
 
 func (s *store) ImagesByTopLayer(id string) ([]*Image, error) {
@@ -2953,7 +2953,7 @@ func (s *store) ImagesByDigest(d digest.Digest) ([]*Image, error) {
 			}
 		}
 		imageList, err := store.ByDigest(d)
-		if err != nil && err != ErrImageUnknown {
+		if err != nil && errors.Cause(err) != ErrImageUnknown {
 			return nil, err
 		}
 		images = append(images, imageList...)


### PR DESCRIPTION
Wrap the ID or the digest to ErrImageUnknown errors to avoid ambiguity
which image is unknown.  Consumers of the storage library may have
multiple subsequent calls to the storage API where it can be unclear
which image is unknown.  Wrapping the ID and digest attempts to avoid
this ambiguity.

Related-to:    github.com/containers/libpod/issues/2979
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@giuseppe @nalind @rhatdan PTAL