### PR TITLE
Move storage options to driver specific entries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,9 +15,6 @@ env:
     - GO_VERSION="stable"
       DISTRO="ubuntu"
 
-    - GO_VERSION="1.11"
-      DISTRO="ubuntu"
-
     - GO_VERSION="1.12"
       DISTRO="ubuntu"
 
@@ -25,17 +22,11 @@ env:
     - GO_VERSION="stable"
       DISTRO="fedora"
 
-    - GO_VERSION="1.11"
-      DISTRO="fedora"
-
     - GO_VERSION="1.12"
       DISTRO="fedora"
 
     # CentOS
     - GO_VERSION="stable"
-      DISTRO="centos"
-
-    - GO_VERSION="1.11"
       DISTRO="centos"
 
     - GO_VERSION="1.12"

--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -62,7 +62,7 @@ export DEBIAN_FRONTEND=noninteractive
 # Short-cut for frequently used base command
 export SUDOAPTGET='sudo -E apt-get -q --yes'
 # Short list of packages or quick-running command
-SHORT_APTGET="timeout_attempt_delay_command 24s 5 30s $SUDOAPTGET"
+SHORT_APTGET="timeout_attempt_delay_command 120s 5 60s $SUDOAPTGET"
 # Long list / long-running command
 LONG_APTGET="timeout_attempt_delay_command 300s 5 60s $SUDOAPTGET"
 

--- a/docs/containers-storage.conf.5.md
+++ b/docs/containers-storage.conf.5.md
@@ -6,9 +6,7 @@
 storage.conf - Syntax of Container Storage configuration file
 
 ## DESCRIPTION
-The STORAGE configuration file specifies all of the available container storage options
-for tools using shared container storage, but in a TOML format that can be more easily modified
-and versioned.
+The STORAGE configuration file specifies all of the available container storage options for tools using shared container storage, but in a TOML format that can be more easily modified and versioned.
 
 ## FORMAT
 The [TOML format][toml] is used as the encoding of the configuration file.
@@ -30,17 +28,15 @@ The `storage` table supports the following options:
 
 **driver**=""
   container storage driver (default: "overlay")
-  Default Copy On Write (COW) container storage driver
-  Valid drivers are "overlay", "vfs", "devmapper", "aufs", "btrfs", and "zfs"
-  Some drivers (for example, "zfs", "btrfs", and "aufs") may not work if your kernel lacks support for the filesystem
+  Default Copy On Write (COW) container storage driver. Valid drivers are "overlay", "vfs", "devmapper", "aufs", "btrfs", and "zfs". Some drivers (for example, "zfs", "btrfs", and "aufs") may not work if your kernel lacks support for the filesystem.
 
 **graphroot**=""
   container storage graph dir (default: "/var/lib/containers/storage")
-  Default directory to store all writable content created by container storage programs
+  Default directory to store all writable content created by container storage programs.
 
 **runroot**=""
   container storage run dir (default: "/var/run/containers/storage")
-  Default directory to store all temporary writable content created by container storage programs
+  Default directory to store all temporary writable content created by container storage programs.
 
 ### STORAGE OPTIONS TABLE
 
@@ -49,88 +45,68 @@ The `storage.options` table supports the following options:
 **additionalimagestores**=[]
   Paths to additional container image stores. Usually these are read/only and stored on remote network shares.
 
-**ignore_chown_errors** = "true|False"
-  ignore_chown_errors can be set to allow a non privileged user running with a  single UID within a user namespace to run containers. The user can pull and use any image even those with multiple uids.  Note multiple UIDs will be squasheddown to the default uid in the container.  These images will have no separation between the users in the container. Only supported for the overlay and vfs drivers.
-
-**mount_program**=""
-  Specifies the path to a custom program to use instead of using kernel defaults for mounting the file system.
-
-      mount_program = "/usr/bin/fuse-overlayfs"
-
-**mountopt**=""
-
-  Comma separated list of default options to be used to mount container images.  Suggested value "nodev".
-
-**size**=""
-  Maximum size of a container image.   This flag can be used to set quota on the size of container images. (default: 10GB)
-
 **remap-uids=**""
 **remap-gids=**""
+  Remap-UIDs/GIDs is the mapping from UIDs/GIDs as they should appear inside of a container, to the UIDs/GIDs outside of the container, and the length of the range of UIDs/GIDs.  Additional mapped sets can be listed and will be heeded by libraries, but there are limits to the number of mappings which the kernel will allow when you later attempt to run a container.
 
-  Remap-UIDs/GIDs is the mapping from UIDs/GIDs as they should appear inside of
-a container, to the UIDs/GIDs outside of the container, and the length of the
-range of UIDs/GIDs.  Additional mapped sets can be listed and will be heeded by
-libraries, but there are limits to the number of mappings which the kernel will
-allow when you later attempt to run a container.
-
-     Example
+  Example
      remap-uids = 0:1668442479:65536
      remap-gids = 0:1668442479:65536
 
-     These mappings tell the container engines to map UID 0 inside of the
-     container to UID 1668442479 outside.  UID 1 will be mapped to 1668442480.
-     UID 2 will be mapped to 1668442481, etc, for the next 65533 UIDs in
-     Succession.
+  These mappings tell the container engines to map UID 0 inside of the container to UID 1668442479 outside.  UID 1 will be mapped to 1668442480. UID 2 will be mapped to 1668442481, etc, for the next 65533 UIDs in succession.
 
 **remap-user**=""
 **remap-group**=""
+  Remap-User/Group is a user name which can be used to look up one or more UID/GID ranges in the /etc/subuid or /etc/subgid file.  Mappings are set up starting with an in-container ID of 0 and then a host-level ID taken from the lowest range that matches the specified name, and using the length of that range. Additional ranges are then assigned, using the ranges which specify the lowest host-level IDs first, to the lowest not-yet-mapped in-container ID, until all of the entries have been used for maps.
 
-  Remap-User/Group is a user name which can be used to look up one or more UID/GID
-ranges in the /etc/subuid or /etc/subgid file.  Mappings are set up starting
-with an in-container ID of 0 and then a host-level ID taken from the lowest
-range that matches the specified name, and using the length of that range.
-Additional ranges are then assigned, using the ranges which specify the
-lowest host-level IDs first, to the lowest not-yet-mapped in-container ID,
-until all of the entries have been used for maps.
+  Example
+     remap-user = "storage"
+     remap-group = "storage"
 
-      remap-user = "storage"
-      remap-group = "storage"
+### STORAGE OPTIONS FOR AUFS TABLE
 
-### STORAGE OPTIONS FOR THINPOOL TABLE
+The `storage.options.aufs` table supports the following options:
 
-The `storage.options.thinpool` table supports the following options:
+**mountopt**=""
+  Comma separated list of default options to be used to mount container images.  Suggested value "nodev". Mount options are documented in the mount(8) man page.
+
+### STORAGE OPTIONS FOR BTRFS TABLE
+
+The `storage.options.btrfs` table supports the following options:
+
+**min_space**=""
+  Specifies the min space in a btrfs volume.
+
+**size**=""
+  Maximum size of a container image.   This flag can be used to set quota on the size of container images. (format: <number>[<unit>], where unit = b (bytes), k (kilobytes), m (megabytes), or g (gigabytes))
+
+### STORAGE OPTIONS FOR THINPOOL (devicemapper) TABLE
+
+The `storage.options.thinpool` table supports the following options for the `devicemapper` driver:
 
 **autoextend_percent**=""
-
-Tells the thinpool driver the amount by which the thinpool needs to be grown. This is specified in terms of % of pool size. So a value of 20 means that when threshold is hit, pool will be grown by 20% of existing pool size. (default: 20%)
+  Tells the thinpool driver the amount by which the thinpool needs to be grown. This is specified in terms of % of pool size. So a value of 20 means that when threshold is hit, pool will be grown by 20% of existing pool size. (default: 20%)
 
 **autoextend_threshold**=""
-
-Tells the driver the thinpool extension threshold in terms of percentage of pool size. For example, if threshold is 60, that means when pool is 60% full, threshold has been hit. (default: 80%)
+  Tells the driver the thinpool extension threshold in terms of percentage of pool size. For example, if threshold is 60, that means when pool is 60% full, threshold has been hit. (default: 80%)
 
 **basesize**=""
-
-Specifies the size to use when creating the base device, which limits the size of images and containers. (default: 10g)
+  Specifies the size to use when creating the base device, which limits the size of images and containers. (default: 10g)
 
 **blocksize**=""
-
-Specifies a custom blocksize to use for the thin pool. (default: 64k)
+  Specifies a custom blocksize to use for the thin pool. (default: 64k)
 
 **directlvm_device**=""
-
-Specifies a custom block storage device to use for the thin pool. Required for using graphdriver `devicemapper`.
+  Specifies a custom block storage device to use for the thin pool. Required for using graphdriver `devicemapper`.
 
 **directlvm_device_force**=""
-
-Tells driver to wipe device (directlvm_device) even if device already has a filesystem.  (default: false)
+  Tells driver to wipe device (directlvm_device) even if device already has a filesystem.  (default: false)
 
 **fs**="xfs"
-
-Specifies the filesystem type to use for the base device. (default: xfs)
+  Specifies the filesystem type to use for the base device. (default: xfs)
 
 **log_level**=""
-
-Sets the log level of devicemapper.
+  Sets the log level of devicemapper.
 
     0: LogLevelSuppress 0 (default)
     2: LogLevelFatal
@@ -141,51 +117,87 @@ Sets the log level of devicemapper.
     7: LogLevelDebug
 
 **min_free_space**=""
-
-Specifies the min free space percent in a thin pool required for new device creation to succeed. Valid values are from 0% - 99%. Value 0% disables. (default: 10%)
+  Specifies the min free space percent in a thin pool required for new device creation to succeed. Valid values are from 0% - 99%. Value 0% disables. (default: 10%)
 
 **mkfsarg**=""
+  Specifies extra mkfs arguments to be used when creating the base device.
 
-Specifies extra mkfs arguments to be used when creating the base device.
+**mountopt**=""
+  Comma separated list of default options to be used to mount container images.  Suggested value "nodev". Mount options are documented in the mount(8) man page.
+
+**size**=""
+  Maximum size of a container image.   This flag can be used to set quota on the size of container images. (format: <number>[<unit>], where unit = b (bytes), k (kilobytes), m (megabytes), or g (gigabytes))
 
 **use_deferred_deletion**=""
-
-Marks thinpool device for deferred deletion. If the thinpool is in use when the driver attempts to delete it, the driver will attempt to delete device every 30 seconds until successful, or when it restarts.  Deferred deletion permanently deletes the device and all data stored in the device will be lost. (default: true).
+  Marks thinpool device for deferred deletion. If the thinpool is in use when the driver attempts to delete it, the driver will attempt to delete device every 30 seconds until successful, or when it restarts.  Deferred deletion permanently deletes the device and all data stored in the device will be lost. (default: true).
 
 **use_deferred_removal**=""
-
-Marks devicemapper block device for deferred removal.  If the device is in use when its driver attempts to remove it, the driver tells the kernel to remove the device as soon as possible.  Note this does not free up the disk space, use deferred deletion to fully remove the thinpool.  (default: true).
+  Marks devicemapper block device for deferred removal.  If the device is in use when its driver attempts to remove it, the driver tells the kernel to remove the device as soon as possible.  Note this does not free up the disk space, use deferred deletion to fully remove the thinpool.  (default: true).
 
 **xfs_nospace_max_retries**=""
+  Specifies the maximum number of retries XFS should attempt to complete IO when ENOSPC (no space) error is returned by underlying storage device. (default: 0, which means to try continuously.)
 
-Specifies the maximum number of retries XFS should attempt to complete IO when ENOSPC (no space) error is returned by underlying storage device. (default: 0, which means to try continuously.)
+### STORAGE OPTIONS FOR OVERLAY TABLE
+
+The `storage.options.overlay` table supports the following options:
+
+**ignore_chown_errors** = "false"
+  ignore_chown_errors can be set to allow a non privileged user running with a  single UID within a user namespace to run containers. The user can pull and use any image even those with multiple uids.  Note multiple UIDs will be squashed down to the default uid in the container.  These images will have no separation between the users in the container. (default: false)
+
+**mount_program**=""
+  Specifies the path to a custom program to use instead of using kernel defaults for mounting the file system.
+  mount_program = "/usr/bin/fuse-overlayfs"
+
+**mountopt**=""
+  Comma separated list of default options to be used to mount container images.  Suggested value "nodev". Mount options are documented in the mount(8) man page.
+
+**size**=""
+  Maximum size of a container image.   This flag can be used to set quota on the size of container images. (format: <number>[<unit>], where unit = b (bytes), k (kilobytes), m (megabytes), or g (gigabytes))
+
+**skip_mount_home** = "false"
+  Set to skip a PRIVATE bind mount on the storage home directory.
+
+### STORAGE OPTIONS FOR VFS TABLE
+
+The `storage.options.vfs` table supports the following options:
+
+**ignore_chown_errors** = "false"
+  ignore_chown_errors can be set to allow a non privileged user running with a  single UID within a user namespace to run containers. The user can pull and use any image even those with multiple uids.  Note multiple UIDs will be squashed down to the default uid in the container.  These images will have no separation between the users in the container. (default: false)
+
+### STORAGE OPTIONS FOR ZFS TABLE
+
+The `storage.options.zfs` table supports the following options:
+
+**fsname**=""
+  File System name for the zfs driver
+
+**mountopt**=""
+  Comma separated list of default options to be used to mount container images.  Suggested value "nodev". Mount options are documented in the mount(8) man page.
+
+**size**=""
+  Maximum size of a container image.   This flag can be used to set quota on the size of container images. (format: <number>[<unit>], where unit = b (bytes), k (kilobytes), m (megabytes), or g (gigabytes))
 
 ## SELINUX LABELING
 
 When running on an SELinux system, if you move the containers storage graphroot directory, you must make sure the labeling is correct.
 
-Tell SELinux about the new containers storage by setting up an equivalence record.
-This tells SELinux to label content under the new path, as if it was stored
-under `/var/lib/containers/storage`.
+Tell SELinux about the new containers storage by setting up an equivalence record. This tells SELinux to label content under the new path, as if it was stored under `/var/lib/containers/storage`.
 
 ```
 semanage fcontext -a -e /var/lib/containers NEWSTORAGEPATH
 restorecon -R -v NEWSTORAGEPATH
 ```
 
-The semanage command above tells SELinux to setup the default labeling of
-`NEWSTORAGEPATH` to match `/var/lib/containers`.  The `restorecon` command
-tells SELinux to apply the labels to the actual content.
+The semanage command above tells SELinux to setup the default labeling of `NEWSTORAGEPATH` to match `/var/lib/containers`.  The `restorecon` command tells SELinux to apply the labels to the actual content.
 
-Now all new content created in these directories will automatically be created
-with the correct label.
+Now all new content created in these directories will automatically be created with the correct label.
 
 ## SEE ALSO
-`semanage(8)`, `restorecon(8)`
+`semanage(8)`, `restorecon(8)`, `mount(8)`
 
 ## FILES
 
-Distributions often provide a /usr/share/containers/storage.conf file to define default storage configuration. Administrators can override this file by creating `/etc/containers/storage.conf` to specify their own configuration. The storage.conf file for rootless users is stored in the $HOME/.config/containers/storage.conf file.
+Distributions often provide a `/usr/share/containers/storage.conf` file to define default storage configuration. Administrators can override this file by creating `/etc/containers/storage.conf` to specify their own configuration. The storage.conf file for rootless users is stored in the `$HOME/.config/containers/storage.conf` file.
 
 ## HISTORY
 May 2017, Originally compiled by Dan Walsh <dwalsh@redhat.com>

--- a/go.mod
+++ b/go.mod
@@ -26,3 +26,5 @@ require (
 	golang.org/x/sys v0.0.0-20190626221950-04f50cda93cb
 	gotest.tools v0.0.0-20190624233834-05ebafbffc79
 )
+
+go 1.13

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -1,5 +1,9 @@
 package config
 
+import (
+	"fmt"
+)
+
 // ThinpoolOptionsConfig represents the "storage.options.thinpool"
 // TOML config table.
 type ThinpoolOptionsConfig struct {
@@ -47,6 +51,9 @@ type ThinpoolOptionsConfig struct {
 	// devices.
 	MountOpt string `toml:"mountopt"`
 
+	// Size
+	Size string `toml:"size"`
+
 	// UseDeferredDeletion marks device for deferred deletion
 	UseDeferredDeletion string `toml:"use_deferred_deletion"`
 
@@ -57,6 +64,47 @@ type ThinpoolOptionsConfig struct {
 	// retries XFS should attempt to complete IO when ENOSPC (no space)
 	// error is returned by underlying storage device.
 	XfsNoSpaceMaxRetries string `toml:"xfs_nospace_max_retries"`
+}
+
+type AufsOptionsConfig struct {
+	// MountOpt specifies extra mount options used when mounting
+	MountOpt string `toml:"mountopt"`
+}
+
+type BtrfsOptionsConfig struct {
+	// MinSpace is the minimal spaces allocated to the device
+	MinSpace string `toml:"min_space"`
+	// Size
+	Size string `toml:"size"`
+}
+
+type OverlayOptionsConfig struct {
+	// IgnoreChownErrors is a flag for whether chown errors should be
+	// ignored when building an image.
+	IgnoreChownErrors string `toml:"ignore_chown_errors"`
+	// MountOpt specifies extra mount options used when mounting
+	MountOpt string `toml:"mountopt"`
+	// Alternative program to use for the mount of the file system
+	MountProgram string `toml:"mount_program"`
+	// Size
+	Size string `toml:"size"`
+	// Do not create a bind mount on the storage home
+	SkipMountHome string `toml:"skip_mount_home"`
+}
+
+type VfsOptionsConfig struct {
+	// IgnoreChownErrors is a flag for whether chown errors should be
+	// ignored when building an image.
+	IgnoreChownErrors string `toml:"ignore_chown_errors"`
+}
+
+type ZfsOptionsConfig struct {
+	// MountOpt specifies extra mount options used when mounting
+	MountOpt string `toml:"mountopt"`
+	// Name is the File System name of the ZFS File system
+	Name string `toml:"fsname"`
+	// Size
+	Size string `toml:"size"`
 }
 
 // OptionsConfig represents the "storage.options" TOML config table.
@@ -83,12 +131,158 @@ type OptionsConfig struct {
 	// RemapGroup is the name of one or more entries in /etc/subgid which
 	// should be used to set up default GID mappings.
 	RemapGroup string `toml:"remap-group"`
+
+	// Aufs container options to be handed to aufs drivers
+	Aufs struct{ AufsOptionsConfig } `toml:"aufs"`
+
+	// Btrfs container options to be handed to btrfs drivers
+	Btrfs struct{ BtrfsOptionsConfig } `toml:"btrfs"`
+
 	// Thinpool container options to be handed to thinpool drivers
 	Thinpool struct{ ThinpoolOptionsConfig } `toml:"thinpool"`
+
+	// Overlay container options to be handed to overlay drivers
+	Overlay struct{ OverlayOptionsConfig } `toml:"overlay"`
+
+	// Vfs container options to be handed to VFS drivers
+	Vfs struct{ VfsOptionsConfig } `toml:"vfs"`
+
+	// Zfs container options to be handed to ZFS drivers
+	Zfs struct{ ZfsOptionsConfig } `toml:"zfs"`
+
+	// Do not create a bind mount on the storage home
+	SkipMountHome string `toml:"skip_mount_home"`
 
 	// Alternative program to use for the mount of the file system
 	MountProgram string `toml:"mount_program"`
 
 	// MountOpt specifies extra mount options used when mounting
 	MountOpt string `toml:"mountopt"`
+}
+
+// GetGraphDriverOptions returns the driver specific options
+func GetGraphDriverOptions(driverName string, options OptionsConfig) []string {
+	var doptions []string
+	switch driverName {
+	case "aufs":
+		if options.Aufs.MountOpt != "" {
+			return append(doptions, fmt.Sprintf("%s.mountopt=%s", driverName, options.Aufs.MountOpt))
+		} else if options.MountOpt != "" {
+			doptions = append(doptions, fmt.Sprintf("%s.mountopt=%s", driverName, options.MountOpt))
+		}
+
+	case "btrfs":
+		if options.Btrfs.MinSpace != "" {
+			return append(doptions, fmt.Sprintf("%s.min_space=%s", driverName, options.Btrfs.MinSpace))
+		}
+		if options.Btrfs.Size != "" {
+			doptions = append(doptions, fmt.Sprintf("%s.size=%s", driverName, options.Btrfs.Size))
+		} else if options.Size != "" {
+			doptions = append(doptions, fmt.Sprintf("%s.size=%s", driverName, options.Size))
+		}
+
+	case "devicemapper":
+		if options.Thinpool.AutoExtendPercent != "" {
+			doptions = append(doptions, fmt.Sprintf("dm.thinp_autoextend_percent=%s", options.Thinpool.AutoExtendPercent))
+		}
+		if options.Thinpool.AutoExtendThreshold != "" {
+			doptions = append(doptions, fmt.Sprintf("dm.thinp_autoextend_threshold=%s", options.Thinpool.AutoExtendThreshold))
+		}
+		if options.Thinpool.BaseSize != "" {
+			doptions = append(doptions, fmt.Sprintf("dm.basesize=%s", options.Thinpool.BaseSize))
+		}
+		if options.Thinpool.BlockSize != "" {
+			doptions = append(doptions, fmt.Sprintf("dm.blocksize=%s", options.Thinpool.BlockSize))
+		}
+		if options.Thinpool.DirectLvmDevice != "" {
+			doptions = append(doptions, fmt.Sprintf("dm.directlvm_device=%s", options.Thinpool.DirectLvmDevice))
+		}
+		if options.Thinpool.DirectLvmDeviceForce != "" {
+			doptions = append(doptions, fmt.Sprintf("dm.directlvm_device_force=%s", options.Thinpool.DirectLvmDeviceForce))
+		}
+		if options.Thinpool.Fs != "" {
+			doptions = append(doptions, fmt.Sprintf("dm.fs=%s", options.Thinpool.Fs))
+		}
+		if options.Thinpool.LogLevel != "" {
+			doptions = append(doptions, fmt.Sprintf("dm.libdm_log_level=%s", options.Thinpool.LogLevel))
+		}
+		if options.Thinpool.MinFreeSpace != "" {
+			doptions = append(doptions, fmt.Sprintf("dm.min_free_space=%s", options.Thinpool.MinFreeSpace))
+		}
+		if options.Thinpool.MkfsArg != "" {
+			doptions = append(doptions, fmt.Sprintf("dm.mkfsarg=%s", options.Thinpool.MkfsArg))
+		}
+		if options.Thinpool.MountOpt != "" {
+			doptions = append(doptions, fmt.Sprintf("%s.mountopt=%s", driverName, options.Thinpool.MountOpt))
+		} else if options.MountOpt != "" {
+			doptions = append(doptions, fmt.Sprintf("%s.mountopt=%s", driverName, options.MountOpt))
+		}
+
+		if options.Thinpool.Size != "" {
+			doptions = append(doptions, fmt.Sprintf("%s.size=%s", driverName, options.Thinpool.Size))
+		} else if options.Size != "" {
+			doptions = append(doptions, fmt.Sprintf("%s.size=%s", driverName, options.Size))
+		}
+
+		if options.Thinpool.UseDeferredDeletion != "" {
+			doptions = append(doptions, fmt.Sprintf("dm.use_deferred_deletion=%s", options.Thinpool.UseDeferredDeletion))
+		}
+		if options.Thinpool.UseDeferredRemoval != "" {
+			doptions = append(doptions, fmt.Sprintf("dm.use_deferred_removal=%s", options.Thinpool.UseDeferredRemoval))
+		}
+		if options.Thinpool.XfsNoSpaceMaxRetries != "" {
+			doptions = append(doptions, fmt.Sprintf("dm.xfs_nospace_max_retries=%s", options.Thinpool.XfsNoSpaceMaxRetries))
+		}
+
+	case "overlay":
+		if options.Overlay.IgnoreChownErrors != "" {
+			doptions = append(doptions, fmt.Sprintf("%s.ignore_chown_errors=%s", driverName, options.Overlay.IgnoreChownErrors))
+		} else if options.IgnoreChownErrors != "" {
+			doptions = append(doptions, fmt.Sprintf("%s.ignore_chown_errors=%s", driverName, options.IgnoreChownErrors))
+		}
+		if options.Overlay.MountProgram != "" {
+			doptions = append(doptions, fmt.Sprintf("%s.mount_program=%s", driverName, options.Overlay.MountProgram))
+		} else if options.MountProgram != "" {
+			doptions = append(doptions, fmt.Sprintf("%s.mount_program=%s", driverName, options.MountProgram))
+		}
+		if options.Overlay.MountOpt != "" {
+			doptions = append(doptions, fmt.Sprintf("%s.mountopt=%s", driverName, options.Overlay.MountOpt))
+		} else if options.MountOpt != "" {
+			doptions = append(doptions, fmt.Sprintf("%s.mountopt=%s", driverName, options.MountOpt))
+		}
+		if options.Overlay.Size != "" {
+			doptions = append(doptions, fmt.Sprintf("%s.size=%s", driverName, options.Overlay.Size))
+		} else if options.Size != "" {
+			doptions = append(doptions, fmt.Sprintf("%s.size=%s", driverName, options.Size))
+		}
+
+		if options.Overlay.SkipMountHome != "" {
+			doptions = append(doptions, fmt.Sprintf("%s.skip_mount_home=%s", driverName, options.Overlay.SkipMountHome))
+		} else if options.SkipMountHome != "" {
+			doptions = append(doptions, fmt.Sprintf("%s.skip_mount_home=%s", driverName, options.SkipMountHome))
+		}
+
+	case "vfs":
+		if options.Vfs.IgnoreChownErrors != "" {
+			doptions = append(doptions, fmt.Sprintf("%s.ignore_chown_errors=%s", driverName, options.Vfs.IgnoreChownErrors))
+		} else if options.IgnoreChownErrors != "" {
+			doptions = append(doptions, fmt.Sprintf("%s.ignore_chown_errors=%s", driverName, options.IgnoreChownErrors))
+		}
+
+	case "zfs":
+		if options.Zfs.Name != "" {
+			doptions = append(doptions, fmt.Sprintf("%s.fsname=%s", driverName, options.Zfs.Name))
+		}
+		if options.Zfs.MountOpt != "" {
+			doptions = append(doptions, fmt.Sprintf("%s.mountopt=%s", driverName, options.Zfs.MountOpt))
+		} else if options.MountOpt != "" {
+			doptions = append(doptions, fmt.Sprintf("%s.mountopt=%s", driverName, options.MountOpt))
+		}
+		if options.Zfs.Size != "" {
+			doptions = append(doptions, fmt.Sprintf("%s.size=%s", driverName, options.Zfs.Size))
+		} else if options.Size != "" {
+			doptions = append(doptions, fmt.Sprintf("%s.size=%s", driverName, options.Size))
+		}
+	}
+	return doptions
 }

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -1,0 +1,350 @@
+package config
+
+import (
+	"strings"
+	"testing"
+)
+
+func searchOptions(options []string, value string) bool {
+	for _, s := range options {
+		if strings.Contains(s, value) {
+			return true
+		}
+	}
+	return false
+}
+
+func TestAufsOptions(t *testing.T) {
+	var (
+		doptions []string
+		options  OptionsConfig
+	)
+	doptions = GetGraphDriverOptions("aufs", options)
+	if len(doptions) != 0 {
+		t.Fatalf("Expected 0 options, got %v", doptions)
+	}
+	// Make sure legacy mountopt still works
+	options = OptionsConfig{}
+	options.MountOpt = "foobar"
+	doptions = GetGraphDriverOptions("aufs", options)
+	if len(doptions) == 0 {
+		t.Fatalf("Expected 0 options, got %v", doptions)
+	}
+	if !searchOptions(doptions, "mountopt=foobar") {
+		t.Fatalf("Expected to find 'foobar' options, got %v", doptions)
+	}
+
+	// Make sure Aufs ignores other drivers mountpoints takes presedence
+	options.Zfs.MountOpt = "nodev"
+	doptions = GetGraphDriverOptions("aufs", options)
+	if searchOptions(doptions, "mountopt=nodev") {
+		t.Fatalf("Expected to find 'nodev' options, got %v", doptions)
+	}
+
+	// Make sure AufsMountOpt takes precedence
+	options.Aufs.MountOpt = "nodev"
+	doptions = GetGraphDriverOptions("aufs", options)
+	if len(doptions) == 0 {
+		t.Fatalf("Expected 0 options, got %v", doptions)
+	}
+	if !searchOptions(doptions, "mountopt=nodev") {
+		t.Fatalf("Expected to find 'nodev' options, got %v", doptions)
+	}
+}
+
+func TestDeviceMapperOptions(t *testing.T) {
+	var (
+		doptions []string
+		options  OptionsConfig
+	)
+	doptions = GetGraphDriverOptions("devicemapper", options)
+	if len(doptions) != 0 {
+		t.Fatalf("Expected 0 options, got %v", doptions)
+	}
+	// Make sure legacy mountopt still works
+	options = OptionsConfig{}
+	options.MountOpt = "foobar"
+	doptions = GetGraphDriverOptions("devicemapper", options)
+	if len(doptions) == 0 {
+		t.Fatalf("Expected 0 options, got %v", doptions)
+	}
+	if !searchOptions(doptions, "mountopt=foobar") {
+		t.Fatalf("Expected to find 'foobar' options, got %v", doptions)
+	}
+
+	// Make sure Devicemapper ignores other drivers mountpoints takes presedence
+	options.Zfs.MountOpt = "nodev"
+	doptions = GetGraphDriverOptions("devicemapper", options)
+	if searchOptions(doptions, "mountopt=nodev") {
+		t.Fatalf("Expected to find 'nodev' options, got %v", doptions)
+	}
+
+	// Make sure DevicemapperMountOpt takes precedence
+	options.Thinpool.MountOpt = "nodev"
+	doptions = GetGraphDriverOptions("devicemapper", options)
+	if len(doptions) == 0 {
+		t.Fatalf("Expected 0 options, got %v", doptions)
+	}
+	if !searchOptions(doptions, "mountopt=nodev") {
+		t.Fatalf("Expected to find 'nodev' options, got %v", doptions)
+	}
+
+	options = OptionsConfig{}
+	options.Thinpool.AutoExtendPercent = "50"
+	doptions = GetGraphDriverOptions("devicemapper", options)
+	if len(doptions) == 0 {
+		t.Fatalf("Expected 0 options, got %v", doptions)
+	}
+	if !searchOptions(doptions, "50") {
+		t.Fatalf("Expected to find '50' options, got %v", doptions)
+	}
+	options.Size = "200"
+	doptions = GetGraphDriverOptions("devicemapper", options)
+	if len(doptions) == 0 {
+		t.Fatalf("Expected 0 options, got %v", doptions)
+	}
+	if !searchOptions(doptions, "200") {
+		t.Fatalf("Expected to find size '200' options, got %v", doptions)
+	}
+	// Make sure Thinpool.Size takes precedence
+	options.Thinpool.Size = "100"
+	doptions = GetGraphDriverOptions("devicemapper", options)
+	if len(doptions) == 0 {
+		t.Fatalf("Expected 0 options, got %v", doptions)
+	}
+	if !searchOptions(doptions, "100") {
+		t.Fatalf("Expected to find size '100', got %v", doptions)
+	}
+
+}
+
+func TestBtrfsOptions(t *testing.T) {
+	var (
+		doptions []string
+		options  OptionsConfig
+	)
+	doptions = GetGraphDriverOptions("btrfs", options)
+	if len(doptions) != 0 {
+		t.Fatalf("Expected 0 options, got %v", doptions)
+	}
+	// Make sure legacy mountopt still works
+	options = OptionsConfig{}
+	options.Btrfs.MinSpace = "100"
+	doptions = GetGraphDriverOptions("btrfs", options)
+	if len(doptions) == 0 {
+		t.Fatalf("Expected 0 options, got %v", doptions)
+	}
+	if !searchOptions(doptions, "100") {
+		t.Fatalf("Expected to find '100' options, got %v", doptions)
+	}
+
+	options = OptionsConfig{}
+	options.Size = "200"
+	doptions = GetGraphDriverOptions("btrfs", options)
+	if len(doptions) == 0 {
+		t.Fatalf("Expected 0 options, got %v", doptions)
+	}
+	if !searchOptions(doptions, "200") {
+		t.Fatalf("Expected to find size '200' options, got %v", doptions)
+	}
+	// Make sure Btrfs.Size takes precedence
+	options.Btrfs.Size = "100"
+	doptions = GetGraphDriverOptions("btrfs", options)
+	if len(doptions) == 0 {
+		t.Fatalf("Expected 0 options, got %v", doptions)
+	}
+	if !searchOptions(doptions, "100") {
+		t.Fatalf("Expected to find size '100', got %v", doptions)
+	}
+
+}
+
+func TestOverlayOptions(t *testing.T) {
+	var (
+		doptions []string
+		options  OptionsConfig
+	)
+	doptions = GetGraphDriverOptions("overlay", options)
+	if len(doptions) != 0 {
+		t.Fatalf("Expected 0 options, got %v", doptions)
+	}
+	options.Vfs.IgnoreChownErrors = "true"
+	doptions = GetGraphDriverOptions("overlay", options)
+	if len(doptions) != 0 {
+		t.Fatalf("Expected 0 options, got %v", doptions)
+	}
+	options.Overlay.IgnoreChownErrors = "true"
+	doptions = GetGraphDriverOptions("overlay", options)
+	if len(doptions) == 0 {
+		t.Fatalf("Expected 1 options, got %v", doptions)
+	}
+	options.Overlay.IgnoreChownErrors = "false"
+	doptions = GetGraphDriverOptions("overlay", options)
+	if len(doptions) == 0 {
+		t.Fatalf("Expected 0 options, got %v", doptions)
+	}
+
+	// Make sure legacy IgnoreChownErrors still works
+	options = OptionsConfig{}
+	options.IgnoreChownErrors = "true"
+	doptions = GetGraphDriverOptions("overlay", options)
+	if len(doptions) == 0 {
+		t.Fatalf("Expected 1 options, got %v", doptions)
+	}
+	// Make sure legacy mountopt still works
+	options = OptionsConfig{}
+	options.MountOpt = "foobar"
+	doptions = GetGraphDriverOptions("overlay", options)
+	if len(doptions) == 0 {
+		t.Fatalf("Expected 0 options, got %v", doptions)
+	}
+	if !searchOptions(doptions, "mountopt=foobar") {
+		t.Fatalf("Expected to find 'foobar' options, got %v", doptions)
+	}
+
+	// Make sure Overlay ignores other drivers mountpoints takes presedence
+	options.Zfs.MountOpt = "nodev"
+	doptions = GetGraphDriverOptions("overlay", options)
+	if searchOptions(doptions, "mountopt=nodev") {
+		t.Fatalf("Expected to find 'nodev' options, got %v", doptions)
+	}
+
+	// Make sure OverlayMountOpt takes precedence
+	options.Overlay.MountOpt = "nodev"
+	doptions = GetGraphDriverOptions("overlay", options)
+	if len(doptions) == 0 {
+		t.Fatalf("Expected 0 options, got %v", doptions)
+	}
+	if !searchOptions(doptions, "mountopt=nodev") {
+		t.Fatalf("Expected to find 'nodev' options, got %v", doptions)
+	}
+
+	// Make sure mount_program takes precedence
+	options.MountProgram = "/usr/bin/root_overlay"
+	doptions = GetGraphDriverOptions("overlay", options)
+	if len(doptions) == 0 {
+		t.Fatalf("Expected 0 options, got %v", doptions)
+	}
+	if !searchOptions(doptions, "mount_program=/usr/bin/root_overlay") {
+		t.Fatalf("Expected to find 'root_overlay' options, got %v", doptions)
+	}
+	options.Overlay.MountProgram = "/usr/bin/fuse_overlay"
+	doptions = GetGraphDriverOptions("overlay", options)
+	if len(doptions) == 0 {
+		t.Fatalf("Expected 0 options, got %v", doptions)
+	}
+	if !searchOptions(doptions, "mount_program=/usr/bin/fuse_overlay") {
+		t.Fatalf("Expected to find 'fuse_overlay' options, got %v", doptions)
+	}
+	options.Overlay.SkipMountHome = "true"
+	doptions = GetGraphDriverOptions("overlay", options)
+	if len(doptions) == 0 {
+		t.Fatalf("Expected 0 options, got %v", doptions)
+	}
+	if !searchOptions(doptions, "skip_mount_home") {
+		t.Fatalf("Expected to find 'skip_mount_home' options, got %v", doptions)
+	}
+
+	// Make sure legacy mountopt still works
+	options = OptionsConfig{}
+	options.SkipMountHome = "true"
+	doptions = GetGraphDriverOptions("overlay", options)
+	if len(doptions) == 0 {
+		t.Fatalf("Expected 0 options, got %v", doptions)
+	}
+	if !searchOptions(doptions, "skip_mount_home") {
+		t.Fatalf("Expected to find 'skip_mount_home' options, got %v", doptions)
+	}
+
+	options.Size = "200"
+	doptions = GetGraphDriverOptions("overlay", options)
+	if len(doptions) == 0 {
+		t.Fatalf("Expected 0 options, got %v", doptions)
+	}
+	if !searchOptions(doptions, "200") {
+		t.Fatalf("Expected to find size '200' options, got %v", doptions)
+	}
+	// Make sure Overlay.Size takes precedence
+	options.Overlay.Size = "100"
+	doptions = GetGraphDriverOptions("overlay", options)
+	if len(doptions) == 0 {
+		t.Fatalf("Expected 0 options, got %v", doptions)
+	}
+	if !searchOptions(doptions, "100") {
+		t.Fatalf("Expected to find size '100', got %v", doptions)
+	}
+
+}
+
+func TestVfsOptions(t *testing.T) {
+	var (
+		doptions []string
+		options  OptionsConfig
+	)
+	doptions = GetGraphDriverOptions("vfs", options)
+	if len(doptions) != 0 {
+		t.Fatalf("Expected 0 options, got %v", doptions)
+	}
+	options.Overlay.IgnoreChownErrors = "true"
+	doptions = GetGraphDriverOptions("vfs", options)
+	if len(doptions) != 0 {
+		t.Fatalf("Expected 0 options, got %v", doptions)
+	}
+	options.Vfs.IgnoreChownErrors = "true"
+	doptions = GetGraphDriverOptions("vfs", options)
+	if len(doptions) == 0 {
+		t.Fatalf("Expected 1 options, got %v", doptions)
+	}
+	// Make sure legacy IgnoreChownErrors still works
+	options = OptionsConfig{}
+	options.IgnoreChownErrors = "true"
+	doptions = GetGraphDriverOptions("vfs", options)
+	if len(doptions) == 0 {
+		t.Fatalf("Expected 1 options, got %v", doptions)
+	}
+}
+
+func TestZfsOptions(t *testing.T) {
+	var (
+		doptions []string
+		options  OptionsConfig
+	)
+	doptions = GetGraphDriverOptions("zfs", options)
+	if len(doptions) != 0 {
+		t.Fatalf("Expected 0 options, got %v", doptions)
+	}
+	// Make sure legacy mountopt still works
+	options = OptionsConfig{}
+	options.Zfs.Name = "foobar"
+	doptions = GetGraphDriverOptions("zfs", options)
+	if len(doptions) == 0 {
+		t.Fatalf("Expected 0 options, got %v", doptions)
+	}
+	if !searchOptions(doptions, options.Zfs.Name) {
+		t.Fatalf("Expected to find 'foobar' options, got %v", doptions)
+	}
+	// Make sure Zfs ignores other drivers mountpoints takes presedence
+	options.Aufs.MountOpt = "nodev"
+	doptions = GetGraphDriverOptions("zfs", options)
+	if searchOptions(doptions, "mountopt=nodev") {
+		t.Fatalf("Expected Not to find 'nodev' options, got %v", doptions)
+	}
+
+	options.Size = "200"
+	doptions = GetGraphDriverOptions("zfs", options)
+	if len(doptions) == 0 {
+		t.Fatalf("Expected 0 options, got %v", doptions)
+	}
+	if !searchOptions(doptions, "200") {
+		t.Fatalf("Expected to find size '200' options, got %v", doptions)
+	}
+	// Make sure Zfs.Size takes precedence
+	options.Zfs.Size = "100"
+	doptions = GetGraphDriverOptions("zfs", options)
+	if len(doptions) == 0 {
+		t.Fatalf("Expected 0 options, got %v", doptions)
+	}
+	if !searchOptions(doptions, "100") {
+		t.Fatalf("Expected to find size '100', got %v", doptions)
+	}
+}

--- a/pkg/parsers/kernel/kernel_windows.go
+++ b/pkg/parsers/kernel/kernel_windows.go
@@ -63,7 +63,7 @@ func GetKernelVersion() (*VersionInfo, error) {
 	}
 
 	KVI.major = int(dwVersion & 0xFF)
-	KVI.minor = int((dwVersion & 0XFF00) >> 8)
+	KVI.minor = int((dwVersion & 0xFF00) >> 8)
 	KVI.build = int((dwVersion & 0xFFFF0000) >> 16)
 
 	return KVI, nil

--- a/storage.conf
+++ b/storage.conf
@@ -21,25 +21,6 @@ graphroot = "/var/lib/containers/storage"
 additionalimagestores = [
 ]
 
-# Size is used to set a maximum size of the container image.  Only supported by
-# certain container storage drivers.
-size = ""
-
-# Path to an helper program to use for mounting the file system instead of mounting it
-# directly.
-#mount_program = "/usr/bin/fuse-overlayfs"
-
-# mountopt specifies comma separated list of extra mount options
-mountopt = "nodev"
-
-# ignore_chown_errors can be set to allow a non privileged user running with
-# a single UID within a user namespace to run containers. The user can pull
-# and use any image even those with multiple uids.  Note multiple UIDs will be
-# squasheddown to the default uid in the container.  These images will have no
-# separation between the users in the container. Only supported for the overlay
-# and vfs drivers.
-#ignore_chown_errors = false
-
 # Remap-UIDs/GIDs is the mapping from UIDs/GIDs as they should appear inside of
 # a container, to the UIDs/GIDs as they should appear outside of the container,
 # and the length of the range of UIDs/GIDs.  Additional mapped sets can be
@@ -60,6 +41,28 @@ mountopt = "nodev"
 #
 # remap-user = "storage"
 # remap-group = "storage"
+
+[storage.options.overlay]
+# ignore_chown_errors can be set to allow a non privileged user running with
+# a single UID within a user namespace to run containers. The user can pull
+# and use any image even those with multiple uids.  Note multiple UIDs will be
+# squashed down to the default uid in the container.  These images will have no
+# separation between the users in the container. Only supported for the overlay
+# and vfs drivers.
+#ignore_chown_errors = false
+
+# Path to an helper program to use for mounting the file system instead of mounting it
+# directly.
+#mount_program = "/usr/bin/fuse-overlayfs"
+
+# mountopt specifies comma separated list of extra mount options
+mountopt = "nodev"
+
+# Set to skip a PRIVATE bind mount on the storage home directory.
+skip_mount_home = "false"
+
+# Size is used to set a maximum size of the container image.
+# size = ""
 
 [storage.options.thinpool]
 # Storage Options for thinpool
@@ -110,6 +113,9 @@ mountopt = "nodev"
 # mkfsarg specifies extra mkfs arguments to be used when creating the base.
 # device.
 # mkfsarg = ""
+
+# Size is used to set a maximum size of the container image.
+# size = ""
 
 # use_deferred_removal marks devicemapper block device for deferred removal.
 # If the thinpool is in use when the driver attempts to remove it, the driver 


### PR DESCRIPTION
Storage options are really driver specific and it is when distributions set defaults, they
should not effect the user if he changes the default driver.  By moving the storage options
to be driver specific, we can make sure all drivers only document and support their options.
Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>