### PR TITLE
ImageSize: don't get tripped up by images with no layers

### DIFF
--- a/cmd/containers-storage/create.go
+++ b/cmd/containers-storage/create.go
@@ -148,7 +148,10 @@ func createImage(flags *mflag.FlagSet, action string, m storage.Store, args []st
 		}
 		paramMetadata = string(b)
 	}
-	layer := args[0]
+	layer := ""
+	if len(args) > 0 {
+		layer = args[0]
+	}
 	imageOptions := &storage.ImageOptions{
 		Digest: digest.Digest(paramDigest),
 	}
@@ -251,7 +254,7 @@ func init() {
 		names:       []string{"create-image", "createimage"},
 		optionsHelp: "[options [...]] topLayerNameOrID",
 		usage:       "Create a new image using layers",
-		minArgs:     1,
+		minArgs:     0,
 		maxArgs:     1,
 		action:      createImage,
 		addFlags: func(flags *mflag.FlagSet, cmd *command) {

--- a/store.go
+++ b/store.go
@@ -1587,10 +1587,12 @@ func (s *store) ImageSize(id string) (int64, error) {
 		return -1, errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
 	}
 
-	// Start with a list of the image's top layers.
+	// Start with a list of the image's top layers, if it has any.
 	queue := make(map[string]struct{})
 	for _, layerID := range append([]string{image.TopLayer}, image.MappedTopLayers...) {
-		queue[layerID] = struct{}{}
+		if layerID != "" {
+			queue[layerID] = struct{}{}
+		}
 	}
 	visited := make(map[string]struct{})
 	// Walk all of the layers.

--- a/tests/image.bats
+++ b/tests/image.bats
@@ -28,3 +28,29 @@ load helpers
 	[[ "$output" =~ "Data: random1" ]]
 	[[ "$output" =~ "Data: random2" ]]
 }
+
+@test "layerless-image" {
+	# Add an image with no specified layers.
+	name=wonderful-image
+	run storage --debug=false create-image --name $name
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	image=${lines[0]}
+
+	# Add a couple of big data items.
+	createrandom ${TESTDIR}/random1
+	createrandom ${TESTDIR}/random2
+	storage set-image-data -f ${TESTDIR}/random1 $image random1
+	storage set-image-data -f ${TESTDIR}/random2 $image random2
+
+	# Get information about the image, and make sure the ID, name, and data names were preserved,
+	# and that we can properly report its disk usage.
+	run storage image $image
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[[ "$output" =~ "ID: $image" ]]
+	[[ "$output" =~ "Name: $name" ]]
+	[[ "$output" =~ "Data: random1" ]]
+	[[ "$output" =~ "Data: random2" ]]
+	[[ "$output" =~ "Size: 512" ]]
+}


### PR DESCRIPTION
Images don't have to have layers, so they don't have to have top layers, and we shouldn't return an error when attempting to determine the size of such an image.