### PR TITLE
tarlogger: disable raw accouting

### DIFF
--- a/pkg/tarlog/tarlogger.go
+++ b/pkg/tarlog/tarlogger.go
@@ -26,7 +26,6 @@ func NewLogger(logger func(*tar.Header)) (io.WriteCloser, error) {
 		closed:     false,
 	}
 	tr := tar.NewReader(reader)
-	tr.RawAccounting = true
 	t.closeMutex.Lock()
 	go func() {
 		hdr, err := tr.Next()


### PR DESCRIPTION
Commit d85da31 enabled raw accounting which is not needed for the
purpose of the tarlogger.  Disable the raw accounting to reduce the
memory footprint considerably (factor of 10 in some cases).

Fixes: #433
Inital-report: github.com/cri-o/cri-o/issues/2847
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>