### PR TITLE
Do not discard errors when panicing on lockfile open

### DIFF
--- a/pkg/lockfile/lockfile_unix.go
+++ b/pkg/lockfile/lockfile_unix.go
@@ -104,7 +104,7 @@ func (l *lockfile) lock(l_type int16, recursive bool) {
 		// If we're the first reference on the lock, we need to open the file again.
 		fd, err := openLock(l.file, l.ro)
 		if err != nil {
-			panic(fmt.Sprintf("error opening %q", l.file))
+			panic(fmt.Sprintf("error opening %q: %v", l.file, err))
 		}
 		unix.CloseOnExec(fd)
 		l.fd = uintptr(fd)


### PR DESCRIPTION
We're seeing some panics with Podman on Ubuntu 19 in this code, and debugging without knowing what's going wrong is very difficult.