### PR TITLE
Add pure file matches indicator

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -821,11 +821,12 @@ func TarWithOptions(srcPath string, options *TarOptions) (io.ReadCloser, error) 
 				// is asking for that file no matter what - which is true
 				// for some files, like .dockerignore and Dockerfile (sometimes)
 				if include != relFilePath {
-					skip, err = pm.Matches(relFilePath)
+					matches, err := pm.Matches(relFilePath)
 					if err != nil {
 						logrus.Errorf("Error matching %s: %v", relFilePath, err)
 						return err
 					}
+					skip = matches > 0
 				}
 
 				if skip {

--- a/pkg/fileutils/fileutils_test.go
+++ b/pkg/fileutils/fileutils_test.go
@@ -386,7 +386,7 @@ func TestMatches(t *testing.T) {
 		pm, err := NewPatternMatcher([]string{test.pattern})
 		require.NoError(t, err, desc)
 		res, _ := pm.Matches(test.text)
-		assert.Equal(t, test.pass, res, desc)
+		assert.Equal(t, test.pass, res > 0, desc)
 	}
 }
 
@@ -587,5 +587,29 @@ func TestMatch(t *testing.T) {
 		if ok != tt.match || err != tt.err {
 			t.Fatalf("Match(%#q, %#q) = %v, %q want %v, %q", pattern, s, ok, errp(err), tt.match, errp(tt.err))
 		}
+	}
+}
+
+func TestMatchesAmount(t *testing.T) {
+	purityTests := []struct {
+		patterns []string
+		input    string
+		amount   uint
+	}{
+		{[]string{"1", "2", "3"}, "2", 1},
+		{[]string{"1", "2", "2"}, "2", 2},
+		{[]string{"1", "2", "2", "2"}, "2", 3},
+		{[]string{"/prefix/path", "/prefix/other"}, "/prefix/path", 1},
+		{[]string{"/prefix*", "/prefix/path"}, "/prefix/path", 2},
+		{[]string{"/prefix*", "!/prefix/path"}, "/prefix/match", 1},
+	}
+
+	for _, testCase := range purityTests {
+		pm, err := NewPatternMatcher(testCase.patterns)
+		require.NoError(t, err)
+		res, err := pm.Matches(testCase.input)
+		require.NoError(t, err)
+		assert.Equal(t, testCase.amount, res,
+			fmt.Sprintf("pattern=%q input=%q", testCase.patterns, testCase.input))
 	}
 }


### PR DESCRIPTION
The `pure` indicator for a match now returns `true` if it's the only
one. This additional information will be used by consumers to decide
more fine-granular if a match can be excluded completely or not.

Needed by https://github.com/containers/buildah/pull/1914