### PR TITLE
Add excluded information to matches

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -821,12 +821,12 @@ func TarWithOptions(srcPath string, options *TarOptions) (io.ReadCloser, error) 
 				// is asking for that file no matter what - which is true
 				// for some files, like .dockerignore and Dockerfile (sometimes)
 				if include != relFilePath {
-					matches, err := pm.Matches(relFilePath)
+					matches, err := pm.IsMatch(relFilePath)
 					if err != nil {
 						logrus.Errorf("Error matching %s: %v", relFilePath, err)
 						return err
 					}
-					skip = matches > 0
+					skip = matches
 				}
 
 				if skip {


### PR DESCRIPTION
This is a follow up of https://github.com/containers/storage/pull/443, because the information of how many matches we have is not sufficient enough to fix the issue in https://github.com/containers/buildah/pull/1914. :innocent: 

We now add the information if an match has been excluded or not, which is
needed for more fine-granular filepath matching.