### PR TITLE
Don't check overlay if using fuse-overlay

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -921,8 +921,10 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 	if err := idtools.MkdirAs(mergedDir, 0700, rootUID, rootGID); err != nil && !os.IsExist(err) {
 		return "", err
 	}
-	if count := d.ctr.Increment(mergedDir); count > 1 {
-		return mergedDir, nil
+	if d.options.mountProgram == "" {
+		if count := d.ctr.Increment(mergedDir); count > 1 {
+			return mergedDir, nil
+		}
 	}
 	defer func() {
 		if retErr != nil {


### PR DESCRIPTION
We want to be able to use fuse-overlay on top of overlay file system.

If code is configured to use fuse-overlay then do not do overlay check.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>