### PR TITLE
overlay: check for FUSE when using mountProgram

### DIFF
--- a/drivers/driver_linux.go
+++ b/drivers/driver_linux.go
@@ -48,6 +48,8 @@ const (
 	FsMagicZfs = FsMagic(0x2fc12fc1)
 	// FsMagicOverlay filesystem id for overlay
 	FsMagicOverlay = FsMagic(0x794C7630)
+	// FsMagicFUSE filesystem id for FUSE
+	FsMagicFUSE = FsMagic(0x65735546)
 )
 
 var (

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -231,13 +231,18 @@ func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) 
 		}
 	}
 
+	fileSystemType := graphdriver.FsMagicOverlay
+	if opts.mountProgram != "" {
+		fileSystemType = graphdriver.FsMagicFUSE
+	}
+
 	d := &Driver{
 		name:          "overlay",
 		home:          home,
 		runhome:       runhome,
 		uidMaps:       options.UIDMaps,
 		gidMaps:       options.GIDMaps,
-		ctr:           graphdriver.NewRefCounter(graphdriver.NewFsChecker(graphdriver.FsMagicOverlay)),
+		ctr:           graphdriver.NewRefCounter(graphdriver.NewFsChecker(fileSystemType)),
 		supportsDType: supportsDType,
 		usingMetacopy: usingMetacopy,
 		locker:        locker.New(),


### PR DESCRIPTION
if a mountProgram is specified, check that the file system is already
mounted using the FUSE magic number instead of overlay.  It enables
using fuse-overlayfs on top of overlay.

Closes: https://github.com/containers/storage/issues/447

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>