### PR TITLE
Fix to be able to build on  FTBFS on mipsel

### DIFF
--- a/drivers/copy/copy_linux.go
+++ b/drivers/copy/copy_linux.go
@@ -155,7 +155,7 @@ func DirCopy(srcDir, dstDir string, copyMode Mode, copyXattrs bool) error {
 
 		switch mode := f.Mode(); {
 		case mode.IsRegular():
-			id := fileID{dev: stat.Dev, ino: stat.Ino}
+			id := fileID{dev: uint64(stat.Dev), ino: stat.Ino}
 			if copyMode == Hardlink {
 				isHardlink = true
 				if err2 := os.Link(srcPath, dstPath); err2 != nil {


### PR DESCRIPTION
Some platforms store s.Rdev as unit32, translate to unit64 so it
will compile.

Also add function to make it clear that the object is a whiteout object.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>