### PR TITLE
VFS support for user.* xattrs

### DIFF
--- a/drivers/copy/copy_linux.go
+++ b/drivers/copy/copy_linux.go
@@ -277,12 +277,10 @@ func doCopyXattrs(srcPath, dstPath string) error {
 		return err
 	}
 
-	if xattrs != nil {
-		for _, key := range xattrs {
-			if strings.HasPrefix(key, "user.") {
-				if err := copyXattr(srcPath, dstPath, key); err != nil {
-					return err
-				}
+	for _, key := range xattrs {
+		if strings.HasPrefix(key, "user.") {
+			if err := copyXattr(srcPath, dstPath, key); err != nil {
+				return err
 			}
 		}
 	}

--- a/drivers/copy/copy_linux.go
+++ b/drivers/copy/copy_linux.go
@@ -16,6 +16,7 @@ import (
 	"io"
 	"os"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -97,7 +98,7 @@ func legacyCopy(srcFile io.Reader, dstFile io.Writer) error {
 
 func copyXattr(srcPath, dstPath, attr string) error {
 	data, err := system.Lgetxattr(srcPath, attr)
-	if err != nil {
+	if err != nil && err != unix.EOPNOTSUPP {
 		return err
 	}
 	if data != nil {
@@ -269,6 +270,21 @@ func DirCopy(srcDir, dstDir string, copyMode Mode, copyXattrs bool) error {
 func doCopyXattrs(srcPath, dstPath string) error {
 	if err := copyXattr(srcPath, dstPath, "security.capability"); err != nil {
 		return err
+	}
+
+	xattrs, err := system.Llistxattr(srcPath)
+	if err != nil && err != unix.EOPNOTSUPP {
+		return err
+	}
+
+	if xattrs != nil {
+		for _, key := range xattrs {
+			if strings.HasPrefix(key, "user.") {
+				if err := copyXattr(srcPath, dstPath, key); err != nil {
+					return err
+				}
+			}
+		}
 	}
 
 	// We need to copy this attribute if it appears in an overlay upper layer, as

--- a/drivers/vfs/copy_linux.go
+++ b/drivers/vfs/copy_linux.go
@@ -3,5 +3,5 @@ package vfs
 import "github.com/containers/storage/drivers/copy"
 
 func dirCopy(srcDir, dstDir string) error {
-	return copy.DirCopy(srcDir, dstDir, copy.Content, false)
+	return copy.DirCopy(srcDir, dstDir, copy.Content, true)
 }

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -404,18 +404,16 @@ func ReadUserXattrToTarHeader(path string, hdr *tar.Header) error {
 	if err != nil && err != system.EOPNOTSUPP {
 		return err
 	}
-	if xattrs != nil {
-		for _, key := range xattrs {
-			if strings.HasPrefix(key, "user.") {
-				value, err := system.Lgetxattr(path, key)
-				if err != nil {
-					return err
-				}
-				if hdr.Xattrs == nil {
-					hdr.Xattrs = make(map[string]string)
-				}
-				hdr.Xattrs[key] = string(value)
+	for _, key := range xattrs {
+		if strings.HasPrefix(key, "user.") {
+			value, err := system.Lgetxattr(path, key)
+			if err != nil {
+				return err
 			}
+			if hdr.Xattrs == nil {
+				hdr.Xattrs = make(map[string]string)
+			}
+			hdr.Xattrs[key] = string(value)
 		}
 	}
 	return nil

--- a/pkg/archive/changes.go
+++ b/pkg/archive/changes.go
@@ -8,6 +8,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sort"
 	"strings"
 	"syscall"
@@ -263,6 +264,7 @@ type FileInfo struct {
 	children   map[string]*FileInfo
 	capability []byte
 	added      bool
+	xattrs     map[string]string
 }
 
 // LookUp looks up the file information of a file.
@@ -331,7 +333,8 @@ func (info *FileInfo) addChanges(oldInfo *FileInfo, changes *[]Change) {
 			// breaks down is if some code intentionally hides a change by setting
 			// back mtime
 			if statDifferent(oldStat, oldInfo, newStat, info) ||
-				!bytes.Equal(oldChild.capability, newChild.capability) {
+				!bytes.Equal(oldChild.capability, newChild.capability) ||
+				!reflect.DeepEqual(oldChild.xattrs, newChild.xattrs) {
 				change := Change{
 					Path: newChild.path(),
 					Kind: ChangeModify,

--- a/pkg/archive/changes_linux.go
+++ b/pkg/archive/changes_linux.go
@@ -92,18 +92,16 @@ func walkchunk(path string, fi os.FileInfo, dir string, root *FileInfo) error {
 	if err != nil && err != system.EOPNOTSUPP {
 		return err
 	}
-	if xattrs != nil {
-		for _, key := range xattrs {
-			if strings.HasPrefix(key, "user.") {
-				value, err := system.Lgetxattr(cpath, key)
-				if err != nil {
-					return err
-				}
-				if info.xattrs == nil {
-					info.xattrs = make(map[string]string)
-				}
-				info.xattrs[key] = string(value)
+	for _, key := range xattrs {
+		if strings.HasPrefix(key, "user.") {
+			value, err := system.Lgetxattr(cpath, key)
+			if err != nil {
+				return err
 			}
+			if info.xattrs == nil {
+				info.xattrs = make(map[string]string)
+			}
+			info.xattrs[key] = string(value)
 		}
 	}
 	parent.children[info.name] = info

--- a/pkg/system/xattrs_linux.go
+++ b/pkg/system/xattrs_linux.go
@@ -1,6 +1,10 @@
 package system
 
-import "golang.org/x/sys/unix"
+import (
+	"bytes"
+
+	"golang.org/x/sys/unix"
+)
 
 // Lgetxattr retrieves the value of the extended attribute identified by attr
 // and associated with the given path in the file system.
@@ -26,4 +30,33 @@ func Lgetxattr(path string, attr string) ([]byte, error) {
 // and associated with the given path in the file system.
 func Lsetxattr(path string, attr string, data []byte, flags int) error {
 	return unix.Lsetxattr(path, attr, data, flags)
+}
+
+// Llistxattr lists extended attributes associated with the given path
+// in the file system.
+func Llistxattr(path string) ([]string, error) {
+	var dest []byte
+
+	for {
+		sz, err := unix.Llistxattr(path, dest)
+		if err != nil {
+			return nil, err
+		}
+
+		if sz > len(dest) {
+			dest = make([]byte, sz)
+		} else {
+			dest = dest[:sz]
+			break
+		}
+	}
+
+	var attrs []string
+	for _, token := range bytes.Split(dest, []byte{0}) {
+		if len(token) > 0 {
+			attrs = append(attrs, string(token))
+		}
+	}
+
+	return attrs, nil
 }

--- a/pkg/system/xattrs_linux.go
+++ b/pkg/system/xattrs_linux.go
@@ -2,8 +2,14 @@ package system
 
 import (
 	"bytes"
+	"syscall"
 
 	"golang.org/x/sys/unix"
+)
+
+const (
+	// Operation not supported
+	EOPNOTSUPP syscall.Errno = unix.EOPNOTSUPP
 )
 
 // Lgetxattr retrieves the value of the extended attribute identified by attr

--- a/pkg/system/xattrs_unsupported.go
+++ b/pkg/system/xattrs_unsupported.go
@@ -2,6 +2,13 @@
 
 package system
 
+import "syscall"
+
+const (
+	// Operation not supported
+	EOPNOTSUPP syscall.Errno = syscall.Errno(0)
+)
+
 // Lgetxattr is not supported on platforms other than linux.
 func Lgetxattr(path string, attr string) ([]byte, error) {
 	return nil, ErrNotSupportedPlatform

--- a/pkg/system/xattrs_unsupported.go
+++ b/pkg/system/xattrs_unsupported.go
@@ -11,3 +11,8 @@ func Lgetxattr(path string, attr string) ([]byte, error) {
 func Lsetxattr(path string, attr string, data []byte, flags int) error {
 	return ErrNotSupportedPlatform
 }
+
+// Llistxattr is not supported on platforms other than linux.
+func Llistxattr(path string) ([]string, error) {
+	return nil, ErrNotSupportedPlatform
+}


### PR DESCRIPTION
Preservation of user.* xattrs is supported by most (if not all) other
drivers, and it's especially useful for containers that run under a
PaX kernel where "user.pax.flags" is used to store PaX flags.

Signed-off-by: Zac Medico <zmedico@gmail.com>