### PR TITLE
Move runroot containers storage into containers directory

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -70,6 +70,18 @@ func ParseIDMapping(UIDMapSlice, GIDMapSlice []string, subUIDMap, subGIDMap stri
 
 // GetRootlessRuntimeDir returns the runtime directory when running as non root
 func GetRootlessRuntimeDir(rootlessUid int) (string, error) {
+	path, err := getRootlessRuntimeDir(rootlessUid)
+	if err != nil {
+		return "", err
+	}
+	path = filepath.Join(path, "containers")
+	if err := os.MkdirAll(path, 0700); err != nil {
+		return "", errors.Wrapf(err, "unable to make rootless runtime dir %s", path)
+	}
+	return path, nil
+}
+
+func getRootlessRuntimeDir(rootlessUid int) (string, error) {
 	runtimeDir := os.Getenv("XDG_RUNTIME_DIR")
 
 	if runtimeDir != "" {


### PR DESCRIPTION
Currently we are throwing lots of files/directories into the
top level of /run/user/UID/  And this makes it difficult to cleanup.
Switching to using /run/user/UID/containers, makes it easier and cleaner.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>