### PR TITLE
pkg/archive: limit user xattr value size to math.MaxUint16 bytes

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -407,6 +407,10 @@ func ReadUserXattrToTarHeader(path string, hdr *tar.Header) error {
 	for _, key := range xattrs {
 		if strings.HasPrefix(key, "user.") {
 			value, err := system.Lgetxattr(path, key)
+			if err == system.E2BIG {
+				logrus.Errorf("archive: Skipping xattr for file %s since value is too big: %s", path, key)
+				continue
+			}
 			if err != nil {
 				return err
 			}

--- a/pkg/archive/changes_linux.go
+++ b/pkg/archive/changes_linux.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/system"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
 
@@ -95,6 +96,10 @@ func walkchunk(path string, fi os.FileInfo, dir string, root *FileInfo) error {
 	for _, key := range xattrs {
 		if strings.HasPrefix(key, "user.") {
 			value, err := system.Lgetxattr(cpath, key)
+			if err == system.E2BIG {
+				logrus.Errorf("archive: Skipping xattr for file %s since value is too big: %s", cpath, key)
+				continue
+			}
 			if err != nil {
 				return err
 			}

--- a/pkg/system/xattrs_linux.go
+++ b/pkg/system/xattrs_linux.go
@@ -2,12 +2,16 @@ package system
 
 import (
 	"bytes"
+	"math"
 	"syscall"
 
 	"golang.org/x/sys/unix"
 )
 
 const (
+	// Value is larger than the maximum size allowed
+	E2BIG syscall.Errno = unix.E2BIG
+
 	// Operation not supported
 	EOPNOTSUPP syscall.Errno = unix.EOPNOTSUPP
 )
@@ -22,6 +26,9 @@ func Lgetxattr(path string, attr string) ([]byte, error) {
 		return nil, nil
 	}
 	if errno == unix.ERANGE {
+		if sz > math.MaxUint16 {
+			return nil, unix.E2BIG
+		}
 		dest = make([]byte, sz)
 		sz, errno = unix.Lgetxattr(path, attr, dest)
 	}

--- a/pkg/system/xattrs_unsupported.go
+++ b/pkg/system/xattrs_unsupported.go
@@ -5,6 +5,9 @@ package system
 import "syscall"
 
 const (
+	// Value is larger than the maximum size allowed
+	E2BIG syscall.Errno = syscall.Errno(0)
+
 	// Operation not supported
 	EOPNOTSUPP syscall.Errno = syscall.Errno(0)
 )


### PR DESCRIPTION
This should avoid the following panic in Lgetxattr:

    panic: runtime error: makeslice: len out of range

Fixes: 0da4bc60b3ba ("pkg/archive: strictly handle errors reading xattrs")
See: https://travis-ci.org/containers/buildah/jobs/617652963
Signed-off-by: Zac Medico <zmedico@gmail.com>