### PR TITLE
Overlayfs has dropped support for skip_mount_home options

### DIFF
--- a/docs/containers-storage.conf.5.md
+++ b/docs/containers-storage.conf.5.md
@@ -154,9 +154,6 @@ The `storage.options.overlay` table supports the following options:
 **size**=""
   Maximum size of a container image.   This flag can be used to set quota on the size of container images. (format: <number>[<unit>], where unit = b (bytes), k (kilobytes), m (megabytes), or g (gigabytes))
 
-**skip_mount_home** = "false"
-  Set to skip a PRIVATE bind mount on the storage home directory.
-
 ### STORAGE OPTIONS FOR VFS TABLE
 
 The `storage.options.vfs` table supports the following options:

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,6 +2,8 @@ package config
 
 import (
 	"fmt"
+
+	"github.com/sirupsen/logrus"
 )
 
 // ThinpoolOptionsConfig represents the "storage.options.thinpool"
@@ -256,10 +258,8 @@ func GetGraphDriverOptions(driverName string, options OptionsConfig) []string {
 			doptions = append(doptions, fmt.Sprintf("%s.size=%s", driverName, options.Size))
 		}
 
-		if options.Overlay.SkipMountHome != "" {
-			doptions = append(doptions, fmt.Sprintf("%s.skip_mount_home=%s", driverName, options.Overlay.SkipMountHome))
-		} else if options.SkipMountHome != "" {
-			doptions = append(doptions, fmt.Sprintf("%s.skip_mount_home=%s", driverName, options.SkipMountHome))
+		if options.Overlay.SkipMountHome != "" || options.SkipMountHome != "" {
+			logrus.Warn("skip_mount_home option is no longer supported, ignoring option")
 		}
 
 	case "vfs":

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -236,26 +236,9 @@ func TestOverlayOptions(t *testing.T) {
 	if !searchOptions(doptions, "mount_program=/usr/bin/fuse_overlay") {
 		t.Fatalf("Expected to find 'fuse_overlay' options, got %v", doptions)
 	}
-	options.Overlay.SkipMountHome = "true"
-	doptions = GetGraphDriverOptions("overlay", options)
-	if len(doptions) == 0 {
-		t.Fatalf("Expected 0 options, got %v", doptions)
-	}
-	if !searchOptions(doptions, "skip_mount_home") {
-		t.Fatalf("Expected to find 'skip_mount_home' options, got %v", doptions)
-	}
 
 	// Make sure legacy mountopt still works
 	options = OptionsConfig{}
-	options.SkipMountHome = "true"
-	doptions = GetGraphDriverOptions("overlay", options)
-	if len(doptions) == 0 {
-		t.Fatalf("Expected 0 options, got %v", doptions)
-	}
-	if !searchOptions(doptions, "skip_mount_home") {
-		t.Fatalf("Expected to find 'skip_mount_home' options, got %v", doptions)
-	}
-
 	options.Size = "200"
 	doptions = GetGraphDriverOptions("overlay", options)
 	if len(doptions) == 0 {

--- a/storage.conf
+++ b/storage.conf
@@ -58,9 +58,6 @@ additionalimagestores = [
 # mountopt specifies comma separated list of extra mount options
 mountopt = "nodev"
 
-# Set to skip a PRIVATE bind mount on the storage home directory.
-skip_mount_home = "false"
-
 # Size is used to set a maximum size of the container image.
 # size = ""
 


### PR DESCRIPTION
Remove all references to the option in man pages in default configuration.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>