### PR TITLE
Fix possible runtime panic in Lgetxattr

### DIFF
--- a/pkg/system/xattrs_linux.go
+++ b/pkg/system/xattrs_linux.go
@@ -2,7 +2,6 @@ package system
 
 import (
 	"bytes"
-	"math"
 	"syscall"
 
 	"golang.org/x/sys/unix"
@@ -20,22 +19,28 @@ const (
 // and associated with the given path in the file system.
 // It will returns a nil slice and nil error if the xattr is not set.
 func Lgetxattr(path string, attr string) ([]byte, error) {
+	// Start with a 128 length byte array
 	dest := make([]byte, 128)
 	sz, errno := unix.Lgetxattr(path, attr, dest)
-	if errno == unix.ENODATA {
+
+	switch {
+	case errno == unix.ENODATA:
 		return nil, nil
-	}
-	if errno == unix.ERANGE {
-		if sz > math.MaxUint16 {
-			return nil, unix.E2BIG
+	case errno == unix.ERANGE:
+		// 128 byte array might just not be good enough. A dummy buffer is used
+		// to get the real size of the xattrs on disk
+		sz, errno = unix.Lgetxattr(path, attr, []byte{})
+		if errno != nil {
+			return nil, errno
 		}
 		dest = make([]byte, sz)
 		sz, errno = unix.Lgetxattr(path, attr, dest)
-	}
-	if errno != nil {
+		if errno != nil {
+			return nil, errno
+		}
+	case errno != nil:
 		return nil, errno
 	}
-
 	return dest[:sz], nil
 }
 


### PR DESCRIPTION
Implementation references:
- Moby: https://github.com/moby/moby/blob/master/pkg/system/xattrs_linux.go
  If [lgetxattr(2)](https://linux.die.net/man/2/lgetxattr) always returns `-1` on any failure, then we cause a runtime panic in L15:  `dest = make([]byte, sz)`
- runc: https://github.com/opencontainers/runc/blob/master/libcontainer/system/xattrs_linux.go
  Looks more correct to me.

Relates to: https://github.com/containers/buildah/pull/1998, https://github.com/containers/storage/pull/470, https://github.com/moby/moby/pull/40283