### PR TITLE
chrootarchive: invokeUnpack: close pipe on all return paths

### DIFF
--- a/pkg/chrootarchive/archive_unix.go
+++ b/pkg/chrootarchive/archive_unix.go
@@ -96,11 +96,13 @@ func invokeUnpack(decompressedArchive io.Reader, dest string, options *archive.T
 	cmd.Stderr = output
 
 	if err := cmd.Start(); err != nil {
+		w.Close()
 		return fmt.Errorf("Untar error on re-exec cmd: %v", err)
 	}
 
 	//write the options to the pipe for the untar exec to read
 	if err := json.NewEncoder(w).Encode(options); err != nil {
+		w.Close()
 		return fmt.Errorf("Untar json encode to pipe failed: %v", err)
 	}
 	w.Close()


### PR DESCRIPTION
Make sure that the created pipe is closed on all return paths.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>