### PR TITLE
Cleanup handling of default driver name, when storage.conf has drivername=""

### DIFF
--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -54,6 +54,7 @@ populate() {
 	lowerlayer="$output"
 	# Mount the layer.
 	run storage --debug=false mount $lowerlayer
+	echo $output
 	[ "$status" -eq 0 ]
 	[ "$output" != "" ]
 	local lowermount="$output"
@@ -81,11 +82,13 @@ populate() {
 
 	# Create a second layer based on the first.
 	run storage --debug=false create-layer "$lowerlayer"
+	echo $output
 	[ "$status" -eq 0 ]
 	[ "$output" != "" ]
 	midlayer="$output"
 	# Mount the second layer.
 	run storage --debug=false mount $midlayer
+	echo $output
 	[ "$status" -eq 0 ]
 	[ "$output" != "" ]
 	local midmount="$output"
@@ -133,11 +136,13 @@ populate() {
 
 	# Create a third layer based on the second.
 	run storage --debug=false create-layer "$midlayer"
+	echo $output
 	[ "$status" -eq 0 ]
 	[ "$output" != "" ]
 	upperlayer="$output"
 	# Mount the third layer.
 	run storage --debug=false mount $upperlayer
+	echo $output
 	[ "$status" -eq 0 ]
 	[ "$output" != "" ]
 	local uppermount="$output"


### PR DESCRIPTION
If the user specifies drivername="" in the storage.conf
then we default to the first driver name based on priority list, usually
overla.

The problem with this, is now the storage.conf file has options that are
driver specific.  The code does not catch this so ends up looking for a driver
name of "", and finds no matching options.

This code will set the drivername that the storage layer would choose earlies,
so that storage will get the correct options out of the config file.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>