### PR TITLE
overlay: allow storing images with more than 127 layers

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -676,9 +676,6 @@ func (d *Driver) getLower(parent string) (string, error) {
 		parentLowers := strings.Split(string(parentLower), ":")
 		lowers = append(lowers, parentLowers...)
 	}
-	if len(lowers) > maxDepth {
-		return "", errors.New("max depth exceeded")
-	}
 	return strings.Join(lowers, ":"), nil
 }
 
@@ -828,6 +825,10 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 	if err != nil && !os.IsNotExist(err) {
 		return "", err
 	}
+	splitLowers := strings.Split(string(lowers), ":")
+	if len(splitLowers) > maxDepth {
+		return "", errors.New("max depth exceeded")
+	}
 
 	// absLowers is the list of lowers as absolute paths, which works well with additional stores.
 	absLowers := []string{}
@@ -851,7 +852,7 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 
 	// For each lower, resolve its path, and append it and any additional diffN
 	// directories to the lowers list.
-	for _, l := range strings.Split(string(lowers), ":") {
+	for _, l := range splitLowers {
 		if l == "" {
 			continue
 		}


### PR DESCRIPTION
Note that such images can now be stored but they cannot be
pushed yet.  Supporting both use cases would be ideal for
source-container images that are known to have a large number
of layers, likely exceeding the current limit of 127 layers.

This limit is inherited from Docker to proactively restrict the
amount and size of arguments passed when mounting.  All (lower)
layers must be specified at mount-time but we only have one page
to pass them.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>