### PR TITLE
Add integration tests for images with a lot of layers

### DIFF
--- a/tests/layers.bats
+++ b/tests/layers.bats
@@ -1,0 +1,22 @@
+#!/usr/bin/env bats
+# vim:set syn=bash:
+
+load helpers
+
+@test "allow storing images with more than 127 layers" {
+    LAYER=""
+    for i in {0..150}; do
+        echo "Layer: $i"
+
+        # Create a layer.
+        run storage --debug=false create-layer "$LAYER"
+        [ "$status" -eq 0 ]
+        [ "$output" != "" ]
+        LAYER="$output"
+    done
+
+    # Create the image
+    run storage --debug=false create-image --name test-image "$LAYER"
+    [ "$status" -eq 0 ]
+    [ "$output" != "" ]
+}


### PR DESCRIPTION
As a follow-up of #489 we now add an integration test which adds an
image with a decent amount of layers.