### PR TITLE
Add better documentation for the mount_program in overlay driver

### DIFF
--- a/docs/containers-storage.conf.5.md
+++ b/docs/containers-storage.conf.5.md
@@ -145,7 +145,12 @@ The `storage.options.overlay` table supports the following options:
   ignore_chown_errors can be set to allow a non privileged user running with a  single UID within a user namespace to run containers. The user can pull and use any image even those with multiple uids.  Note multiple UIDs will be squashed down to the default uid in the container.  These images will have no separation between the users in the container. (default: false)
 
 **mount_program**=""
-  Specifies the path to a custom program to use instead of using kernel defaults for mounting the file system.
+  Specifies the path to a custom program to use instead of using kernel defaults
+for mounting the file system. In rootless mode, without the CAP_SYS_ADMIN
+capability, many kernels prevent mounting of overlay file systems, requiring
+you to specify a mount_program. The mount_program option is also required on
+systems where the underlying storage is btrfs, aufs, zfs, overlay, or ecryptfs
+based file systems.
   mount_program = "/usr/bin/fuse-overlayfs"
 
 **mountopt**=""

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -142,8 +142,7 @@ func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) 
 	if opts.mountProgram == "" {
 		switch fsMagic {
 		case graphdriver.FsMagicAufs, graphdriver.FsMagicZfs, graphdriver.FsMagicOverlay, graphdriver.FsMagicEcryptfs:
-			logrus.Errorf("'overlay' is not supported over %s", backingFs)
-			return nil, errors.Wrapf(graphdriver.ErrIncompatibleFS, "'overlay' is not supported over %s", backingFs)
+			return nil, errors.Wrapf(graphdriver.ErrIncompatibleFS, "'overlay' is not supported over %s, a mount_program is required", backingFs)
 		}
 	}
 


### PR DESCRIPTION
Currently users get an error message saying overlay is not supported on specific
drivers, but their is no information about the mount_program in the error
messages.  This PR adds a mention of this so that users can investigate the use
of the mount_program.

Also add information to the containers-storage.conf man page to document when
the mount_program is required to be used for an overlay driver.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>