### PR TITLE
drivers: btrfs: Allow unprivileged user to delete subvolumes

### DIFF
--- a/drivers/btrfs/btrfs.go
+++ b/drivers/btrfs/btrfs.go
@@ -627,7 +627,12 @@ func (d *Driver) Remove(id string) error {
 	d.updateQuotaStatus()
 
 	if err := subvolDelete(d.subvolumesDir(), id, d.quotaEnabled); err != nil {
-		return err
+		if d.quotaEnabled {
+			return err
+		}
+		// If quota is not enabled, fallback to rmdir syscall to delete subvolumes.
+		// This would allow unprivileged user to delete their owned subvolumes
+		// in kernel >= 4.18 without user_subvol_rm_alowed mount option.
 	}
 	if err := system.EnsureRemoveAll(dir); err != nil {
 		return err


### PR DESCRIPTION
rootless podman does not work correctly with btrfs backend since unprivileged subvolume deletion fails: https://github.com/containers/libpod/issues/3963 https://github.com/containers/libpod/issues/4764

This commit fallbacks to rm/rmdir syscalls if subvolume deletion ioctls fails
so that unprivileged user can delete their owned subvolumes.


