### PR TITLE
Handle mount options for overlay2 driver.

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -236,7 +236,7 @@ func GetGraphDriverOptions(driverName string, options OptionsConfig) []string {
 			doptions = append(doptions, fmt.Sprintf("dm.xfs_nospace_max_retries=%s", options.Thinpool.XfsNoSpaceMaxRetries))
 		}
 
-	case "overlay":
+	case "overlay", "overlay2":
 		if options.Overlay.IgnoreChownErrors != "" {
 			doptions = append(doptions, fmt.Sprintf("%s.ignore_chown_errors=%s", driverName, options.Overlay.IgnoreChownErrors))
 		} else if options.IgnoreChownErrors != "" {


### PR DESCRIPTION
Overlay and overlay2 drivers are the same, but we
were not procesessing mount options correctly for overlay2.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>