### PR TITLE
[WIP] Add `rootless_storage_path` directive to storage.conf

### DIFF
--- a/docs/containers-storage.conf.5.md
+++ b/docs/containers-storage.conf.5.md
@@ -34,6 +34,20 @@ The `storage` table supports the following options:
   container storage graph dir (default: "/var/lib/containers/storage")
   Default directory to store all writable content created by container storage programs.
 
+**rootless_storage_path**="$HOME/.local/share/containers/storage"
+  Storage path for rootless users. By default the graphroot for rootless users
+is set to `$XDG_DATA_HOME/containers/storage`, if XDG_DATA_HOME is set.
+Otherwise the `$HOME/.local/share/containers/storage` is used.  This field can
+be used if administrators need to change the storage location for all users.
+
+    The rootless storage path supports three substations:
+    * `$HOME` => Replaced by the users home directory.
+    * `$UID`  => Replaced by the users UID
+    * `$USER` => Replaced by the users name
+
+  A common use case for this field is `NFS home directories`, which do not work
+with rootless container storage.
+
 **runroot**=""
   container storage run dir (default: "/var/run/containers/storage")
   Default directory to store all temporary writable content created by container storage programs.

--- a/storage.conf
+++ b/storage.conf
@@ -13,6 +13,10 @@ runroot = "/var/run/containers/storage"
 # Primary Read/Write location of container storage
 graphroot = "/var/lib/containers/storage"
 
+# Storage path for rootless users
+#
+# rootless_storage_path = "$HOME/.config/containers/storage"
+
 [storage.options]
 # Storage options to be passed to underlying storage drivers
 

--- a/store.go
+++ b/store.go
@@ -138,6 +138,9 @@ type StoreOptions struct {
 	// GraphRoot is the filesystem path under which we will store the
 	// contents of layers, images, and containers.
 	GraphRoot string `json:"root,omitempty"`
+	// RooltessStoragePath is the storage path for rootless users
+	// (default is $HOME/.config/containers/storage)
+	RootlessStoragePath string `toml:"rootless_storage_path"`
 	// GraphDriverName is the underlying storage driver that we'll be
 	// using.  It only needs to be specified the first time a Store is
 	// initialized for a given RunRoot and GraphRoot.


### PR DESCRIPTION
This allows rootless admins to setup alternative
paths to content in the homedir.

Rootless users on NFS homedirs will not be allowed to run
podman, if an admin wants to setup alternative directory say
in /var/tmp on local storage, they could configure the storage.conf
file and then all users would automatically get storage in /var/tmp.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>