### PR TITLE
Revert API break due to lint fixes

### DIFF
--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -48,9 +48,9 @@ type CreateOpts struct {
 type MountOpts struct {
 	// Mount label is the MAC Labels to assign to mount point (SELINUX)
 	MountLabel string
-	// UIDMaps & GIDMaps are the User Namespace mappings to be assigned to content in the mount point
-	UIDMaps []idtools.IDMap
-	GIDMaps []idtools.IDMap
+	// UidMaps & GidMaps are the User Namespace mappings to be assigned to content in the mount point
+	UidMaps []idtools.IDMap // nolint: golint
+	GidMaps []idtools.IDMap // nolint: golint
 	Options []string
 }
 

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -952,7 +952,7 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 	if d.options.mountProgram != "" {
 		mountFunc = func(source string, target string, mType string, flags uintptr, label string) error {
 			if !disableShifting {
-				label = d.optsAppendMappings(label, options.UIDMaps, options.GIDMaps)
+				label = d.optsAppendMappings(label, options.UidMaps, options.GidMaps)
 			}
 
 			mountProgram := exec.Command(d.options.mountProgram, "-o", label, target)

--- a/layers.go
+++ b/layers.go
@@ -793,8 +793,8 @@ func (r *layerStore) Mount(id string, options drivers.MountOpts) (string, error)
 		options.MountLabel = layer.MountLabel
 	}
 
-	if (options.UIDMaps != nil || options.GIDMaps != nil) && !r.driver.SupportsShifting() {
-		if !reflect.DeepEqual(options.UIDMaps, layer.UIDMap) || !reflect.DeepEqual(options.GIDMaps, layer.GIDMap) {
+	if (options.UidMaps != nil || options.GidMaps != nil) && !r.driver.SupportsShifting() {
+		if !reflect.DeepEqual(options.UidMaps, layer.UIDMap) || !reflect.DeepEqual(options.GidMaps, layer.GIDMap) {
 			return "", fmt.Errorf("cannot mount layer %v: shifting not enabled", layer.ID)
 		}
 	}

--- a/pkg/mount/mounter_linux.go
+++ b/pkg/mount/mounter_linux.go
@@ -14,7 +14,7 @@ const (
 	// broflags is the combination of bind and read only
 	broflags = unix.MS_BIND | unix.MS_RDONLY
 
-	none = "non"
+	none = "none"
 )
 
 // isremount returns true if either device name or flags identify a remount request, false otherwise.

--- a/store.go
+++ b/store.go
@@ -2505,8 +2505,8 @@ func (s *store) Mount(id, mountLabel string) (string, error) {
 	if rlstore.Exists(id) {
 		options := drivers.MountOpts{
 			MountLabel: mountLabel,
-			UIDMaps:    uidMap,
-			GIDMaps:    gidMap,
+			UidMaps:    uidMap,
+			GidMaps:    gidMap,
 			Options:    mountOpts,
 		}
 		return rlstore.Mount(id, options)


### PR DESCRIPTION
A follow-up of https://github.com/containers/storage/pull/522, especially reverting the API break.