### PR TITLE
reexec: drop Pdeathsig

### DIFF
--- a/pkg/reexec/command_linux.go
+++ b/pkg/reexec/command_linux.go
@@ -5,9 +5,6 @@ package reexec
 import (
 	"context"
 	"os/exec"
-	"syscall"
-
-	"golang.org/x/sys/unix"
 )
 
 // Self returns the path to the current process's binary.
@@ -16,28 +13,20 @@ func Self() string {
 	return "/proc/self/exe"
 }
 
-// Command returns *exec.Cmd which has Path as current binary. Also it setting
-// SysProcAttr.Pdeathsig to SIGTERM.
+// Command returns *exec.Cmd which has Path as current binary.
 // This will use the in-memory version (/proc/self/exe) of the current binary,
 // it is thus safe to delete or replace the on-disk binary (os.Args[0]).
 func Command(args ...string) *exec.Cmd {
 	cmd := exec.Command(Self())
 	cmd.Args = args
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Pdeathsig: unix.SIGTERM,
-	}
 	return cmd
 }
 
-// CommandContext returns *exec.Cmd which has Path as current binary, and also
-// sets SysProcAttr.Pdeathsig to SIGTERM.
+// CommandContext returns *exec.Cmd which has Path as current binary.
 // This will use the in-memory version (/proc/self/exe) of the current binary,
 // it is thus safe to delete or replace the on-disk binary (os.Args[0]).
 func CommandContext(ctx context.Context, args ...string) *exec.Cmd {
 	cmd := exec.CommandContext(ctx, Self())
 	cmd.Args = args
-	cmd.SysProcAttr = &syscall.SysProcAttr{
-		Pdeathsig: unix.SIGTERM,
-	}
 	return cmd
 }


### PR DESCRIPTION
it can lead to a race condition where the process is killed even if
the parent process is still running.

It can happen as the parent in the prctl(PR_SET_PDEATHSIG) case is
considered the *thread* that created the process.  In the case of the
Go runtime the thread could be freed by the runtime at any time
causing the re-execed process to receive the SIGTERM.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>