### PR TITLE
add pkg/homedir

### DIFF
--- a/pkg/homedir/homedir_linux.go
+++ b/pkg/homedir/homedir_linux.go
@@ -1,23 +1,96 @@
-// +build linux
-
 package homedir
 
-import (
-	"os"
+// Copyright 2013-2018 Docker, Inc.
+// NOTE: this package has originally been copied from github.com/docker/docker.
 
-	"github.com/containers/storage/pkg/idtools"
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
 )
 
-// GetStatic returns the home directory for the current user without calling
-// os/user.Current(). This is useful for static-linked binary on glibc-based
-// system, because a call to os/user.Current() in a static binary leads to
-// segfault due to a glibc issue that won't be fixed in a short term.
-// (#29344, golang/go#13470, https://sourceware.org/bugzilla/show_bug.cgi?id=19341)
-func GetStatic() (string, error) {
-	uid := os.Getuid()
-	usr, err := idtools.LookupUID(uid)
-	if err != nil {
-		return "", err
+// GetRuntimeDir returns XDG_RUNTIME_DIR.
+// XDG_RUNTIME_DIR is typically configured via pam_systemd.
+// GetRuntimeDir returns non-nil error if XDG_RUNTIME_DIR is not set.
+//
+// See also https://standards.freedesktop.org/basedir-spec/latest/ar01s03.html
+func GetRuntimeDir() (string, error) {
+	if xdgRuntimeDir := os.Getenv("XDG_RUNTIME_DIR"); xdgRuntimeDir != "" {
+		return xdgRuntimeDir, nil
 	}
-	return usr.Home, nil
+	return "", errors.New("could not get XDG_RUNTIME_DIR")
+}
+
+// StickRuntimeDirContents sets the sticky bit on files that are under
+// XDG_RUNTIME_DIR, so that the files won't be periodically removed by the system.
+//
+// StickyRuntimeDir returns slice of sticked files.
+// StickyRuntimeDir returns nil error if XDG_RUNTIME_DIR is not set.
+//
+// See also https://standards.freedesktop.org/basedir-spec/latest/ar01s03.html
+func StickRuntimeDirContents(files []string) ([]string, error) {
+	runtimeDir, err := GetRuntimeDir()
+	if err != nil {
+		// ignore error if runtimeDir is empty
+		return nil, nil
+	}
+	runtimeDir, err = filepath.Abs(runtimeDir)
+	if err != nil {
+		return nil, err
+	}
+	var sticked []string
+	for _, f := range files {
+		f, err = filepath.Abs(f)
+		if err != nil {
+			return sticked, err
+		}
+		if strings.HasPrefix(f, runtimeDir+"/") {
+			if err = stick(f); err != nil {
+				return sticked, err
+			}
+			sticked = append(sticked, f)
+		}
+	}
+	return sticked, nil
+}
+
+func stick(f string) error {
+	st, err := os.Stat(f)
+	if err != nil {
+		return err
+	}
+	m := st.Mode()
+	m |= os.ModeSticky
+	return os.Chmod(f, m)
+}
+
+// GetDataHome returns XDG_DATA_HOME.
+// GetDataHome returns $HOME/.local/share and nil error if XDG_DATA_HOME is not set.
+//
+// See also https://standards.freedesktop.org/basedir-spec/latest/ar01s03.html
+func GetDataHome() (string, error) {
+	if xdgDataHome := os.Getenv("XDG_DATA_HOME"); xdgDataHome != "" {
+		return xdgDataHome, nil
+	}
+	home := os.Getenv("HOME")
+	if home == "" {
+		return "", errors.New("could not get either XDG_DATA_HOME or HOME")
+	}
+	return filepath.Join(home, ".local", "share"), nil
+}
+
+// GetConfigHome returns XDG_CONFIG_HOME.
+// GetConfigHome returns $HOME/.config and nil error if XDG_CONFIG_HOME is not set.
+//
+// See also https://standards.freedesktop.org/basedir-spec/latest/ar01s03.html
+func GetConfigHome() (string, error) {
+	if xdgConfigHome := os.Getenv("XDG_CONFIG_HOME"); xdgConfigHome != "" {
+		return xdgConfigHome, nil
+	}
+	home := os.Getenv("HOME")
+	if home == "" {
+		return "", errors.New("could not get either XDG_CONFIG_HOME or HOME")
+	}
+	return filepath.Join(home, ".config"), nil
 }

--- a/pkg/homedir/homedir_others.go
+++ b/pkg/homedir/homedir_others.go
@@ -2,12 +2,29 @@
 
 package homedir
 
+// Copyright 2013-2018 Docker, Inc.
+// NOTE: this package has originally been copied from github.com/docker/docker.
+
 import (
 	"errors"
 )
 
-// GetStatic is not needed for non-linux systems.
-// (Precisely, it is needed only for glibc-based linux systems.)
-func GetStatic() (string, error) {
-	return "", errors.New("homedir.GetStatic() is not supported on this system")
+// GetRuntimeDir is unsupported on non-linux system.
+func GetRuntimeDir() (string, error) {
+	return "", errors.New("homedir.GetRuntimeDir() is not supported on this system")
+}
+
+// StickRuntimeDirContents is unsupported on non-linux system.
+func StickRuntimeDirContents(files []string) ([]string, error) {
+	return nil, errors.New("homedir.StickRuntimeDirContents() is not supported on this system")
+}
+
+// GetDataHome is unsupported on non-linux system.
+func GetDataHome() (string, error) {
+	return "", errors.New("homedir.GetDataHome() is not supported on this system")
+}
+
+// GetConfigHome is unsupported on non-linux system.
+func GetConfigHome() (string, error) {
+	return "", errors.New("homedir.GetConfigHome() is not supported on this system")
 }

--- a/pkg/homedir/homedir_test.go
+++ b/pkg/homedir/homedir_test.go
@@ -1,5 +1,8 @@
 package homedir
 
+// Copyright 2013-2018 Docker, Inc.
+// NOTE: this package has originally been copied from github.com/docker/docker.
+
 import (
 	"path/filepath"
 	"testing"

--- a/pkg/homedir/homedir_unix.go
+++ b/pkg/homedir/homedir_unix.go
@@ -2,10 +2,12 @@
 
 package homedir
 
+// Copyright 2013-2018 Docker, Inc.
+// NOTE: this package has originally been copied from github.com/docker/docker.
+
 import (
 	"os"
-
-	"github.com/opencontainers/runc/libcontainer/user"
+	"os/user"
 )
 
 // Key returns the env var name for the user's home dir based on
@@ -17,11 +19,16 @@ func Key() string {
 // Get returns the home directory of the current user with the help of
 // environment variables depending on the target operating system.
 // Returned path should be used with "path/filepath" to form new paths.
+//
+// If linking statically with cgo enabled against glibc, ensure the
+// osusergo build tag is used.
+//
+// If needing to do nss lookups, do not disable cgo or set osusergo.
 func Get() string {
 	home := os.Getenv(Key())
 	if home == "" {
-		if u, err := user.CurrentUser(); err == nil {
-			return u.Home
+		if u, err := user.Current(); err == nil {
+			return u.HomeDir
 		}
 	}
 	return home

--- a/pkg/homedir/homedir_windows.go
+++ b/pkg/homedir/homedir_windows.go
@@ -1,5 +1,8 @@
 package homedir
 
+// Copyright 2013-2018 Docker, Inc.
+// NOTE: this package has originally been copied from github.com/docker/docker.
+
 import (
 	"os"
 )

--- a/store.go
+++ b/store.go
@@ -20,6 +20,7 @@ import (
 	"github.com/containers/storage/pkg/archive"
 	cfg "github.com/containers/storage/pkg/config"
 	"github.com/containers/storage/pkg/directory"
+	"github.com/containers/storage/pkg/homedir"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/ioutils"
 	"github.com/containers/storage/pkg/parsers"
@@ -3275,9 +3276,9 @@ const defaultConfigFile = "/etc/containers/storage.conf"
 // DefaultConfigFile returns the path to the storage config file used
 func DefaultConfigFile(rootless bool) (string, error) {
 	if rootless {
-		home, err := homeDir()
-		if err != nil {
-			return "", errors.Wrapf(err, "cannot determine users homedir")
+		home := homedir.Get()
+		if home == "" {
+			return "", errors.New("cannot determine user's homedir")
 		}
 		return filepath.Join(home, ".config/containers/storage.conf"), nil
 	}


### PR DESCRIPTION
pkg/homedir is a fork from docker/docker and part of un-dockering the  
direct dependencies of the containers projects.  There is nothing wrong
at all with the Docker packages but there is an increasing risk of     
non-deterministic behavior as Docker does not provide a go module and  
it's release related only to the binary but not to the go libraries.   
Enforcing control over that will prevent us from regressions in the    
future.                                                                
                                                                       
c/storage seems like the best place for this package since it's at the 
very end of the containers/ dependency chain.                          
                                                                       
Note that all forked files have a copyright note to correctly attribute
the original authors.                                                  
                                                                       
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>                 
