### PR TITLE
storage.conf: Fix "the base. device." typo

### DIFF
--- a/storage.conf
+++ b/storage.conf
@@ -107,7 +107,7 @@ mountopt = "nodev"
 # Value 0% disables
 # min_free_space = "10%"
 
-# mkfsarg specifies extra mkfs arguments to be used when creating the base.
+# mkfsarg specifies extra mkfs arguments to be used when creating the base
 # device.
 # mkfsarg = ""
 


### PR DESCRIPTION
The extra period was introduced in 939bd74869 (#177).