### PR TITLE
ioutils: use Fdatasync instead of Sync

### DIFF
--- a/pkg/ioutils/fswriters.go
+++ b/pkg/ioutils/fswriters.go
@@ -65,7 +65,7 @@ func (w *atomicFileWriter) Close() (retErr error) {
 			os.Remove(w.f.Name())
 		}
 	}()
-	if err := w.f.Sync(); err != nil {
+	if err := fdatasync(w.f); err != nil {
 		w.f.Close()
 		return err
 	}
@@ -126,7 +126,7 @@ type syncFileCloser struct {
 }
 
 func (w syncFileCloser) Close() error {
-	err := w.File.Sync()
+	err := fdatasync(w.File)
 	if err1 := w.File.Close(); err == nil {
 		err = err1
 	}

--- a/pkg/ioutils/fswriters_linux.go
+++ b/pkg/ioutils/fswriters_linux.go
@@ -1,0 +1,11 @@
+package ioutils
+
+import (
+	"os"
+
+	"golang.org/x/sys/unix"
+)
+
+func fdatasync(f *os.File) error {
+	return unix.Fdatasync(int(f.Fd()))
+}

--- a/pkg/ioutils/fswriters_unsupported.go
+++ b/pkg/ioutils/fswriters_unsupported.go
@@ -1,0 +1,11 @@
+// +build !linux
+
+package ioutils
+
+import (
+	"os"
+)
+
+func fdatasync(f *os.File) error {
+	return f.Sync()
+}


### PR DESCRIPTION
since we don't care of other inode attributes, but only those required
to retrieve the data, use the slightly faster fdatasync.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>