### PR TITLE
lockfile: drop call to unix.Fsync

### DIFF
--- a/pkg/lockfile/lockfile_unix.go
+++ b/pkg/lockfile/lockfile_unix.go
@@ -206,10 +206,6 @@ func (l *lockfile) Touch() error {
 	if n != len(id) {
 		return unix.ENOSPC
 	}
-	err = unix.Fsync(int(l.fd))
-	if err != nil {
-		return err
-	}
 	return nil
 }
 


### PR DESCRIPTION
do not flush the modified metadata to disk each time the store is
modified.

It is not needed for other processes stat'ing the lock file to see the
updated mtime.

introduced with commit 9b0633295b55d9b52d909a4fb8e3b6e84265c2cf

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>