### PR TITLE
pkg/system: fix/improve xattr functions

### DIFF
--- a/pkg/system/xattrs_linux.go
+++ b/pkg/system/xattrs_linux.go
@@ -16,30 +16,29 @@ const (
 
 // Lgetxattr retrieves the value of the extended attribute identified by attr
 // and associated with the given path in the file system.
-// It will returns a nil slice and nil error if the xattr is not set.
+// Returns a []byte slice if the xattr is set and nil otherwise.
 func Lgetxattr(path string, attr string) ([]byte, error) {
 	// Start with a 128 length byte array
 	dest := make([]byte, 128)
 	sz, errno := unix.Lgetxattr(path, attr, dest)
 
-	switch {
-	case errno == unix.ENODATA:
-		return nil, nil
-	case errno == unix.ERANGE:
-		// 128 byte array might just not be good enough. A dummy buffer is used
-		// to get the real size of the xattrs on disk
+	for errno == unix.ERANGE {
+		// Buffer too small, use zero-sized buffer to get the actual size
 		sz, errno = unix.Lgetxattr(path, attr, []byte{})
 		if errno != nil {
 			return nil, errno
 		}
 		dest = make([]byte, sz)
 		sz, errno = unix.Lgetxattr(path, attr, dest)
-		if errno != nil {
-			return nil, errno
-		}
+	}
+
+	switch {
+	case errno == unix.ENODATA:
+		return nil, nil
 	case errno != nil:
 		return nil, errno
 	}
+
 	return dest[:sz], nil
 }
 

--- a/pkg/system/xattrs_linux.go
+++ b/pkg/system/xattrs_linux.go
@@ -2,17 +2,16 @@ package system
 
 import (
 	"bytes"
-	"syscall"
 
 	"golang.org/x/sys/unix"
 )
 
 const (
 	// Value is larger than the maximum size allowed
-	E2BIG syscall.Errno = unix.E2BIG
+	E2BIG unix.Errno = unix.E2BIG
 
 	// Operation not supported
-	EOPNOTSUPP syscall.Errno = unix.EOPNOTSUPP
+	EOPNOTSUPP unix.Errno = unix.EOPNOTSUPP
 )
 
 // Lgetxattr retrieves the value of the extended attribute identified by attr


### PR DESCRIPTION
### 1. pkg/system: handle changed size case
    
`lgetxattr(2)` man page says:
    
> If size is specified as zero, these calls return the  current  size  of
> the  named extended attribute (and leave value unchanged).  This can be
> used to determine the size of the buffer that should be supplied  in  a
> subsequent  call.   (But, bear in mind that there is a possibility that
> the attribute value may change between the two calls,  so  that  it  is
> still necessary to check the return status from the second call.)

The current code does not handle the "bear in mind" case, i.e. when
the size changes between the two calls, and the new size is larger.
    
Fix the above problem, and slightly simplify the code.

### 2. pkg/system: improve Llistxattr

The current code
 * is hard to read (at least for me, that is);
 * is suboptimal (always calls `unix.Llistxattr()` twice);
 * doesn't handle the condition when attributes size
   is changed in between the two calls to `unix.Llistxattr()`
   (see the detailed description in previous patch)
    
Fix all three issues by reusing the logic from `Lgetxattr()`.