### PR TITLE
pkg/mount: optimize/cleanup

### DIFF
--- a/pkg/mount/flags_linux.go
+++ b/pkg/mount/flags_linux.go
@@ -82,4 +82,6 @@ const (
 	// it possible for the kernel to default to relatime or noatime but still
 	// allow userspace to override it.
 	STRICTATIME = unix.MS_STRICTATIME
+
+	mntDetach = unix.MNT_DETACH
 )

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -67,7 +67,7 @@ func Unmount(target string) error {
 }
 
 // RecursiveUnmount unmounts the target and all mounts underneath, starting with
-// the deepsest mount first.
+// the deepest mount first.
 func RecursiveUnmount(target string) error {
 	mounts, err := GetMounts()
 	if err != nil {
@@ -75,7 +75,9 @@ func RecursiveUnmount(target string) error {
 	}
 
 	// Make the deepest mount be first
-	sort.Sort(sort.Reverse(byMountpoint(mounts)))
+	sort.Slice(mounts, func(i, j int) bool {
+		return len(mounts[i].Mountpoint) > len(mounts[j].Mountpoint)
+	})
 
 	for i, m := range mounts {
 		if !strings.HasPrefix(m.Mountpoint, target) {

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -3,7 +3,6 @@ package mount
 import (
 	"sort"
 	"strings"
-	"time"
 
 	"github.com/containers/storage/pkg/fileutils"
 )
@@ -63,7 +62,7 @@ func Unmount(target string) error {
 	if mounted, err := Mounted(target); err != nil || !mounted {
 		return err
 	}
-	return ForceUnmount(target)
+	return unmount(target, mntDetach)
 }
 
 // RecursiveUnmount unmounts the target and all mounts underneath, starting with
@@ -96,13 +95,6 @@ func RecursiveUnmount(target string) error {
 
 // ForceUnmount will force an unmount of the target filesystem, regardless if
 // it is mounted or not.
-func ForceUnmount(target string) (err error) {
-	// Simple retry logic for unmount
-	for i := 0; i < 10; i++ {
-		if err = unmount(target, 0); err == nil {
-			return nil
-		}
-		time.Sleep(100 * time.Millisecond)
-	}
-	return nil
+func ForceUnmount(target string) error {
+	return unmount(target, mntDetach)
 }

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -38,13 +38,13 @@ func Mounted(mountpoint string) (bool, error) {
 // specified like the mount or fstab unix commands: "opt1=val1,opt2=val2". See
 // flags.go for supported option flags.
 func Mount(device, target, mType, options string) error {
-	flag, _ := ParseOptions(options)
+	flag, data := ParseOptions(options)
 	if flag&REMOUNT != REMOUNT {
 		if mounted, err := Mounted(target); err != nil || mounted {
 			return err
 		}
 	}
-	return ForceMount(device, target, mType, options)
+	return mount(device, target, mType, uintptr(flag), data)
 }
 
 // ForceMount will mount a filesystem according to the specified configuration,

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -90,8 +90,10 @@ func RecursiveUnmount(target string) error {
 	return nil
 }
 
-// ForceUnmount will force an unmount of the target filesystem, regardless if
-// it is mounted or not.
+// ForceUnmount lazily unmounts a filesystem on supported platforms,
+// otherwise does a normal unmount.
+//
+// Deprecated: please use Unmount instead, it is identical.
 func ForceUnmount(target string) error {
 	return unmount(target, mntDetach)
 }

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -59,9 +59,6 @@ func ForceMount(device, target, mType, options string) error {
 // Unmount lazily unmounts a filesystem on supported platforms, otherwise
 // does a normal unmount.
 func Unmount(target string) error {
-	if mounted, err := Mounted(target); err != nil || !mounted {
-		return err
-	}
 	return unmount(target, mntDetach)
 }
 

--- a/pkg/mount/mount_unix_test.go
+++ b/pkg/mount/mount_unix_test.go
@@ -25,6 +25,10 @@ func TestMountOptionsParsing(t *testing.T) {
 }
 
 func TestMounted(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("root required")
+	}
+
 	tmp := path.Join(os.TempDir(), "mount-tests")
 	if err := os.MkdirAll(tmp, 0777); err != nil {
 		t.Fatal(err)
@@ -76,6 +80,10 @@ func TestMounted(t *testing.T) {
 }
 
 func TestMountReadonly(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("root required")
+	}
+
 	tmp := path.Join(os.TempDir(), "mount-tests")
 	if err := os.MkdirAll(tmp, 0777); err != nil {
 		t.Fatal(err)

--- a/pkg/mount/mounter_freebsd.go
+++ b/pkg/mount/mounter_freebsd.go
@@ -14,8 +14,6 @@ import (
 	"fmt"
 	"strings"
 	"unsafe"
-
-	"golang.org/x/sys/unix"
 )
 
 func allocateIOVecs(options []string) []C.struct_iovec {
@@ -53,8 +51,4 @@ func mount(device, target, mType string, flag uintptr, data string) error {
 		return fmt.Errorf("Failed to call nmount: %s", reason)
 	}
 	return nil
-}
-
-func unmount(target string, flag int) error {
-	return unix.Unmount(target, flag)
 }

--- a/pkg/mount/mounter_linux.go
+++ b/pkg/mount/mounter_linux.go
@@ -53,7 +53,3 @@ func mount(device, target, mType string, flags uintptr, data string) error {
 
 	return nil
 }
-
-func unmount(target string, flag int) error {
-	return unix.Unmount(target, flag)
-}

--- a/pkg/mount/mounter_linux_test.go
+++ b/pkg/mount/mounter_linux_test.go
@@ -1,5 +1,3 @@
-// +build linux
-
 package mount
 
 import (

--- a/pkg/mount/mounter_linux_test.go
+++ b/pkg/mount/mounter_linux_test.go
@@ -171,7 +171,7 @@ func validateMount(t *testing.T, mnt string, opts, optional, vfs string) {
 			for _, opt := range strings.Split(mi.Opts, ",") {
 				opt = clean(opt)
 				if !has(volunteeredOPT, opt) && !has(wantedOpts, opt) && !has(pOpts, opt) {
-					t.Errorf("unexpected mount option %q expected %q", opt, opts)
+					t.Errorf("unexpected mount option %q, expected %q", opt, opts)
 				}
 				delete(wantedOpts, opt)
 			}
@@ -185,13 +185,13 @@ func validateMount(t *testing.T, mnt string, opts, optional, vfs string) {
 			for _, field := range strings.Split(mi.Optional, ",") {
 				field = clean(field)
 				if !has(wantedOptional, field) && !has(pOptional, field) {
-					t.Errorf("unexpected optional failed %q expected %q", field, optional)
+					t.Errorf("unexpected optional field %q, expected %q", field, optional)
 				}
 				delete(wantedOptional, field)
 			}
 		}
 		for field := range wantedOptional {
-			t.Errorf("missing optional field %q found %q", field, mi.Optional)
+			t.Errorf("missing optional field %q, found %q", field, mi.Optional)
 		}
 
 		// Validate VFS if set
@@ -200,13 +200,13 @@ func validateMount(t *testing.T, mnt string, opts, optional, vfs string) {
 				for _, opt := range strings.Split(mi.VfsOpts, ",") {
 					opt = clean(opt)
 					if !has(wantedVFS, opt) && !has(volunteeredVFS, opt) {
-						t.Errorf("unexpected mount option %q expected %q", opt, vfs)
+						t.Errorf("unexpected vfs option %q, expected %q", opt, vfs)
 					}
 					delete(wantedVFS, opt)
 				}
 			}
 			for opt := range wantedVFS {
-				t.Errorf("missing mount option %q found %q", opt, mi.VfsOpts)
+				t.Errorf("missing vfs option %q, found %q", opt, mi.VfsOpts)
 			}
 		}
 

--- a/pkg/mount/mounter_solaris.go
+++ b/pkg/mount/mounter_solaris.go
@@ -4,8 +4,6 @@ package mount
 
 import (
 	"unsafe"
-
-	"golang.org/x/sys/unix"
 )
 
 // #include <stdlib.h>
@@ -25,10 +23,5 @@ func mount(device, target, mType string, flag uintptr, data string) error {
 	C.free(unsafe.Pointer(spec))
 	C.free(unsafe.Pointer(dir))
 	C.free(unsafe.Pointer(fstype))
-	return err
-}
-
-func unmount(target string, flag int) error {
-	err := unix.Unmount(target, flag)
 	return err
 }

--- a/pkg/mount/mounter_unsupported.go
+++ b/pkg/mount/mounter_unsupported.go
@@ -5,7 +5,3 @@ package mount
 func mount(device, target, mType string, flag uintptr, data string) error {
 	panic("Not implemented")
 }
-
-func unmount(target string, flag int) error {
-	panic("Not implemented")
-}

--- a/pkg/mount/mountinfo.go
+++ b/pkg/mount/mountinfo.go
@@ -38,17 +38,3 @@ type Info struct {
 	// VfsOpts represents per super block options.
 	VfsOpts string
 }
-
-type byMountpoint []*Info
-
-func (by byMountpoint) Len() int {
-	return len(by)
-}
-
-func (by byMountpoint) Less(i, j int) bool {
-	return by[i].Mountpoint < by[j].Mountpoint
-}
-
-func (by byMountpoint) Swap(i, j int) {
-	by[i], by[j] = by[j], by[i]
-}

--- a/pkg/mount/mountinfo_linux.go
+++ b/pkg/mount/mountinfo_linux.go
@@ -1,5 +1,3 @@
-// +build linux
-
 package mount
 
 import (

--- a/pkg/mount/mountinfo_linux_test.go
+++ b/pkg/mount/mountinfo_linux_test.go
@@ -1,5 +1,3 @@
-// +build linux
-
 package mount
 
 import (

--- a/pkg/mount/sharedsubtree_linux.go
+++ b/pkg/mount/sharedsubtree_linux.go
@@ -1,5 +1,3 @@
-// +build linux
-
 package mount
 
 // MakeShared ensures a mounted filesystem has the SHARED mount option enabled.

--- a/pkg/mount/sharedsubtree_linux.go
+++ b/pkg/mount/sharedsubtree_linux.go
@@ -3,62 +3,62 @@ package mount
 // MakeShared ensures a mounted filesystem has the SHARED mount option enabled.
 // See the supported options in flags.go for further reference.
 func MakeShared(mountPoint string) error {
-	return ensureMountedAs(mountPoint, "shared")
+	return ensureMountedAs(mountPoint, SHARED)
 }
 
 // MakeRShared ensures a mounted filesystem has the RSHARED mount option enabled.
 // See the supported options in flags.go for further reference.
 func MakeRShared(mountPoint string) error {
-	return ensureMountedAs(mountPoint, "rshared")
+	return ensureMountedAs(mountPoint, RSHARED)
 }
 
 // MakePrivate ensures a mounted filesystem has the PRIVATE mount option enabled.
 // See the supported options in flags.go for further reference.
 func MakePrivate(mountPoint string) error {
-	return ensureMountedAs(mountPoint, "private")
+	return ensureMountedAs(mountPoint, PRIVATE)
 }
 
 // MakeRPrivate ensures a mounted filesystem has the RPRIVATE mount option
 // enabled. See the supported options in flags.go for further reference.
 func MakeRPrivate(mountPoint string) error {
-	return ensureMountedAs(mountPoint, "rprivate")
+	return ensureMountedAs(mountPoint, RPRIVATE)
 }
 
 // MakeSlave ensures a mounted filesystem has the SLAVE mount option enabled.
 // See the supported options in flags.go for further reference.
 func MakeSlave(mountPoint string) error {
-	return ensureMountedAs(mountPoint, "slave")
+	return ensureMountedAs(mountPoint, SLAVE)
 }
 
 // MakeRSlave ensures a mounted filesystem has the RSLAVE mount option enabled.
 // See the supported options in flags.go for further reference.
 func MakeRSlave(mountPoint string) error {
-	return ensureMountedAs(mountPoint, "rslave")
+	return ensureMountedAs(mountPoint, RSLAVE)
 }
 
 // MakeUnbindable ensures a mounted filesystem has the UNBINDABLE mount option
 // enabled. See the supported options in flags.go for further reference.
 func MakeUnbindable(mountPoint string) error {
-	return ensureMountedAs(mountPoint, "unbindable")
+	return ensureMountedAs(mountPoint, UNBINDABLE)
 }
 
 // MakeRUnbindable ensures a mounted filesystem has the RUNBINDABLE mount
 // option enabled. See the supported options in flags.go for further reference.
 func MakeRUnbindable(mountPoint string) error {
-	return ensureMountedAs(mountPoint, "runbindable")
+	return ensureMountedAs(mountPoint, RUNBINDABLE)
 }
 
-func ensureMountedAs(mountPoint, options string) error {
-	mounted, err := Mounted(mountPoint)
+func ensureMountedAs(mnt string, flags int) error {
+	mounted, err := Mounted(mnt)
 	if err != nil {
 		return err
 	}
 
 	if !mounted {
-		if err := ForceMount(mountPoint, mountPoint, "none", "bind"); err != nil {
+		if err := mount(mnt, mnt, "none", uintptr(BIND), ""); err != nil {
 			return err
 		}
 	}
 
-	return ForceMount("", mountPoint, "none", options)
+	return mount("", mnt, "none", uintptr(flags), "")
 }

--- a/pkg/mount/sharedsubtree_linux.go
+++ b/pkg/mount/sharedsubtree_linux.go
@@ -55,12 +55,9 @@ func ensureMountedAs(mountPoint, options string) error {
 	}
 
 	if !mounted {
-		if err := Mount(mountPoint, mountPoint, "none", "bind,rw"); err != nil {
+		if err := ForceMount(mountPoint, mountPoint, "none", "bind"); err != nil {
 			return err
 		}
-	}
-	if _, err = Mounted(mountPoint); err != nil {
-		return err
 	}
 
 	return ForceMount("", mountPoint, "none", options)

--- a/pkg/mount/sharedsubtree_linux_test.go
+++ b/pkg/mount/sharedsubtree_linux_test.go
@@ -1,5 +1,3 @@
-// +build linux
-
 package mount
 
 import (

--- a/pkg/mount/sharedsubtree_linux_test.go
+++ b/pkg/mount/sharedsubtree_linux_test.go
@@ -10,6 +10,10 @@ import (
 
 // nothing is propagated in or out
 func TestSubtreePrivate(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("root required")
+	}
+
 	tmp := path.Join(os.TempDir(), "mount-tests")
 	if err := os.MkdirAll(tmp, 0777); err != nil {
 		t.Fatal(err)
@@ -108,6 +112,10 @@ func TestSubtreePrivate(t *testing.T) {
 // Testing that when a target is a shared mount,
 // then child mounts propagate to the source
 func TestSubtreeShared(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("root required")
+	}
+
 	tmp := path.Join(os.TempDir(), "mount-tests")
 	if err := os.MkdirAll(tmp, 0777); err != nil {
 		t.Fatal(err)
@@ -176,6 +184,10 @@ func TestSubtreeShared(t *testing.T) {
 // testing that mounts to a shared source show up in the slave target,
 // and that mounts into a slave target do _not_ show up in the shared source
 func TestSubtreeSharedSlave(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("root required")
+	}
+
 	tmp := path.Join(os.TempDir(), "mount-tests")
 	if err := os.MkdirAll(tmp, 0777); err != nil {
 		t.Fatal(err)
@@ -280,6 +292,10 @@ func TestSubtreeSharedSlave(t *testing.T) {
 }
 
 func TestSubtreeUnbindable(t *testing.T) {
+	if os.Getuid() != 0 {
+		t.Skip("root required")
+	}
+
 	tmp := path.Join(os.TempDir(), "mount-tests")
 	if err := os.MkdirAll(tmp, 0777); err != nil {
 		t.Fatal(err)

--- a/pkg/mount/unmount_unix.go
+++ b/pkg/mount/unmount_unix.go
@@ -1,0 +1,17 @@
+// +build !windows
+
+package mount
+
+import "golang.org/x/sys/unix"
+
+func unmount(target string, flags int) error {
+	err := unix.Unmount(target, flags)
+	if err == unix.EINVAL {
+		// Ignore "not mounted" error here. Note the same error
+		// can be returned if flags are invalid, so this code
+		// assumes that the flags value is always correct.
+		err = nil
+	}
+
+	return err
+}

--- a/pkg/mount/unmount_unsupported.go
+++ b/pkg/mount/unmount_unsupported.go
@@ -1,0 +1,7 @@
+// +build windows
+
+package mount
+
+func unmount(target string, flag int) error {
+	panic("Not implemented")
+}


### PR DESCRIPTION
This tries to bring `pkg/mount` package to a better shape, mostly reshuffling things here and there, removing redundant and excessive calls to parse `/proc/self/mountinfo`, etc.

Please see individual commits for detailed descriptions.

:warning: **This needs a very thorough review**

PS In fact, this might fix some bugs, too, since reading `/proc/self/mountinfo` from the kernel proved to be unreliable/racy. In case there are multiple mounts and unmounts happening while reading /proc/self/mountinfo, the kernel can only give you half the mounts (if you're curious, see https://github.com/kolyshkin/procfs-test for more details and repro).

PPS Once this lands, I want to optimize the mountinfo parser which is still used for at least `Mount()`. Probably makes sense to also drop Solaris support.