### PR TITLE
Faster Chown

### DIFF
--- a/drivers/chown.go
+++ b/drivers/chown.go
@@ -5,10 +5,10 @@ import (
 	"encoding/json"
 	"fmt"
 	"os"
-	"path/filepath"
 
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/reexec"
+	"github.com/opencontainers/selinux/pkg/pwalk"
 )
 
 const (
@@ -51,16 +51,13 @@ func chownByMapsMain() {
 	if len(toHost.UIDs()) == 0 && len(toHost.GIDs()) == 0 {
 		toHost = nil
 	}
-	chown := func(path string, info os.FileInfo, err error) error {
-		if err != nil {
-			return fmt.Errorf("error walking to %q: %v", path, err)
-		}
+	chown := func(path string, info os.FileInfo, _ error) error {
 		if path == "." {
 			return nil
 		}
 		return platformLChown(path, info, toHost, toContainer)
 	}
-	if err := filepath.Walk(".", chown); err != nil {
+	if err := pwalk.Walk(".", chown); err != nil {
 		fmt.Fprintf(os.Stderr, "error during chown: %v", err)
 		os.Exit(1)
 	}

--- a/drivers/chown_unix.go
+++ b/drivers/chown_unix.go
@@ -48,10 +48,6 @@ func platformLChown(path string, info os.FileInfo, toHost, toContainer *idtools.
 		uid, gid = mappedPair.UID, mappedPair.GID
 	}
 	if uid != int(st.Uid) || gid != int(st.Gid) {
-		stat, err := os.Lstat(path)
-		if err != nil {
-			return fmt.Errorf("%s: lstat(%q): %v", os.Args[0], path, err)
-		}
 		cap, err := system.Lgetxattr(path, "security.capability")
 		if err != nil && err != system.ErrNotSupportedPlatform {
 			return fmt.Errorf("%s: Lgetxattr(%q): %v", os.Args[0], path, err)
@@ -62,8 +58,8 @@ func platformLChown(path string, info os.FileInfo, toHost, toContainer *idtools.
 			return fmt.Errorf("%s: chown(%q): %v", os.Args[0], path, err)
 		}
 		// Restore the SUID and SGID bits if they were originally set.
-		if (stat.Mode()&os.ModeSymlink == 0) && stat.Mode()&(os.ModeSetuid|os.ModeSetgid) != 0 {
-			if err := os.Chmod(path, stat.Mode()); err != nil {
+		if (info.Mode()&os.ModeSymlink == 0) && info.Mode()&(os.ModeSetuid|os.ModeSetgid) != 0 {
+			if err := os.Chmod(path, info.Mode()); err != nil {
 				return fmt.Errorf("%s: chmod(%q): %v", os.Args[0], path, err)
 			}
 		}

--- a/drivers/chown_unix.go
+++ b/drivers/chown_unix.go
@@ -12,66 +12,67 @@ import (
 )
 
 func platformLChown(path string, info os.FileInfo, toHost, toContainer *idtools.IDMappings) error {
-	sysinfo := info.Sys()
-	if st, ok := sysinfo.(*syscall.Stat_t); ok {
-		// Map an on-disk UID/GID pair from host to container
-		// using the first map, then back to the host using the
-		// second map.  Skip that first step if they're 0, to
-		// compensate for cases where a parent layer should
-		// have had a mapped value, but didn't.
-		uid, gid := int(st.Uid), int(st.Gid)
-		if toContainer != nil {
-			pair := idtools.IDPair{
-				UID: uid,
-				GID: gid,
-			}
-			mappedUID, mappedGID, err := toContainer.ToContainer(pair)
-			if err != nil {
-				if (uid != 0) || (gid != 0) {
-					return fmt.Errorf("error mapping host ID pair %#v for %q to container: %v", pair, path, err)
-				}
-				mappedUID, mappedGID = uid, gid
-			}
-			uid, gid = mappedUID, mappedGID
+	st, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return nil
+	}
+	// Map an on-disk UID/GID pair from host to container
+	// using the first map, then back to the host using the
+	// second map.  Skip that first step if they're 0, to
+	// compensate for cases where a parent layer should
+	// have had a mapped value, but didn't.
+	uid, gid := int(st.Uid), int(st.Gid)
+	if toContainer != nil {
+		pair := idtools.IDPair{
+			UID: uid,
+			GID: gid,
 		}
-		if toHost != nil {
-			pair := idtools.IDPair{
-				UID: uid,
-				GID: gid,
+		mappedUID, mappedGID, err := toContainer.ToContainer(pair)
+		if err != nil {
+			if (uid != 0) || (gid != 0) {
+				return fmt.Errorf("error mapping host ID pair %#v for %q to container: %v", pair, path, err)
 			}
-			mappedPair, err := toHost.ToHost(pair)
-			if err != nil {
-				return fmt.Errorf("error mapping container ID pair %#v for %q to host: %v", pair, path, err)
-			}
-			uid, gid = mappedPair.UID, mappedPair.GID
+			mappedUID, mappedGID = uid, gid
 		}
-		if uid != int(st.Uid) || gid != int(st.Gid) {
-			stat, err := os.Lstat(path)
-			if err != nil {
-				return fmt.Errorf("%s: lstat(%q): %v", os.Args[0], path, err)
-			}
-			cap, err := system.Lgetxattr(path, "security.capability")
-			if err != nil && err != system.ErrNotSupportedPlatform {
-				return fmt.Errorf("%s: Lgetxattr(%q): %v", os.Args[0], path, err)
-			}
+		uid, gid = mappedUID, mappedGID
+	}
+	if toHost != nil {
+		pair := idtools.IDPair{
+			UID: uid,
+			GID: gid,
+		}
+		mappedPair, err := toHost.ToHost(pair)
+		if err != nil {
+			return fmt.Errorf("error mapping container ID pair %#v for %q to host: %v", pair, path, err)
+		}
+		uid, gid = mappedPair.UID, mappedPair.GID
+	}
+	if uid != int(st.Uid) || gid != int(st.Gid) {
+		stat, err := os.Lstat(path)
+		if err != nil {
+			return fmt.Errorf("%s: lstat(%q): %v", os.Args[0], path, err)
+		}
+		cap, err := system.Lgetxattr(path, "security.capability")
+		if err != nil && err != system.ErrNotSupportedPlatform {
+			return fmt.Errorf("%s: Lgetxattr(%q): %v", os.Args[0], path, err)
+		}
 
-			// Make the change.
-			if err := syscall.Lchown(path, uid, gid); err != nil {
-				return fmt.Errorf("%s: chown(%q): %v", os.Args[0], path, err)
-			}
-			// Restore the SUID and SGID bits if they were originally set.
-			if (stat.Mode()&os.ModeSymlink == 0) && stat.Mode()&(os.ModeSetuid|os.ModeSetgid) != 0 {
-				if err := os.Chmod(path, stat.Mode()); err != nil {
-					return fmt.Errorf("%s: chmod(%q): %v", os.Args[0], path, err)
-				}
-			}
-			if cap != nil {
-				if err := system.Lsetxattr(path, "security.capability", cap, 0); err != nil {
-					return fmt.Errorf("%s: Lsetxattr(%q): %v", os.Args[0], path, err)
-				}
-			}
-
+		// Make the change.
+		if err := syscall.Lchown(path, uid, gid); err != nil {
+			return fmt.Errorf("%s: chown(%q): %v", os.Args[0], path, err)
 		}
+		// Restore the SUID and SGID bits if they were originally set.
+		if (stat.Mode()&os.ModeSymlink == 0) && stat.Mode()&(os.ModeSetuid|os.ModeSetgid) != 0 {
+			if err := os.Chmod(path, stat.Mode()); err != nil {
+				return fmt.Errorf("%s: chmod(%q): %v", os.Args[0], path, err)
+			}
+		}
+		if cap != nil {
+			if err := system.Lsetxattr(path, "security.capability", cap, 0); err != nil {
+				return fmt.Errorf("%s: Lsetxattr(%q): %v", os.Args[0], path, err)
+			}
+		}
+
 	}
 	return nil
 }

--- a/go.mod
+++ b/go.mod
@@ -11,7 +11,7 @@ require (
 	github.com/mistifyio/go-zfs v2.1.1+incompatible
 	github.com/opencontainers/go-digest v1.0.0-rc1
 	github.com/opencontainers/runc v1.0.0-rc9
-	github.com/opencontainers/selinux v1.3.3
+	github.com/opencontainers/selinux v1.4.0
 	github.com/pkg/errors v0.9.1
 	github.com/pquerna/ffjson v0.0.0-20181028064349-e517b90714f7
 	github.com/sirupsen/logrus v1.4.2

--- a/go.sum
+++ b/go.sum
@@ -55,8 +55,8 @@ github.com/opencontainers/runc v1.0.0-rc9 h1:/k06BMULKF5hidyoZymkoDCzdJzltZpz/UU
 github.com/opencontainers/runc v1.0.0-rc9/go.mod h1:qT5XzbpPznkRYVz/mWwUaVBUv2rmF59PVA73FjuZG0U=
 github.com/opencontainers/runtime-spec v0.1.2-0.20190507144316-5b71a03e2700/go.mod h1:jwyrGlmzljRJv/Fgzds9SsS/C5hL+LL3ko9hs6T5lQ0=
 github.com/opencontainers/runtime-tools v0.0.0-20181011054405-1d69bd0f9c39/go.mod h1:r3f7wjNzSs2extwzU3Y+6pKfobzPh+kKFJ3ofN+3nfs=
-github.com/opencontainers/selinux v1.3.3 h1:RX0wAeqtvVSYQcr017X3pFXPkLEtB6V4NjRD7gVQgg4=
-github.com/opencontainers/selinux v1.3.3/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwyzAJufJyiTt7s0g=
+github.com/opencontainers/selinux v1.4.0 h1:cpiX/2wWIju/6My60T6/z9CxNG7c8xTQyEmA9fChpUo=
+github.com/opencontainers/selinux v1.4.0/go.mod h1:yTcKuYAh6R95iDpefGLQaPaRwJFwyzAJufJyiTt7s0g=
 github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=

--- a/vendor/github.com/opencontainers/selinux/go-selinux/label/label.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/label/label.go
@@ -1,109 +1,77 @@
-// +build !selinux !linux
-
 package label
 
-// InitLabels returns the process label and file labels to be used within
-// the container.  A list of options can be passed into this function to alter
-// the labels.
-func InitLabels(options []string) (string, string, error) {
-	return "", "", nil
-}
+import (
+	"github.com/opencontainers/selinux/go-selinux"
+)
 
-func ROMountLabel() string {
-	return ""
-}
+// Deprecated: use selinux.ROFileLabel
+var ROMountLabel = selinux.ROFileLabel
 
-func GenLabels(options string) (string, string, error) {
-	return "", "", nil
-}
+// SetProcessLabel takes a process label and tells the kernel to assign the
+// label to the next program executed by the current process.
+// Deprecated: use selinux.SetExecLabel
+var SetProcessLabel = selinux.SetExecLabel
 
-func FormatMountLabel(src string, mountLabel string) string {
-	return src
-}
+// ProcessLabel returns the process label that the kernel will assign
+// to the next program executed by the current process.  If "" is returned
+// this indicates that the default labeling will happen for the process.
+// Deprecated: use selinux.ExecLabel
+var ProcessLabel = selinux.ExecLabel
 
-func SetProcessLabel(processLabel string) error {
-	return nil
-}
+// SetSocketLabel takes a process label and tells the kernel to assign the
+// label to the next socket that gets created
+// Deprecated: use selinux.SetSocketLabel
+var SetSocketLabel = selinux.SetSocketLabel
 
-func ProcessLabel() (string, error) {
-	return "", nil
-}
+// SocketLabel retrieves the current default socket label setting
+// Deprecated: use selinux.SocketLabel
+var SocketLabel = selinux.SocketLabel
 
-func SetSocketLabel(processLabel string) error {
-	return nil
-}
+// SetKeyLabel takes a process label and tells the kernel to assign the
+// label to the next kernel keyring that gets created
+// Deprecated: use selinux.SetKeyLabel
+var SetKeyLabel = selinux.SetKeyLabel
 
-func SocketLabel() (string, error) {
-	return "", nil
-}
+// KeyLabel retrieves the current default kernel keyring label setting
+// Deprecated: use selinux.KeyLabel
+var KeyLabel = selinux.KeyLabel
 
-func SetKeyLabel(processLabel string) error {
-	return nil
-}
+// FileLabel returns the label for specified path
+// Deprecated: use selinux.FileLabel
+var FileLabel = selinux.FileLabel
 
-func KeyLabel() (string, error) {
-	return "", nil
-}
+// PidLabel will return the label of the process running with the specified pid
+// Deprecated: use selinux.PidLabel
+var PidLabel = selinux.PidLabel
 
-func FileLabel(path string) (string, error) {
-	return "", nil
-}
-
-func SetFileLabel(path string, fileLabel string) error {
-	return nil
-}
-
-func SetFileCreateLabel(fileLabel string) error {
-	return nil
-}
-
-func Relabel(path string, fileLabel string, shared bool) error {
-	return nil
-}
-
-func PidLabel(pid int) (string, error) {
-	return "", nil
-}
-
+// Init initialises the labeling system
 func Init() {
+	selinux.GetEnabled()
 }
 
-// ClearLabels clears all reserved labels
-func ClearLabels() {
-	return
-}
+// ClearLabels will clear all reserved labels
+// Deprecated: use selinux.ClearLabels
+var ClearLabels = selinux.ClearLabels
 
+// ReserveLabel will record the fact that the MCS label has already been used.
+// This will prevent InitLabels from using the MCS label in a newly created
+// container
+// Deprecated: use selinux.ReserveLabel
 func ReserveLabel(label string) error {
+	selinux.ReserveLabel(label)
 	return nil
 }
 
+// ReleaseLabel will remove the reservation of the MCS label.
+// This will allow InitLabels to use the MCS label in a newly created
+// containers
+// Deprecated: use selinux.ReleaseLabel
 func ReleaseLabel(label string) error {
+	selinux.ReleaseLabel(label)
 	return nil
 }
 
 // DupSecOpt takes a process label and returns security options that
 // can be used to set duplicate labels on future container processes
-func DupSecOpt(src string) ([]string, error) {
-	return nil, nil
-}
-
-// DisableSecOpt returns a security opt that can disable labeling
-// support for future container processes
-func DisableSecOpt() []string {
-	return nil
-}
-
-// Validate checks that the label does not include unexpected options
-func Validate(label string) error {
-	return nil
-}
-
-// RelabelNeeded checks whether the user requested a relabel
-func RelabelNeeded(label string) bool {
-	return false
-}
-
-// IsShared checks that the label includes a "shared" mark
-func IsShared(label string) bool {
-	return false
-}
+// Deprecated: use selinux.DupSecOpt
+var DupSecOpt = selinux.DupSecOpt

--- a/vendor/github.com/opencontainers/selinux/go-selinux/label/label_stub.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/label/label_stub.go
@@ -1,0 +1,54 @@
+// +build !selinux !linux
+
+package label
+
+// InitLabels returns the process label and file labels to be used within
+// the container.  A list of options can be passed into this function to alter
+// the labels.
+func InitLabels(options []string) (string, string, error) {
+	return "", "", nil
+}
+
+// Deprecated: The GenLabels function is only to be used during the transition
+// to the official API. Use InitLabels(strings.Fields(options)) instead.
+func GenLabels(options string) (string, string, error) {
+	return "", "", nil
+}
+
+func FormatMountLabel(src string, mountLabel string) string {
+	return src
+}
+
+func SetFileLabel(path string, fileLabel string) error {
+	return nil
+}
+
+func SetFileCreateLabel(fileLabel string) error {
+	return nil
+}
+
+func Relabel(path string, fileLabel string, shared bool) error {
+	return nil
+}
+
+// DisableSecOpt returns a security opt that can disable labeling
+// support for future container processes
+func DisableSecOpt() []string {
+	// TODO the selinux.DisableSecOpt stub returns []string{"disable"} instead of "nil"
+	return nil
+}
+
+// Validate checks that the label does not include unexpected options
+func Validate(label string) error {
+	return nil
+}
+
+// RelabelNeeded checks whether the user requested a relabel
+func RelabelNeeded(label string) bool {
+	return false
+}
+
+// IsShared checks that the label includes a "shared" mark
+func IsShared(label string) bool {
+	return false
+}

--- a/vendor/github.com/opencontainers/selinux/go-selinux/selinux_linux.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/selinux_linux.go
@@ -17,8 +17,8 @@ import (
 	"strconv"
 	"strings"
 	"sync"
-	"syscall"
 
+	"github.com/opencontainers/selinux/pkg/pwalk"
 	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
@@ -37,7 +37,6 @@ const (
 	selinuxTypeTag   = "SELINUXTYPE"
 	selinuxTag       = "SELINUX"
 	xattrNameSelinux = "security.selinux"
-	stRdOnly         = 0x01
 )
 
 type selinuxState struct {
@@ -103,13 +102,13 @@ func SetDisabled() {
 }
 
 func verifySELinuxfsMount(mnt string) bool {
-	var buf syscall.Statfs_t
+	var buf unix.Statfs_t
 	for {
-		err := syscall.Statfs(mnt, &buf)
+		err := unix.Statfs(mnt, &buf)
 		if err == nil {
 			break
 		}
-		if err == syscall.EAGAIN {
+		if err == unix.EAGAIN {
 			continue
 		}
 		return false
@@ -118,7 +117,7 @@ func verifySELinuxfsMount(mnt string) bool {
 	if uint32(buf.Type) != uint32(unix.SELINUX_MAGIC) {
 		return false
 	}
-	if (buf.Flags & stRdOnly) != 0 {
+	if (buf.Flags & unix.ST_RDONLY) != 0 {
 		return false
 	}
 
@@ -251,10 +250,10 @@ func isProcHandle(fh *os.File) error {
 	var buf unix.Statfs_t
 	err := unix.Fstatfs(int(fh.Fd()), &buf)
 	if err != nil {
-		return fmt.Errorf("statfs(%q) failed: %v", fh.Name(), err)
+		return errors.Wrapf(err, "statfs(%q) failed", fh.Name())
 	}
 	if buf.Type != unix.PROC_SUPER_MAGIC {
-		return fmt.Errorf("file %q is not on procfs", fh.Name())
+		return errors.Errorf("file %q is not on procfs", fh.Name())
 	}
 
 	return nil
@@ -282,12 +281,29 @@ func readCon(fpath string) (string, error) {
 	return strings.Trim(retval, "\x00"), nil
 }
 
+// ClassIndex returns the int index for an object class in the loaded policy, or -1 and an error
+func ClassIndex(class string) (int, error) {
+	permpath := fmt.Sprintf("class/%s/index", class)
+	indexpath := filepath.Join(getSelinuxMountPoint(), permpath)
+
+	indexB, err := ioutil.ReadFile(indexpath)
+	if err != nil {
+		return -1, err
+	}
+	index, err := strconv.Atoi(string(indexB))
+	if err != nil {
+		return -1, err
+	}
+
+	return index, nil
+}
+
 // SetFileLabel sets the SELinux label for this path or returns an error.
 func SetFileLabel(fpath string, label string) error {
 	if fpath == "" {
 		return ErrEmptyPath
 	}
-	if err := lsetxattr(fpath, xattrNameSelinux, []byte(label), 0); err != nil {
+	if err := unix.Lsetxattr(fpath, xattrNameSelinux, []byte(label), 0); err != nil {
 		return errors.Wrapf(err, "failed to set file label on %s", fpath)
 	}
 	return nil
@@ -390,7 +406,7 @@ func attrPath(attr string) string {
 		return path.Join(threadSelfPrefix, attr)
 	}
 
-	return path.Join("/proc/self/task/", strconv.Itoa(syscall.Gettid()), "/attr/", attr)
+	return path.Join("/proc/self/task/", strconv.Itoa(unix.Gettid()), "/attr/", attr)
 }
 
 func readAttr(attr string) (string, error) {
@@ -408,6 +424,18 @@ can be used to see if two contexts are equivalent
 */
 func CanonicalizeContext(val string) (string, error) {
 	return readWriteCon(filepath.Join(getSelinuxMountPoint(), "context"), val)
+}
+
+/*
+ComputeCreateContext requests the type transition from source to target for class  from the kernel.
+*/
+func ComputeCreateContext(source string, target string, class string) (string, error) {
+	classidx, err := ClassIndex(class)
+	if err != nil {
+		return "", err
+	}
+
+	return readWriteCon(filepath.Join(getSelinuxMountPoint(), "create"), fmt.Sprintf("%s %s %d", source, target, classidx))
 }
 
 func readWriteCon(fpath string, val string) (string, error) {
@@ -461,17 +489,17 @@ func SocketLabel() (string, error) {
 
 // PeerLabel retrieves the label of the client on the other side of a socket
 func PeerLabel(fd uintptr) (string, error) {
-	return unix.GetsockoptString(int(fd), syscall.SOL_SOCKET, syscall.SO_PEERSEC)
+	return unix.GetsockoptString(int(fd), unix.SOL_SOCKET, unix.SO_PEERSEC)
 }
 
 // SetKeyLabel takes a process label and tells the kernel to assign the
 // label to the next kernel keyring that gets created
 func SetKeyLabel(label string) error {
 	err := writeCon("/proc/self/attr/keycreate", label)
-	if os.IsNotExist(err) {
+	if os.IsNotExist(errors.Cause(err)) {
 		return nil
 	}
-	if label == "" && os.IsPermission(err) {
+	if label == "" && os.IsPermission(errors.Cause(err)) {
 		return nil
 	}
 	return err
@@ -772,14 +800,14 @@ func badPrefix(fpath string) error {
 	badPrefixes := []string{"/usr"}
 	for _, prefix := range badPrefixes {
 		if strings.HasPrefix(fpath, prefix) {
-			return fmt.Errorf("relabeling content in %s is not allowed", prefix)
+			return errors.Errorf("relabeling content in %s is not allowed", prefix)
 		}
 	}
 	return nil
 }
 
-// Chcon changes the `fpath` file object to the SELinux label `label`.
-// If `fpath` is a directory and `recurse`` is true, Chcon will walk the
+// Chcon changes the fpath file object to the SELinux label label.
+// If fpath is a directory and recurse is true, Chcon will walk the
 // directory tree setting the label.
 func Chcon(fpath string, label string, recurse bool) error {
 	if fpath == "" {
@@ -791,19 +819,19 @@ func Chcon(fpath string, label string, recurse bool) error {
 	if err := badPrefix(fpath); err != nil {
 		return err
 	}
-	callback := func(p string, info os.FileInfo, err error) error {
+
+	if !recurse {
+		return SetFileLabel(fpath, label)
+	}
+
+	return pwalk.Walk(fpath, func(p string, info os.FileInfo, err error) error {
 		e := SetFileLabel(p, label)
-		if os.IsNotExist(e) {
+		// Walk a file tree can race with removal, so ignore ENOENT
+		if os.IsNotExist(errors.Cause(e)) {
 			return nil
 		}
 		return e
-	}
-
-	if recurse {
-		return filepath.Walk(fpath, callback)
-	}
-
-	return SetFileLabel(fpath, label)
+	})
 }
 
 // DupSecOpt takes an SELinux process label and returns security options that

--- a/vendor/github.com/opencontainers/selinux/go-selinux/selinux_stub.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/selinux_stub.go
@@ -1,4 +1,4 @@
-// +build !selinux
+// +build !selinux !linux
 
 package selinux
 
@@ -33,6 +33,11 @@ func SetDisabled() {
 // GetEnabled returns whether selinux is currently enabled.
 func GetEnabled() bool {
 	return false
+}
+
+// ClassIndex returns the int index for an object class in the loaded policy, or -1 and an error
+func ClassIndex(class string) (int, error) {
+	return -1, nil
 }
 
 // SetFileLabel sets the SELinux label for this path or returns an error.
@@ -85,6 +90,13 @@ the function then returns the context that the kernel will use.  This function
 can be used to see if two contexts are equivalent
 */
 func CanonicalizeContext(val string) (string, error) {
+	return "", nil
+}
+
+/*
+ComputeCreateContext requests the type transition from source to target for class  from the kernel.
+*/
+func ComputeCreateContext(source string, target string, class string) (string, error) {
 	return "", nil
 }
 

--- a/vendor/github.com/opencontainers/selinux/go-selinux/xattrs.go
+++ b/vendor/github.com/opencontainers/selinux/go-selinux/xattrs.go
@@ -12,8 +12,8 @@ func lgetxattr(path string, attr string) ([]byte, error) {
 	// Start with a 128 length byte array
 	dest := make([]byte, 128)
 	sz, errno := unix.Lgetxattr(path, attr, dest)
-	if errno == unix.ERANGE {
-		// Buffer too small, get the real size first
+	for errno == unix.ERANGE {
+		// Buffer too small, use zero-sized buffer to get the actual size
 		sz, errno = unix.Lgetxattr(path, attr, []byte{})
 		if errno != nil {
 			return nil, errno
@@ -27,8 +27,4 @@ func lgetxattr(path string, attr string) ([]byte, error) {
 	}
 
 	return dest[:sz], nil
-}
-
-func lsetxattr(path string, attr string, data []byte, flags int) error {
-	return unix.Lsetxattr(path, attr, data, flags)
 }

--- a/vendor/github.com/opencontainers/selinux/pkg/pwalk/README.md
+++ b/vendor/github.com/opencontainers/selinux/pkg/pwalk/README.md
@@ -1,0 +1,42 @@
+## pwalk: parallel implementation of filepath.Walk
+
+This is a wrapper for [filepath.Walk](https://pkg.go.dev/path/filepath?tab=doc#Walk)
+which may speed it up by calling multiple callback functions (WalkFunc) in parallel,
+utilizing goroutines.
+
+By default, it utilizes 2\*runtime.NumCPU() goroutines for callbacks.
+This can be changed by using WalkN function which has the additional
+parameter, specifying the number of goroutines (concurrency).
+
+### Caveats
+
+Please note the following limitations of this code:
+
+* Unlike filepath.Walk, the order of calls is non-deterministic;
+
+* Only primitive error handling is supported:
+
+  * filepath.SkipDir is not supported;
+
+  * no errors are ever passed to WalkFunc;
+
+  * once any error is returned from any WalkFunc instance, no more new calls
+    to WalkFunc are made, and the error is returned to the caller of Walk;
+
+  * if more than one walkFunc instance will return an error, only one
+    of such errors will be propagated and returned by Walk, others
+    will be silently discarded.
+
+### Documentation
+
+For the official documentation, see
+https://pkg.go.dev/github.com/opencontainers/selinux/pkg/pwalk?tab=doc
+
+### Benchmarks
+
+For a WalkFunc that consists solely of the return statement, this
+implementation is about 10% slower than the standard library's
+filepath.Walk.
+
+Otherwise (if a WalkFunc is doing something) this is usually faster,
+except when the WalkN(..., 1) is used.

--- a/vendor/github.com/opencontainers/selinux/pkg/pwalk/pwalk.go
+++ b/vendor/github.com/opencontainers/selinux/pkg/pwalk/pwalk.go
@@ -1,0 +1,99 @@
+package pwalk
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"sync"
+
+	"github.com/pkg/errors"
+)
+
+type WalkFunc = filepath.WalkFunc
+
+// Walk is a wrapper for filepath.Walk which can call multiple walkFn
+// in parallel, allowing to handle each item concurrently. A maximum of
+// twice the runtime.NumCPU() walkFn will be called at any one time.
+// If you want to change the maximum, use WalkN instead.
+//
+// The order of calls is non-deterministic.
+//
+// Note that this implementation only supports primitive error handling:
+//
+// * no errors are ever passed to WalkFn
+//
+// * once a walkFn returns any error, all further processing stops
+//   and the error is returned to the caller of Walk;
+//
+// * filepath.SkipDir is not supported;
+//
+// * if more than one walkFn instance will return an error, only one
+//   of such errors will be propagated and returned by Walk, others
+//   will be silently discarded.
+//
+func Walk(root string, walkFn WalkFunc) error {
+	return WalkN(root, walkFn, runtime.NumCPU()*2)
+}
+
+// WalkN is a wrapper for filepath.Walk which can call multiple walkFn
+// in parallel, allowing to handle each item concurrently. A maximum of
+// num walkFn will be called at any one time.
+func WalkN(root string, walkFn WalkFunc, num int) error {
+	// make sure limit is sensible
+	if num < 1 {
+		return errors.Errorf("walk(%q): num must be > 0", root)
+	}
+
+	files := make(chan *walkArgs, 2*num)
+	errCh := make(chan error, 1) // get the first error, ignore others
+
+	// Start walking a tree asap
+	var err error
+	go func() {
+		err = filepath.Walk(root, func(p string, info os.FileInfo, err error) error {
+			if err != nil {
+				close(files)
+				return err
+			}
+			// add a file to the queue unless a callback sent an error
+			select {
+			case e := <-errCh:
+				close(files)
+				return e
+			default:
+				files <- &walkArgs{path: p, info: &info}
+				return nil
+			}
+		})
+		if err == nil {
+			close(files)
+		}
+	}()
+
+	var wg sync.WaitGroup
+	wg.Add(num)
+	for i := 0; i < num; i++ {
+		go func() {
+			for file := range files {
+				if e := walkFn(file.path, *file.info, nil); e != nil {
+					select {
+					case errCh <- e: // sent ok
+					default: // buffer full
+					}
+				}
+			}
+			wg.Done()
+		}()
+	}
+
+	wg.Wait()
+
+	return err
+}
+
+// walkArgs holds the arguments that were passed to the Walk or WalkLimit
+// functions.
+type walkArgs struct {
+	path string
+	info *os.FileInfo
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -62,9 +62,10 @@ github.com/opencontainers/go-digest
 # github.com/opencontainers/runc v1.0.0-rc9
 github.com/opencontainers/runc/libcontainer/system
 github.com/opencontainers/runc/libcontainer/user
-# github.com/opencontainers/selinux v1.3.3
+# github.com/opencontainers/selinux v1.4.0
 github.com/opencontainers/selinux/go-selinux
 github.com/opencontainers/selinux/go-selinux/label
+github.com/opencontainers/selinux/pkg/pwalk
 # github.com/pkg/errors v0.9.1
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0


### PR DESCRIPTION
This makes use of `pwalk.Walk()` (introduced in https://github.com/opencontainers/selinux/pull/89)
for recursive `Chown`, and also optimizes `drivers/platformLChown()` a bit, following the discussion at https://github.com/containers/storage/pull/216/commits/2df72f37c652520d994c4aa42d1ec583ef6ceaaa#r387867583

TODO:
 - [ ] benchmarks

@rhatdan @giuseppe PTAL