### PR TITLE
Make mount.Mounted() capable of handling files

### DIFF
--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -1,6 +1,7 @@
 package mount
 
 import (
+	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -56,10 +57,17 @@ func Mounted(mountpoint string) (bool, error) {
 		return false, err
 	}
 
-	mountpoint, err = fileutils.ReadSymlinkedDirectory(mountpoint)
+	info, err := os.Stat(mountpoint)
 	if err != nil {
 		return false, err
 	}
+	if info.IsDir() {
+		mountpoint, err = fileutils.ReadSymlinkedDirectory(mountpoint)
+		if err != nil {
+			return false, err
+		}
+	}
+
 	// Search the table for the mountpoint
 	for _, e := range entries {
 		if e.Mountpoint == mountpoint {


### PR DESCRIPTION
The function `fileutils.ReadSymlinkedDirectory` makes `mount.Mounted()`
fail if the mount is a file. We now only check that if the mount is a
directory to allow handling files in `mount.Mounted()`.