### PR TITLE
config: honor XDG_CONFIG_HOME

### DIFF
--- a/docs/containers-storage.conf.5.md
+++ b/docs/containers-storage.conf.5.md
@@ -212,7 +212,7 @@ Now all new content created in these directories will automatically be created w
 
 ## FILES
 
-Distributions often provide a `/usr/share/containers/storage.conf` file to define default storage configuration. Administrators can override this file by creating `/etc/containers/storage.conf` to specify their own configuration. The storage.conf file for rootless users is stored in the `$HOME/.config/containers/storage.conf` file.
+Distributions often provide a `/usr/share/containers/storage.conf` file to define default storage configuration. Administrators can override this file by creating `/etc/containers/storage.conf` to specify their own configuration. The storage.conf file for rootless users is stored in the `$XDG_CONFIG_HOME/containers/storage.conf` file.  If `$XDG_CONFIG_HOME` is not set then the file `$HOME/.config/containers/storage.conf` is used.
 
 ## HISTORY
 May 2017, Originally compiled by Dan Walsh <dwalsh@redhat.com>

--- a/store.go
+++ b/store.go
@@ -3308,6 +3308,9 @@ const defaultConfigFile = "/etc/containers/storage.conf"
 // DefaultConfigFile returns the path to the storage config file used
 func DefaultConfigFile(rootless bool) (string, error) {
 	if rootless {
+		if configHome := os.Getenv("XDG_CONFIG_HOME"); configHome != "" {
+			return filepath.Join(configHome, "containers/storage.conf"), nil
+		}
 		home := homedir.Get()
 		if home == "" {
 			return "", errors.New("cannot determine user's homedir")


### PR DESCRIPTION
when the env variable is set, use its value for locating the user
configuration file.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>