### PR TITLE
mount.Mounted: normalize mountpoints

### DIFF
--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -1,7 +1,6 @@
 package mount
 
 import (
-	"os"
 	"sort"
 	"strconv"
 	"strings"
@@ -57,15 +56,9 @@ func Mounted(mountpoint string) (bool, error) {
 		return false, err
 	}
 
-	info, err := os.Stat(mountpoint)
+	mountpoint, err = fileutils.ReadSymlinkedPath(mountpoint)
 	if err != nil {
 		return false, err
-	}
-	if info.IsDir() {
-		mountpoint, err = fileutils.ReadSymlinkedDirectory(mountpoint)
-		if err != nil {
-			return false, err
-		}
 	}
 
 	// Search the table for the mountpoint


### PR DESCRIPTION
Commit 90513cbb96a7 introduced a regression as specified mountpoints
must be normalized (e.g., "" -> "/") before we can deal with them.
Instead of working around the fileutils package and special casing
files, add a new `fileutils.ReadSymlinkedPath` which can work with
directories and files.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>