### PR TITLE
Use temp instead of run as fallback directory for rootless mode

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"os/exec"
 	"os/user"
@@ -82,31 +83,92 @@ func GetRootlessRuntimeDir(rootlessUID int) (string, error) {
 	return path, nil
 }
 
-func getRootlessRuntimeDir(rootlessUID int) (string, error) {
-	runtimeDir, err := homedir.GetRuntimeDir()
+type rootlessRuntimeDirEnvironment interface {
+	getProcCommandFile() string
+	getRunUserDir() string
+	getTmpPerUserDir() string
+
+	homeDirGetRuntimeDir() (string, error)
+	systemLstat(string) (*system.StatT, error)
+	homedirGet() string
+}
+
+type rootlessRuntimeDirEnvironmentImplementation struct {
+	procCommandFile string
+	runUserDir      string
+	tmpPerUserDir   string
+}
+
+func (env rootlessRuntimeDirEnvironmentImplementation) getProcCommandFile() string {
+	return env.procCommandFile
+}
+func (env rootlessRuntimeDirEnvironmentImplementation) getRunUserDir() string {
+	return env.runUserDir
+}
+func (env rootlessRuntimeDirEnvironmentImplementation) getTmpPerUserDir() string {
+	return env.tmpPerUserDir
+}
+func (rootlessRuntimeDirEnvironmentImplementation) homeDirGetRuntimeDir() (string, error) {
+	return homedir.GetRuntimeDir()
+}
+func (rootlessRuntimeDirEnvironmentImplementation) systemLstat(path string) (*system.StatT, error) {
+	return system.Lstat(path)
+}
+func (rootlessRuntimeDirEnvironmentImplementation) homedirGet() string {
+	return homedir.Get()
+}
+
+func isRootlessRuntimeDirOwner(dir string, env rootlessRuntimeDirEnvironment) bool {
+	st, err := env.systemLstat(dir)
+	return err == nil && int(st.UID()) == os.Getuid() && st.Mode()&0700 == 0700 && st.Mode()&0066 == 0000
+}
+
+// getRootlessRuntimeDirIsolated is an internal implementation detail of getRootlessRuntimeDir to allow testing.
+// Everyone but the tests this is intended for should only call getRootlessRuntimeDir, never this function.
+func getRootlessRuntimeDirIsolated(env rootlessRuntimeDirEnvironment) (string, error) {
+	runtimeDir, err := env.homeDirGetRuntimeDir()
 	if err == nil {
 		return runtimeDir, nil
 	}
-	tmpDir := fmt.Sprintf("/run/user/%d", rootlessUID)
-	st, err := system.Stat(tmpDir)
-	if err == nil && int(st.UID()) == os.Getuid() && st.Mode()&0700 == 0700 && st.Mode()&0066 == 0000 {
-		return tmpDir, nil
+
+	initCommand, err := ioutil.ReadFile(env.getProcCommandFile())
+	if err != nil || string(initCommand) == "systemd" {
+		runUserDir := env.getRunUserDir()
+		if isRootlessRuntimeDirOwner(runUserDir, env) {
+			return runUserDir, nil
+		}
 	}
-	tmpDir = fmt.Sprintf("%s/%d", os.TempDir(), rootlessUID)
-	if err := os.MkdirAll(tmpDir, 0700); err != nil {
-		logrus.Errorf("failed to create %s: %v", tmpDir, err)
-	} else {
-		return tmpDir, nil
+
+	tmpPerUserDir := env.getTmpPerUserDir()
+	if _, err := env.systemLstat(tmpPerUserDir); os.IsNotExist(err) {
+		if err := os.Mkdir(tmpPerUserDir, 0700); err != nil {
+			logrus.Errorf("failed to create temp directory for user: %v", err)
+		} else {
+			return tmpPerUserDir, nil
+		}
+	} else if isRootlessRuntimeDirOwner(tmpPerUserDir, env) {
+		return tmpPerUserDir, nil
 	}
-	home := homedir.Get()
-	if home == "" {
-		return "", errors.Wrapf(err, "neither XDG_RUNTIME_DIR nor HOME was set non-empty")
+
+	homeDir := env.homedirGet()
+	if homeDir == "" {
+		return "", errors.New("neither XDG_RUNTIME_DIR not temp dir nor HOME was set non-empty")
 	}
-	resolvedHome, err := filepath.EvalSymlinks(home)
+	resolvedHomeDir, err := filepath.EvalSymlinks(homeDir)
 	if err != nil {
-		return "", errors.Wrapf(err, "cannot resolve %s", home)
+		return "", errors.Wrapf(err, "cannot resolve %s", homeDir)
 	}
-	return filepath.Join(resolvedHome, "rundir"), nil
+	return filepath.Join(resolvedHomeDir, "rundir"), nil
+}
+
+func getRootlessRuntimeDir(rootlessUID int) (string, error) {
+	return getRootlessRuntimeDirIsolated(
+		rootlessRuntimeDirEnvironmentImplementation{
+			"/proc/1/comm",
+			fmt.Sprintf("/run/user/%d", rootlessUID),
+			fmt.Sprintf("%s/containers-user-%d", os.TempDir(), rootlessUID),
+		},
+	)
 }
 
 // getRootlessDirInfo returns the parent path of where the storage for containers and

--- a/utils_test.go
+++ b/utils_test.go
@@ -1,8 +1,14 @@
 package storage
 
 import (
+	"errors"
+	"io/ioutil"
+	"os"
+	"path/filepath"
 	"testing"
 
+	"github.com/containers/storage/pkg/homedir"
+	"github.com/containers/storage/pkg/system"
 	"gotest.tools/assert"
 )
 
@@ -41,4 +47,251 @@ func TestValidStoragePathFormat(t *testing.T) {
 		err := validRootlessStoragePathFormat(path)
 		assert.NilError(t, err)
 	}
+}
+
+type homeRuntimeData struct {
+	dir   string
+	error error
+}
+
+type rootlessRuntimeDirEnvironmentTest struct {
+	homeRuntime     homeRuntimeData
+	procCommandFile string
+	runUserDir      string
+	tmpPerUserDir   string
+	homeDir         string
+	result          string
+}
+
+func (env rootlessRuntimeDirEnvironmentTest) getProcCommandFile() string {
+	return env.procCommandFile
+}
+func (env rootlessRuntimeDirEnvironmentTest) getRunUserDir() string {
+	return env.runUserDir
+}
+func (env rootlessRuntimeDirEnvironmentTest) getTmpPerUserDir() string {
+	return env.tmpPerUserDir
+}
+func (env rootlessRuntimeDirEnvironmentTest) homeDirGetRuntimeDir() (string, error) {
+	return env.homeRuntime.dir, env.homeRuntime.error
+}
+func (env rootlessRuntimeDirEnvironmentTest) systemLstat(path string) (*system.StatT, error) {
+	return system.Lstat(path)
+}
+func (env rootlessRuntimeDirEnvironmentTest) homedirGet() string {
+	return env.homeDir
+}
+
+func TestRootlessRuntimeDir(t *testing.T) {
+	testDir, err := ioutil.TempDir("", "rootless-runtime-dir-test")
+	assert.NilError(t, err)
+	defer os.Remove(testDir)
+
+	homeRuntimeDir := filepath.Join(testDir, "home-rundir")
+	err = os.Mkdir(homeRuntimeDir, 0700)
+	assert.NilError(t, err)
+
+	homeRuntimeDisabled := homeRuntimeData{error: errors.New("homedirGetRuntimeDir is disabled")}
+
+	systemdCommandFile := filepath.Join(testDir, "systemd-command")
+	err = ioutil.WriteFile(systemdCommandFile, []byte("systemd"), 0644)
+	assert.NilError(t, err)
+
+	initCommandFile := filepath.Join(testDir, "init-command")
+	err = ioutil.WriteFile(initCommandFile, []byte("init"), 0644)
+	assert.NilError(t, err)
+
+	dirForOwner := filepath.Join(testDir, "dir-for-owner")
+	err = os.Mkdir(dirForOwner, 0700)
+	assert.NilError(t, err)
+
+	dirForAll := filepath.Join(testDir, "dir-for-all")
+	err = os.Mkdir(dirForAll, 0777)
+	assert.NilError(t, err)
+
+	dirToBeCreated := filepath.Join(testDir, "dir-to-be-created")
+
+	envs := []rootlessRuntimeDirEnvironmentTest{
+		{
+			homeRuntime: homeRuntimeData{dir: homeRuntimeDir},
+			result:      homeRuntimeDir,
+		},
+
+		// Reading proc command file fails
+		{
+			homeRuntime:     homeRuntimeDisabled,
+			procCommandFile: "",
+			runUserDir:      dirForOwner,
+			result:          dirForOwner,
+		},
+		{
+			homeRuntime:     homeRuntimeDisabled,
+			procCommandFile: "",
+			runUserDir:      "", // Accessing run user dir fails
+			tmpPerUserDir:   dirForOwner,
+			result:          dirForOwner,
+		},
+		{
+			homeRuntime:     homeRuntimeDisabled,
+			procCommandFile: "",
+			runUserDir:      dirForAll,
+			tmpPerUserDir:   dirForOwner,
+			result:          dirForOwner,
+		},
+		{
+			homeRuntime:     homeRuntimeDisabled,
+			procCommandFile: "",
+			runUserDir:      "", // Accessing run user dir fails
+			tmpPerUserDir:   dirToBeCreated,
+			result:          dirToBeCreated,
+		},
+		{
+			homeRuntime:     homeRuntimeDisabled,
+			procCommandFile: "",
+			runUserDir:      "", // Accessing run user dir fails
+			tmpPerUserDir:   "", // Accessing tmp per user dir fails
+			homeDir:         dirForOwner,
+			result:          filepath.Join(dirForOwner, "rundir"),
+		},
+		{
+			homeRuntime:     homeRuntimeDisabled,
+			procCommandFile: "",
+			runUserDir:      "", // Accessing run user dir fails
+			tmpPerUserDir:   dirForAll,
+			homeDir:         dirForOwner,
+			result:          filepath.Join(dirForOwner, "rundir"),
+		},
+
+		// systemd
+		{
+			homeRuntime:     homeRuntimeDisabled,
+			procCommandFile: systemdCommandFile,
+			runUserDir:      dirForOwner,
+			result:          dirForOwner,
+		},
+		{
+			homeRuntime:     homeRuntimeDisabled,
+			procCommandFile: systemdCommandFile,
+			runUserDir:      "", // Accessing run user dir fails
+			tmpPerUserDir:   dirForOwner,
+			result:          dirForOwner,
+		},
+		{
+			homeRuntime:     homeRuntimeDisabled,
+			procCommandFile: systemdCommandFile,
+			runUserDir:      dirForAll,
+			tmpPerUserDir:   dirForOwner,
+			result:          dirForOwner,
+		},
+		{
+			homeRuntime:     homeRuntimeDisabled,
+			procCommandFile: systemdCommandFile,
+			runUserDir:      "", // Accessing run user dir fails
+			tmpPerUserDir:   dirToBeCreated,
+			result:          dirToBeCreated,
+		},
+		{
+			homeRuntime:     homeRuntimeDisabled,
+			procCommandFile: systemdCommandFile,
+			runUserDir:      "", // Accessing run user dir fails
+			tmpPerUserDir:   "", // Accessing tmp per user dir fails
+			homeDir:         dirForOwner,
+			result:          filepath.Join(dirForOwner, "rundir"),
+		},
+		{
+			homeRuntime:     homeRuntimeDisabled,
+			procCommandFile: systemdCommandFile,
+			runUserDir:      "", // Accessing run user dir fails
+			tmpPerUserDir:   dirForAll,
+			homeDir:         dirForOwner,
+			result:          filepath.Join(dirForOwner, "rundir"),
+		},
+
+		// init
+		{
+			homeRuntime:     homeRuntimeDisabled,
+			procCommandFile: initCommandFile,
+			tmpPerUserDir:   dirForOwner,
+			result:          dirForOwner,
+		},
+		{
+			homeRuntime:     homeRuntimeDisabled,
+			procCommandFile: initCommandFile,
+			tmpPerUserDir:   dirToBeCreated,
+			result:          dirToBeCreated,
+		},
+		{
+			homeRuntime:     homeRuntimeDisabled,
+			procCommandFile: initCommandFile,
+			tmpPerUserDir:   "", // Accessing tmp per user dir fails
+			homeDir:         dirForOwner,
+			result:          filepath.Join(dirForOwner, "rundir"),
+		},
+		{
+			homeRuntime:     homeRuntimeDisabled,
+			procCommandFile: initCommandFile,
+			tmpPerUserDir:   dirForAll,
+			homeDir:         dirForOwner,
+			result:          filepath.Join(dirForOwner, "rundir"),
+		},
+	}
+
+	for _, env := range envs {
+		os.Remove(dirToBeCreated)
+
+		resultDir, err := getRootlessRuntimeDirIsolated(env)
+		assert.NilError(t, err)
+		assert.Assert(t, resultDir == env.result)
+	}
+}
+
+type rootlessRuntimeDirEnvironmentRace struct {
+	procCommandFile string
+	tmpPerUserDir   string
+}
+
+func (env rootlessRuntimeDirEnvironmentRace) getProcCommandFile() string {
+	return env.procCommandFile
+}
+func (rootlessRuntimeDirEnvironmentRace) getRunUserDir() string {
+	return ""
+}
+func (env rootlessRuntimeDirEnvironmentRace) getTmpPerUserDir() string {
+	return env.tmpPerUserDir
+}
+func (rootlessRuntimeDirEnvironmentRace) homeDirGetRuntimeDir() (string, error) {
+	return "", errors.New("homedirGetRuntimeDir is disabled")
+}
+func (env rootlessRuntimeDirEnvironmentRace) systemLstat(path string) (*system.StatT, error) {
+	if path == env.tmpPerUserDir {
+		st, err := system.Lstat(path)
+		// We can simulate that race directory was created immediately after system.Lstat call.
+		if err := os.Mkdir(path, 0700); err != nil {
+			return nil, err
+		}
+		return st, err
+	}
+	return system.Lstat(path)
+}
+func (rootlessRuntimeDirEnvironmentRace) homedirGet() string {
+	return homedir.Get()
+}
+
+func TestRootlessRuntimeDirRace(t *testing.T) {
+	raceDir, err := ioutil.TempDir("", "rootless-runtime-dir-race-test")
+	assert.NilError(t, err)
+	defer os.Remove(raceDir)
+
+	procCommandFile := filepath.Join(raceDir, "command")
+	err = ioutil.WriteFile(procCommandFile, []byte("init"), 0644)
+	assert.NilError(t, err)
+
+	tmpPerUserDir := filepath.Join(raceDir, "tmp")
+
+	resultDir, err := getRootlessRuntimeDirIsolated(rootlessRuntimeDirEnvironmentRace{
+		procCommandFile,
+		tmpPerUserDir,
+	})
+	assert.NilError(t, err)
+	assert.Assert(t, resultDir != tmpPerUserDir, "Rootless runtime dir shouldn't follow race dir.")
 }


### PR DESCRIPTION
[`XDG_*` directories](https://github.com/moby/moby/issues/40708) will be a big question. But please do not use `/run/user` as fallback directory, use something like `/tmp/storage-user` instead.