### PR TITLE
Fix CGo builds on non-Linux

### DIFF
--- a/pkg/unshare/unshare.c
+++ b/pkg/unshare/unshare.c
@@ -1,3 +1,5 @@
+#ifndef UNSHARE_NO_CODE_AT_ALL
+
 #define _GNU_SOURCE
 #include <sys/types.h>
 #include <sys/ioctl.h>
@@ -285,3 +287,5 @@ void _containers_unshare(void)
 	}
 	return;
 }
+
+#endif // !UNSHARE_NO_CODE_AT_ALL

--- a/pkg/unshare/unshare_unsupported_cgo.go
+++ b/pkg/unshare/unshare_unsupported_cgo.go
@@ -1,0 +1,10 @@
+// +build !linux,cgo
+
+package unshare
+
+// Go refuses to compile a subpackage with CGO_ENABLED=1 if there is a *.c file but no 'import "C"'.
+// OTOH if we did have an 'import "C"', the Linux-only code would fail to compile.
+// So, satisfy the Go compiler by using import "C" but #ifdef-ing out all of the code.
+
+// #cgo CPPFLAGS: -DUNSHARE_NO_CODE_AT_ALL
+import "C"


### PR DESCRIPTION
Go refuses to compile a subpackage with `CGO_ENABLED=1` if there is a `*.c` file but no `import "C"`.  OTOH if we did have an `import "C"`, the Linux-only code would fail to compile.

So, satisfy the Go compiler by using `import "C"` but `#ifdef`-ing out all of the code.
