### PR TITLE
Run bats jobs in parallel

### DIFF
--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -71,10 +71,10 @@ LONG_APTGET="timeout_attempt_delay_command 300s 5 60s $SUDOAPTGET"
 
 # Packaging adjustments needed to:
 # https://github.com/containers/libpod/blob/master/contrib/cirrus/packer/fedora_setup.sh
-RPMS_REQUIRED="autoconf automake"
+RPMS_REQUIRED="autoconf automake parallel"
 RPMS_CONFLICTING="gcc-go"
 # https://github.com/containers/libpod/blob/master/contrib/cirrus/packer/ubuntu_setup.sh
-DEBS_REQUIRED=""
+DEBS_REQUIRED="parallel"
 DEBS_CONFLICTING=""
 
 # For devicemapper testing, device names need to be passed down for use in tests
@@ -183,6 +183,14 @@ install_fuse_overlayfs_from_git(){
     ooe.sh make
     sudo make install prefix=/usr
     cd $wd
+}
+
+install_bats_from_git(){
+    git clone https://github.com/bats-core/bats-core --depth=1
+    sudo ./bats-core/install.sh /usr
+    rm -rf bats-core
+    mkdir -p ~/.parallel
+    touch ~/.parallel/will-cite
 }
 
 showrun() {

--- a/contrib/cirrus/setup.sh
+++ b/contrib/cirrus/setup.sh
@@ -41,3 +41,4 @@ case "$OS_RELEASE_ID" in
 esac
 
 install_fuse_overlayfs_from_git
+install_bats_from_git

--- a/tests/test_runner.bash
+++ b/tests/test_runner.bash
@@ -14,5 +14,7 @@ function execute() {
 # Tests to run. Defaults to all.
 TESTS=${@:-.}
 
+export JOBS=${JOBS:-$(($(nproc --all) * 4))}
+
 # Run the tests.
-execute time bats --tap $TESTS
+execute time bats --jobs "$JOBS" --tap $TESTS


### PR DESCRIPTION
We now run the bats jobs in parallel to have a faster test output.