### PR TITLE
Add docs about when locks can panic

### DIFF
--- a/pkg/lockfile/lockfile.go
+++ b/pkg/lockfile/lockfile.go
@@ -13,6 +13,9 @@ import (
 // by the lock.
 type Locker interface {
 	// Acquire a writer lock.
+	// The default unix implementation panics if:
+	// - opening the lockfile failed
+	// - tried to lock a read-only lock-file
 	Lock()
 
 	// Acquire a writer lock recursively, allowing for recursive acquisitions
@@ -20,6 +23,9 @@ type Locker interface {
 	RecursiveLock()
 
 	// Unlock the lock.
+	// The default unix implementation panics if:
+	// - unlocking an unlocked lock
+	// - if the lock counter is corrupted
 	Unlock()
 
 	// Acquire a reader lock.


### PR DESCRIPTION
This partially fixes a CRI-O panic on container restore if the sandbox
could not restored successfully and CRI-O tries to remove the sandbox
afterwards. To not have the need to recover the panic in CRI-O (or
possible other consumers of this library) we should avoid panic'ing here
and stick to error handling.

Reproduce the panic with the latest CRI-O master:

```json
{
  "metadata": {
    "name": "nginx-sandbox",
    "namespace": "default",
    "attempt": 1,
    "uid": "hdishd83djaidwnduwk28bcsb"
  },
  "log_directory": "/tmp",
  "linux": {}
}
```

```
# Start CRI-O
> sudo ./bin/crio
> sudo crictl runp sandbox.json
# Stop CRI-O, start CRI-O again
panic: attempted to update last-writer in lockfile without the write lock

goroutine 86 [running]:
github.com/containers/storage/pkg/lockfile.(*lockfile).Touch(0xc0007149b0, 0xc0006e4000, 0x0)
        /home/sascha/go/src/github.com/cri-o/cri-o/vendor/github.com/containers/storage/pkg/lockfile/lockfile_unix.go:193 +0x235
github.com/containers/storage.(*containerStore).Touch(0xc00014af60, 0x3e, 0xc0005b4030)
        /home/sascha/go/src/github.com/cri-o/cri-o/vendor/github.com/containers/storage/containers.go:588 +0x33
github.com/containers/storage.(*containerStore).Save(0xc00014af60, 0x0, 0x0)
        /home/sascha/go/src/github.com/cri-o/cri-o/vendor/github.com/containers/storage/containers.go:228 +0x202
github.com/containers/storage.(*containerStore).Delete(0xc00014af60, 0xc00042e500, 0x39, 0x6d20746c75616665, 0x72662073746e756f)
        /home/sascha/go/src/github.com/cri-o/cri-o/vendor/github.com/containers/storage/containers.go:405 +0x26c
github.com/containers/storage.(*store).DeleteContainer.func2(0xc0000aaa80, 0x2220400, 0xc00014af60, 0xc00042e500, 0x39, 0xc00045c4e0)
        /home/sascha/go/src/github.com/cri-o/cri-o/vendor/github.com/containers/storage/store.go:2335 +0x49
created by github.com/containers/storage.(*store).DeleteContainer
        /home/sascha/go/src/github.com/cri-o/cri-o/vendor/github.com/containers/storage/store.go:2334 +0x540
```

cc @rhafer