### PR TITLE
internalDelete needs the r.byname id deletion

### DIFF
--- a/layers.go
+++ b/layers.go
@@ -992,6 +992,9 @@ func (r *layerStore) deleteInternal(id string) error {
 	if err == nil {
 		os.Remove(r.tspath(id))
 		delete(r.byid, id)
+		for _, name := range layer.Names {
+			delete(r.byname, name)
+		}
 		r.idindex.Delete(id)
 		mountLabel := layer.MountLabel
 		if layer.MountPoint != "" {


### PR DESCRIPTION
r.lookup references r.byid, r.byname, and r.idindex to lookup a layer. The resulting Delete() function call misses the `delete(r.byname, name)` causing crio to say a layer is in use, when it actually is not.