### PR TITLE
overlay: recreate workdir on UpdateLayerIDMap

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -1237,6 +1237,15 @@ func (d *Driver) UpdateLayerIDMap(id string, toContainer, toHost *idtools.IDMapp
 		i--
 	}
 
+	// We need to re-create the work directory as it might keep a reference
+	// to the old upper layer in the index.
+	workDir := filepath.Join(dir, "work")
+	if err := os.RemoveAll(workDir); err == nil {
+		if err := idtools.MkdirAs(workDir, 0755, rootUID, rootGID); err != nil {
+			return err
+		}
+	}
+
 	// Re-create the directory that we're going to use as the upper layer.
 	if err := idtools.MkdirAs(diffDir, 0755, rootUID, rootGID); err != nil {
 		return err


### PR DESCRIPTION
make sure the work dir is also recreated with the diff dir.

When using index=on, overlay records a reference to the upperdir inode
into work/index, and raises an error if on a successive mount there is
a mismatch between what is stored in the work/index xattr and the
upper dir inode.

Closes: https://github.com/containers/libpod/issues/5816

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>