### PR TITLE
fix bug, lost mountopts when read json from file

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -148,10 +148,20 @@ func (c *Container) ProcessLabel() string {
 }
 
 func (c *Container) MountOpts() []string {
-	if mountOpts, ok := c.Flags["MountOpts"].([]string); ok {
+	switch c.Flags["MountOpts"].(type) {
+	case []string:
+		return c.Flags["MountOpts"].([]string)
+	case []interface{}:
+		var mountOpts []string
+		for _, v := range c.Flags["MountOpts"].([]interface{}) {
+			if flag, ok := v.(string); ok {
+				mountOpts = append(mountOpts, flag)
+			}
+		}
 		return mountOpts
+	default:
+		return nil
 	}
-	return nil
 }
 
 func (r *containerStore) Containers() ([]Container, error) {


### PR DESCRIPTION
The type of container flag is map[string]interface{}.
json unmarshal from container.json will convert []string to []interface{}, thus MountOpts will be lost.
We should assert it in case lost MountOpts data