### PR TITLE
bugfix for store call layerStore's Load method

### DIFF
--- a/store.go
+++ b/store.go
@@ -2742,7 +2742,11 @@ func (s *store) Diff(from, to string, options *DiffOptions) (io.ReadCloser, erro
 	}
 	for _, s := range append([]ROLayerStore{lstore}, lstores...) {
 		store := s
-		store.RLock()
+		if store == lstore {
+			store.Lock()
+		} else {
+			store.RLock()
+		}
 		if modified, err := store.Modified(); modified || err != nil {
 			if err = store.Load(); err != nil {
 				return nil, err
@@ -3002,7 +3006,11 @@ func (s *store) Layer(id string) (*Layer, error) {
 	}
 	for _, s := range append([]ROLayerStore{lstore}, lstores...) {
 		store := s
-		store.RLock()
+		if store == lstore {
+			store.Lock()
+		} else {
+			store.RLock()
+		}
 		defer store.Unlock()
 		if modified, err := store.Modified(); modified || err != nil {
 			if err = store.Load(); err != nil {


### PR DESCRIPTION
When build images high concurrency, a lot of export may happen.
To read layers, many Diff() in store.go will call frequently, and
Layers() call also occur. These two method call layerStore.Load()
with a RLock. The Load() will rebuild all layers, this may change
this layerStore's state temporary until it completely done. What
makes it terrible is in store.Diff->layerStore.Diff->r.newFileGetter
will get a simpleGetCloser with Mount or Unmount a layer. When Unmout,
a true unmout may happen with a new layer which Load() method rebuild,
but not yet load mount info, it's MountCount and MountPoint is empty,
This can cause image export faild with 'no such file or directory' error

Signed-off-by: zvier <zvier6@163.com>