### PR TITLE
Add mountoptions to help figure out why mount failed

### DIFF
--- a/drivers/overlay/check.go
+++ b/drivers/overlay/check.go
@@ -145,7 +145,7 @@ func doesMetacopy(d, mountOpts string) (bool, error) {
 		opts = fmt.Sprintf("%s,%s", opts, data)
 	}
 	if err := unix.Mount("overlay", filepath.Join(td, "merged"), "overlay", uintptr(flags), opts); err != nil {
-		return false, errors.Wrap(err, "failed to mount overlay for metacopy check")
+		return false, errors.Wrapf(err, "failed to mount overlay for metacopy check with %q options", mountOpts)
 	}
 	defer func() {
 		if err := unix.Unmount(filepath.Join(td, "merged"), 0); err != nil {


### PR DESCRIPTION
Fuse-overlay now has an option fsync=0, which kernel overlay does
not support, when I changed from fuse-overlay, to regular with
the fsync=0 flag set, I had a hard time diagnosing what was going
wrong. This information would have helped.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>