### PR TITLE
unbreak build on mipsen

### DIFF
--- a/drivers/devmapper/deviceset.go
+++ b/drivers/devmapper/deviceset.go
@@ -1544,8 +1544,8 @@ func getDeviceMajorMinor(file *os.File) (uint64, uint64, error) {
 	}
 
 	dev := stat.Rdev
-	majorNum := major(dev)
-	minorNum := minor(dev)
+	majorNum := major(uint64(dev))
+	minorNum := minor(uint64(dev))
 
 	logrus.Debugf("devmapper: Major:Minor for device: %s is:%v:%v", file.Name(), majorNum, minorNum)
 	return majorNum, minorNum, nil


### PR DESCRIPTION
Stat_t on MIPS uses 32-bit fields for Dev and Rdev, so we need to cast these to uint64

Inpiration from https://github.com/moby/moby/pull/37490
Example build failure log: https://buildd.debian.org/status/fetch.php?pkg=golang-github-containers-storage&arch=mips64el&ver=1.15.8%2Bdfsg1-1&stamp=1580872314&raw=0