### PR TITLE
Add back skip_mount_home

### DIFF
--- a/docs/containers-storage.conf.5.md
+++ b/docs/containers-storage.conf.5.md
@@ -198,6 +198,9 @@ The `storage.options.zfs` table supports the following options:
 **mountopt**=""
   Comma separated list of default options to be used to mount container images.  Suggested value "nodev". Mount options are documented in the mount(8) man page.
 
+**skip_mount_home=""**
+  Tell storage drivers to not create a PRIVATE bind mount on their home directory.
+
 **size**=""
   Maximum size of a container image.   This flag can be used to set quota on the size of container images. (format: <number>[<unit>], where unit = b (bytes), k (kilobytes), m (megabytes), or g (gigabytes))
 

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -311,6 +311,9 @@ func parseOptions(options []string) (*overlayOptions, error) {
 				return nil, fmt.Errorf("overlay: can't stat program %s: %v", val, err)
 			}
 			o.mountProgram = val
+		case "overlay2.skip_mount_home", "overlay.skip_mount_home", ".skip_mount_home":
+			logrus.Debugf("overlay: skip_mount_home=%s", val)
+			o.skipMountHome, err = strconv.ParseBool(val)
 		case ".ignore_chown_errors", "overlay2.ignore_chown_errors", "overlay.ignore_chown_errors":
 			logrus.Debugf("overlay: ignore_chown_errors=%s", val)
 			o.ignoreChownErrors, err = strconv.ParseBool(val)

--- a/hack/git-validation.sh
+++ b/hack/git-validation.sh
@@ -8,6 +8,6 @@ if [ ! -x "$GIT_VALIDATION" ]; then
 fi
 if test "$TRAVIS" != true ; then
 	#GITVALIDATE_EPOCH=":/git-validation epoch"
-	GITVALIDATE_EPOCH="f835dce9c4fe435d0e7df797bacb0a8ee78e180a"
+	GITVALIDATE_EPOCH="0a7c48440c25ec26b4a710c03c957e665f4b2649"
 fi
 exec "$GIT_VALIDATION" -q -run DCO,short-subject ${GITVALIDATE_EPOCH:+-range "${GITVALIDATE_EPOCH}""..${GITVALIDATE_TIP:-@}"} ${GITVALIDATE_FLAGS}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,8 +2,6 @@ package config
 
 import (
 	"fmt"
-
-	"github.com/sirupsen/logrus"
 )
 
 // ThinpoolOptionsConfig represents the "storage.options.thinpool"
@@ -269,11 +267,11 @@ func GetGraphDriverOptions(driverName string, options OptionsConfig) []string {
 		} else if options.Size != "" {
 			doptions = append(doptions, fmt.Sprintf("%s.size=%s", driverName, options.Size))
 		}
-
-		if options.Overlay.SkipMountHome != "" || options.SkipMountHome != "" {
-			logrus.Warn("skip_mount_home option is no longer supported, ignoring option")
+		if options.Overlay.SkipMountHome != "" {
+			doptions = append(doptions, fmt.Sprintf("%s.skip_mount_home=%s", driverName, options.Overlay.SkipMountHome))
+		} else if options.SkipMountHome != "" {
+			doptions = append(doptions, fmt.Sprintf("%s.skip_mount_home=%s", driverName, options.SkipMountHome))
 		}
-
 	case "vfs":
 		if options.Vfs.IgnoreChownErrors != "" {
 			doptions = append(doptions, fmt.Sprintf("%s.ignore_chown_errors=%s", driverName, options.Vfs.IgnoreChownErrors))

--- a/pkg/config/config_test.go
+++ b/pkg/config/config_test.go
@@ -244,9 +244,26 @@ func TestOverlayOptions(t *testing.T) {
 	if !searchOptions(doptions, "mount_program=/usr/bin/fuse_overlay") {
 		t.Fatalf("Expected to find 'fuse_overlay' options, got %v", doptions)
 	}
+	options.Overlay.SkipMountHome = "true"
+	doptions = GetGraphDriverOptions("overlay", options)
+	if len(doptions) == 0 {
+		t.Fatalf("Expected 0 options, got %v", doptions)
+	}
+	if !searchOptions(doptions, "skip_mount_home") {
+		t.Fatalf("Expected to find 'skip_mount_home' options, got %v", doptions)
+	}
 
 	// Make sure legacy mountopt still works
 	options = OptionsConfig{}
+	options.SkipMountHome = "true"
+	doptions = GetGraphDriverOptions("overlay", options)
+	if len(doptions) == 0 {
+		t.Fatalf("Expected 0 options, got %v", doptions)
+	}
+	if !searchOptions(doptions, "skip_mount_home") {
+		t.Fatalf("Expected to find 'skip_mount_home' options, got %v", doptions)
+	}
+
 	options.Size = s200
 	doptions = GetGraphDriverOptions("overlay", options)
 	if len(doptions) == 0 {

--- a/storage.conf
+++ b/storage.conf
@@ -76,6 +76,9 @@ additionalimagestores = [
 # mountopt specifies comma separated list of extra mount options
 mountopt = "nodev"
 
+# Set to skip a PRIVATE bind mount on the storage home directory.
+# skip_mount_home = "false"
+
 # Size is used to set a maximum size of the container image.
 # size = ""
 

--- a/store.go
+++ b/store.go
@@ -3481,6 +3481,9 @@ func ReloadConfigurationFile(configFile string, storeOptions *StoreOptions) {
 	if config.Storage.Options.MountProgram != "" {
 		storeOptions.GraphDriverOptions = append(storeOptions.GraphDriverOptions, fmt.Sprintf("%s.mount_program=%s", config.Storage.Driver, config.Storage.Options.MountProgram))
 	}
+	if config.Storage.Options.SkipMountHome != "" {
+		storeOptions.GraphDriverOptions = append(storeOptions.GraphDriverOptions, fmt.Sprintf("%s.skip_mount_home=%s", config.Storage.Driver, config.Storage.Options.SkipMountHome))
+	}
 	if config.Storage.Options.IgnoreChownErrors != "" {
 		storeOptions.GraphDriverOptions = append(storeOptions.GraphDriverOptions, fmt.Sprintf("%s.ignore_chown_errors=%s", config.Storage.Driver, config.Storage.Options.IgnoreChownErrors))
 	}


### PR DESCRIPTION
Certain workloads, we would like to eliminate the mounting of containers-storage as private.
Running containers within containers for example.

This looks like it was accidently removed in the past, since there was still partial
implementation.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>