### PR TITLE
devmapper: increase LVM PV metadatasize

### DIFF
--- a/drivers/devmapper/device_setup.go
+++ b/drivers/devmapper/device_setup.go
@@ -206,7 +206,7 @@ func setupDirectLVM(cfg directLVMConfig) error {
 		cfg.ThinpMetaPercent = 1
 	}
 
-	out, err := exec.Command("pvcreate", "-f", cfg.Device).CombinedOutput()
+	out, err := exec.Command("pvcreate", "--metadatasize", "128M", "-f", cfg.Device).CombinedOutput()
 	if err != nil {
 		return errors.Wrap(err, string(out))
 	}


### PR DESCRIPTION
The default is ~1k and is not enough to store metadata about
hundreds of LVs. This bumps it to 128M.

128M was chosen in the context of relatively large hosts, so the exact value
could be up for discussion if people are using the devicemapper driver on
small hosts.

We have experienced metadata exhaustion in other contexts with many LVs,
so this change was a proactive measure to avoid problems with many containers and images.