### PR TITLE
Stop using golang 1.12

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -104,7 +104,7 @@ lint_task:
     env:
         CIRRUS_WORKING_DIR: "/go/src/github.com/containers/storage"
     container:
-        image: golang:1.12
+        image: golang:1.13
     modules_cache:
         fingerprint_script: cat go.sum
         folder: $GOPATH/pkg/mod
@@ -140,7 +140,7 @@ meta_task:
 
 vendor_task:
     container:
-        image: golang:1.13
+        image: golang:1.14
     modules_cache:
         fingerprint_script: cat go.sum
         folder: $GOPATH/pkg/mod


### PR DESCRIPTION
Move testing to 1.13 and 1.14

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>