### PR TITLE
Store the pvcreate --metadatasize option in storage.conf

### DIFF
--- a/docs/containers-storage.conf.5.md
+++ b/docs/containers-storage.conf.5.md
@@ -138,6 +138,9 @@ The `storage.options.thinpool` table supports the following options for the `dev
     6: LogLevelInfo
     7: LogLevelDebug
 
+**metadata_size**=""
+  metadata_size is used to set the `pvcreate --metadatasize` options when creating thin devices. (Default 128k)
+
 **min_free_space**=""
   Specifies the min free space percent in a thin pool required for new device creation to succeed. Valid values are from 0% - 99%. Value 0% disables. (default: 10%)
 

--- a/drivers/devmapper/device_setup.go
+++ b/drivers/devmapper/device_setup.go
@@ -23,6 +23,7 @@ type directLVMConfig struct {
 	ThinpMetaPercent    uint64
 	AutoExtendPercent   uint64
 	AutoExtendThreshold uint64
+	MetaDataSize        string
 }
 
 var (
@@ -209,8 +210,11 @@ func setupDirectLVM(cfg directLVMConfig) error {
 	if cfg.ThinpMetaPercent == 0 {
 		cfg.ThinpMetaPercent = 1
 	}
+	if cfg.MetaDataSize == "" {
+		cfg.MetaDataSize = "128k"
+	}
 
-	out, err := exec.Command("pvcreate", "-f", cfg.Device).CombinedOutput()
+	out, err := exec.Command("pvcreate", "--metadatasize", cfg.MetaDataSize, "-f", cfg.Device).CombinedOutput()
 	if err != nil {
 		return errors.Wrap(err, string(out))
 	}

--- a/drivers/devmapper/deviceset.go
+++ b/drivers/devmapper/deviceset.go
@@ -101,6 +101,7 @@ type DeviceSet struct {
 
 	// Options
 	dataLoopbackSize      int64
+	metaDataSize          string
 	metaDataLoopbackSize  int64
 	baseFsSize            uint64
 	filesystem            string
@@ -2708,6 +2709,8 @@ func NewDeviceSet(root string, doInit bool, options []string, uidMaps, gidMaps [
 			devices.mountOptions = joinMountOptions(devices.mountOptions, val)
 		case "dm.metadatadev":
 			devices.metadataDevice = val
+		case "dm.metadata_size":
+			devices.metaDataSize = val
 		case "dm.datadev":
 			devices.dataDevice = val
 		case "dm.thinpooldev":
@@ -2743,6 +2746,8 @@ func NewDeviceSet(root string, doInit bool, options []string, uidMaps, gidMaps [
 				return nil, err
 			}
 
+		case "dm.metaDataSize":
+			lvmSetupConfig.MetaDataSize = val
 		case "dm.min_free_space":
 			if !strings.HasSuffix(val, "%") {
 				return nil, fmt.Errorf("devmapper: Option dm.min_free_space requires %% suffix")

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -39,6 +39,10 @@ type ThinpoolOptionsConfig struct {
 	// log_level sets the log level of devicemapper.
 	LogLevel string `toml:"log_level"`
 
+	// MetadataSize specifies the size of the metadata for the thinpool
+	// It will be used with the `pvcreate --metadata` option.
+	MetadataSize string `toml:"metadatasize"`
+
 	// MinFreeSpace specifies the min free space percent in a thin pool
 	// require for new device creation to
 	MinFreeSpace string `toml:"min_free_space"`
@@ -217,6 +221,9 @@ func GetGraphDriverOptions(driverName string, options OptionsConfig) []string {
 		}
 		if options.Thinpool.LogLevel != "" {
 			doptions = append(doptions, fmt.Sprintf("dm.libdm_log_level=%s", options.Thinpool.LogLevel))
+		}
+		if options.Thinpool.MetadataSize != "" {
+			doptions = append(doptions, fmt.Sprintf("dm.metadata_size=%s", options.Thinpool.MetadataSize))
 		}
 		if options.Thinpool.MinFreeSpace != "" {
 			doptions = append(doptions, fmt.Sprintf("dm.min_free_space=%s", options.Thinpool.MinFreeSpace))

--- a/storage.conf
+++ b/storage.conf
@@ -132,6 +132,10 @@ mountopt = "nodev"
 # device.
 # mkfsarg = ""
 
+# metadata_size is used to set the `pvcreate --metadatasize` options when
+# creating thin devices. Default is 128k
+# metadata_size = ""
+
 # Size is used to set a maximum size of the container image.
 # size = ""
 


### PR DESCRIPTION
As the number of devices increase the size of the metadata
needs to be modified.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>