### PR TITLE
clean residual resources in layerStore when remove an image

### DIFF
--- a/layers.go
+++ b/layers.go
@@ -1013,6 +1013,7 @@ func (r *layerStore) deleteInternal(id string) error {
 		if layer.MountPoint != "" {
 			delete(r.bymount, layer.MountPoint)
 		}
+		r.deleteInDigestMap(id)
 		toDeleteIndex := -1
 		for i, candidate := range r.layers {
 			if candidate.ID == id {
@@ -1042,6 +1043,27 @@ func (r *layerStore) deleteInternal(id string) error {
 		}
 	}
 	return err
+}
+
+func (r *layerStore) deleteInDigestMap(id string) {
+	for digest, layers := range r.bycompressedsum {
+		for i, layerID := range layers {
+			if layerID == id {
+				layers = append(layers[:i], layers[i+1:]...)
+				r.bycompressedsum[digest] = layers
+				break
+			}
+		}
+	}
+	for digest, layers := range r.byuncompressedsum {
+		for i, layerID := range layers {
+			if layerID == id {
+				layers = append(layers[:i], layers[i+1:]...)
+				r.byuncompressedsum[digest] = layers
+				break
+			}
+		}
+	}
 }
 
 func (r *layerStore) Delete(id string) error {


### PR DESCRIPTION
Fix ISSUE #664 

In some special case, residual resources in layerStore when remove an image may cause image export failed. These residual resources  also lead memory leak. So, it is nessary to clean all resources with the image remove.

Signed-off-by: zvier <zvier20@gmail.com>