### PR TITLE
userns: fix available range with explicit idmapping

### DIFF
--- a/userns.go
+++ b/userns.go
@@ -229,7 +229,7 @@ func subtractHostIDs(avail idtools.IDMap, used idtools.IDMap) []idtools.IDMap {
 	case used.HostID <= avail.HostID && used.HostID+used.Size >= avail.HostID+avail.Size:
 		return nil
 	case used.HostID <= avail.HostID && used.HostID+used.Size > avail.HostID && used.HostID+used.Size < avail.HostID+avail.Size:
-		newContainerID := used.HostID + used.Size
+		newContainerID := avail.ContainerID + used.Size
 		newHostID := used.HostID + used.Size
 		r := idtools.IDMap{
 			ContainerID: newContainerID,
@@ -275,7 +275,7 @@ func subtractContainerIDs(avail idtools.IDMap, used idtools.IDMap) []idtools.IDM
 		return nil
 	case used.ContainerID <= avail.ContainerID && used.ContainerID+used.Size > avail.ContainerID && used.ContainerID+used.Size < avail.ContainerID+avail.Size:
 		newContainerID := used.ContainerID + used.Size
-		newHostID := used.HostID + used.Size
+		newHostID := avail.HostID + used.Size
 		r := idtools.IDMap{
 			ContainerID: newContainerID,
 			HostID:      newHostID,
@@ -297,7 +297,7 @@ func subtractContainerIDs(avail idtools.IDMap, used idtools.IDMap) []idtools.IDM
 		}
 		r2 := idtools.IDMap{
 			ContainerID: used.ContainerID + used.Size,
-			HostID:      used.HostID + used.Size,
+			HostID:      avail.HostID + used.Size,
 			Size:        avail.ContainerID + avail.Size - used.ContainerID - used.Size,
 		}
 		return []idtools.IDMap{r1, r2}

--- a/userns_test.go
+++ b/userns_test.go
@@ -114,6 +114,7 @@ func TestSubtractContainerID(t *testing.T) {
 	ret := subtractContainerIDs(avail, used)
 	assert.Equal(t, len(ret), 1)
 	assert.Equal(t, avail.ContainerID, ret[0].ContainerID)
+	assert.Equal(t, 0, ret[0].HostID)
 	assert.Equal(t, avail.Size, ret[0].Size)
 
 	used = idtools.IDMap{
@@ -128,12 +129,13 @@ func TestSubtractContainerID(t *testing.T) {
 
 	used = idtools.IDMap{
 		ContainerID: 0,
-		HostID:      0,
+		HostID:      1,
 		Size:        65536,
 	}
 	ret = subtractContainerIDs(avail, used)
 	assert.Equal(t, len(ret), 1)
 	assert.Equal(t, avail.ContainerID, ret[0].ContainerID)
+	assert.Equal(t, 0, ret[0].HostID)
 	assert.Equal(t, avail.Size, ret[0].Size)
 
 	used = idtools.IDMap{
@@ -144,6 +146,7 @@ func TestSubtractContainerID(t *testing.T) {
 	ret = subtractContainerIDs(avail, used)
 	assert.Equal(t, len(ret), 1)
 	assert.Equal(t, ret[0].ContainerID, avail.ContainerID+4096)
+	assert.Equal(t, 4096, ret[0].HostID)
 	assert.Equal(t, ret[0].Size, avail.Size-4096)
 
 	used = idtools.IDMap{


### PR DESCRIPTION
when an explicit idmapping is specified, the host id must be taken
from the available range of IDs.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>