### PR TITLE
layer mount: fix RO logic

### DIFF
--- a/layers.go
+++ b/layers.go
@@ -777,10 +777,10 @@ func (r *layerStore) Mount(id string, options drivers.MountOpts) (string, error)
 	hasReadOnlyOpt := func(opts []string) bool {
 		for _, item := range opts {
 			if item == "ro" {
-				return false
+				return true
 			}
 		}
-		return true
+		return false
 	}
 
 	// You are not allowed to mount layers from readonly stores if they


### PR DESCRIPTION
Fix the logic in an anon-func looking for the `ro` option to allow for
mounting images that are set as read-only.

Signed-off-by: Valentin Rothberg <rothberg@redhat.com>