### PR TITLE
unshare: memoize HomeDir()

### DIFF
--- a/pkg/unshare/unshare.go
+++ b/pkg/unshare/unshare.go
@@ -4,19 +4,30 @@ import (
 	"fmt"
 	"os"
 	"os/user"
+	"sync"
 
 	"github.com/pkg/errors"
 )
 
+var (
+	homeDirOnce sync.Once
+	homeDirErr  error
+	homeDir     string
+)
+
 // HomeDir returns the home directory for the current user.
 func HomeDir() (string, error) {
-	home := os.Getenv("HOME")
-	if home == "" {
-		usr, err := user.LookupId(fmt.Sprintf("%d", GetRootlessUID()))
-		if err != nil {
-			return "", errors.Wrapf(err, "unable to resolve HOME directory")
+	homeDirOnce.Do(func() {
+		home := os.Getenv("HOME")
+		if home == "" {
+			usr, err := user.LookupId(fmt.Sprintf("%d", GetRootlessUID()))
+			if err != nil {
+				homeDir, homeDirErr = "", errors.Wrapf(err, "unable to resolve HOME directory")
+				return
+			}
+			homeDir, homeDirErr = usr.HomeDir, nil
 		}
-		home = usr.HomeDir
-	}
-	return home, nil
+		homeDir, homeDirErr = home, nil
+	})
+	return homeDir, homeDirErr
 }


### PR DESCRIPTION
do the potentially expensive user lookup function just once.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>