### PR TITLE
unbreak build on mipsen harder

### DIFF
--- a/drivers/devmapper/deviceset.go
+++ b/drivers/devmapper/deviceset.go
@@ -1749,7 +1749,7 @@ func (devices *DeviceSet) initDevmapper(doInit bool) (retErr error) {
 	//	- Managed by container storage
 	//	- The target of this device is at major <maj> and minor <min>
 	//	- If <inode> is defined, use that file inside the device as a loopback image. Otherwise use the device itself.
-	devices.devicePrefix = fmt.Sprintf("container-%d:%d-%d", major(st.Dev), minor(st.Dev), st.Ino)
+	devices.devicePrefix = fmt.Sprintf("container-%d:%d-%d", major(uint64(st.Dev)), minor(uint64(st.Dev)), st.Ino)
 	logrus.Debugf("devmapper: Generated prefix: %s", devices.devicePrefix)
 
 	// Check for the existence of the thin-pool device


### PR DESCRIPTION
Stat_t on MIPS uses 32-bit fields for Dev and Rdev, so we need to cast these to uint64

Turns out the change in 07171909b06e27a6c6b7f918aa981bec0c724f20
is incomplete and an additional line needs a cast.

Inpiration from moby/moby#37490
Example build failure log: https://buildd.debian.org/status/fetch.php?pkg=golang-github-containers-storage&arch=mips64el&ver=1.20.2-1&stamp=1594477648&raw=0Signed-off-by: Reinhard Tartler <siretart@tauware.de>

Signed-off-by: Reinhard Tartler <siretart@tauware.de>
