### PR TITLE
archive: fix the bug of ReadSecurityXattrToTarHeader

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -393,13 +393,15 @@ func fillGo18FileTypeBits(mode int64, fi os.FileInfo) int64 {
 // ReadSecurityXattrToTarHeader reads security.capability, security,image
 // xattrs from filesystem to a tar header
 func ReadSecurityXattrToTarHeader(path string, hdr *tar.Header) error {
+	if hdr.Xattrs == nil {
+		hdr.Xattrs = make(map[string]string)
+	}
 	for _, xattr := range []string{"security.capability", "security.ima"} {
 		capability, err := system.Lgetxattr(path, xattr)
 		if err != nil && err != system.EOPNOTSUPP && err != system.ErrNotSupportedPlatform {
 			return errors.Wrapf(err, "failed to read %q attribute from %q", xattr, path)
 		}
 		if capability != nil {
-			hdr.Xattrs = make(map[string]string)
 			hdr.Xattrs[xattr] = string(capability)
 		}
 	}


### PR DESCRIPTION
archive: fix the bug of ReadSecurityXattrToTarHeader

The xattr of hdr will lose when the security.ima
and security.capability both have value.

Signed-off-by: yangfeiyu <yangfeiyu20102011@163.com>