### PR TITLE
userns: make sure host id is not always 0

### DIFF
--- a/userns.go
+++ b/userns.go
@@ -356,6 +356,7 @@ func findAvailableIDRange(size uint32, availableIDs, usedIDs []idtools.IDMap) ([
 			return avail[:i+1], nil
 		}
 		remaining -= uint32(avail[i].Size)
+		currentID += avail[i].Size
 	}
 
 	return nil, errors.New("could not find enough available IDs")

--- a/userns_test.go
+++ b/userns_test.go
@@ -256,4 +256,17 @@ func TestFindAvailableIDRange(t *testing.T) {
 	assert.Equal(t, len(ret), 1)
 	assert.Equal(t, ret[0].HostID, 100000+32768)
 	assert.Equal(t, ret[0].Size, 4096)
+
+	used = []idtools.IDMap{
+		{
+			ContainerID: 0,
+			HostID:      100010,
+			Size:        10,
+		},
+	}
+	ret, err = findAvailableIDRange(4096, avail, used)
+	assert.Nil(t, err)
+	assert.Equal(t, len(ret), 2)
+	assert.Equal(t, ret[0].HostID, 100000)
+	assert.Equal(t, ret[1].HostID, 100010)
 }


### PR DESCRIPTION
when it finds multiple available ranges, make sure the host id is
correctly initialized.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>