### PR TITLE
store: support mapped layers deletion

### DIFF
--- a/pkg/stringutils/stringutils.go
+++ b/pkg/stringutils/stringutils.go
@@ -56,11 +56,22 @@ func Truncate(s string, maxlen int) string {
 // Comparison is case insensitive
 func InSlice(slice []string, s string) bool {
 	for _, ss := range slice {
-		if strings.ToLower(s) == strings.ToLower(ss) {
+		if strings.EqualFold(s, ss) {
 			return true
 		}
 	}
 	return false
+}
+
+// RemoveFromSlice removes a string from a slice.  The string can be present
+// multiple times.  The entire slice is iterated.
+func RemoveFromSlice(slice []string, s string) (ret []string) {
+	for _, ss := range slice {
+		if !strings.EqualFold(s, ss) {
+			ret = append(ret, ss)
+		}
+	}
+	return ret
 }
 
 func quote(word string, buf *bytes.Buffer) {


### PR DESCRIPTION
currently it is not possible to delete a mapped layer as it is always
referenced by the image.

Change it allow deleting the mapping if it is not used by any
container or other layers.

It will be useful in CRI-O as a lot of thrown away containers will be
created and the mapped images would keep growing without a way of
cleaning them up.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>