### PR TITLE
Cirrus: Fix matrix filter

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -62,8 +62,10 @@ testing_task:
         - lint
 
     # Not all $TEST_DRIVER combinations are valid for all OS types.
-    # Note: Nested-variable resolution happens at runtime, not eval. time.
-    # Use verbose logic for ease of reading/maintaining.
+    # N/B: As of the addition of this note, nested-variable resolution
+    # does not happen for boolean `only_if` expressions.  Since $VM_IMAGE
+    # contains nested variables, we must filter based on that and not the
+    # actual distro/version value.
     only_if: >-
         ( $VM_IMAGE =~ '.*UBUNTU.*' && $TEST_DRIVER == "vfs" ) ||
         ( $VM_IMAGE =~ '.*UBUNTU.*' && $TEST_DRIVER == "aufs" ) ||

--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -148,3 +148,15 @@ vendor_task:
         folder: $GOPATH/pkg/mod
     build_script: make vendor
     test_script: hack/tree_status.sh
+
+# Represent overall pass/fail status from required dependent tasks
+success_task:
+    depends_on:
+        - lint
+        - testing
+        - meta
+        - vendor
+    container:
+        image: golang:1.14
+    clone_script: 'mkdir -p "$CIRRUS_WORKING_DIR"'  # Source code not needed
+    script: /bin/true


### PR DESCRIPTION
An errant behavior change in Cirrus-CI between Jul. 28th and Aug. 3rd caused nested variable references to not resolve properly in `only_if` matrix  filters.  An attempt to correct the behavior made things worse, and so the old (pre-July 28) behavior was re-established.  In other words, nested variables in `only_if` will **NOT** be dereferenced, so they must match the nested variable name, not it's value.  I've updated the nearby comment to reflect the current situation.

Also I added a `success` task, which can be marked as `required` in Github's branch protection.  This will help guarantee that specific tests pass, before allowing PRs to merge.

Signed-off-by: Chris Evich <cevich@redhat.com>