### PR TITLE
[WIP] Allow callers to pass down OmitTimestamp flag

### DIFF
--- a/drivers/aufs/aufs.go
+++ b/drivers/aufs/aufs.go
@@ -493,9 +493,9 @@ func (a *Driver) isParent(id, parent string) bool {
 
 // Diff produces an archive of the changes between the specified
 // layer and its parent layer which may be "".
-func (a *Driver) Diff(id string, idMappings *idtools.IDMappings, parent string, parentMappings *idtools.IDMappings, mountLabel string) (io.ReadCloser, error) {
+func (a *Driver) Diff(id string, idMappings *idtools.IDMappings, parent string, parentMappings *idtools.IDMappings, mountLabel string, omitTimestamp bool) (io.ReadCloser, error) {
 	if !a.isParent(id, parent) {
-		return a.naiveDiff.Diff(id, idMappings, parent, parentMappings, mountLabel)
+		return a.naiveDiff.Diff(id, idMappings, parent, parentMappings, mountLabel, omitTimestamp)
 	}
 
 	if idMappings == nil {

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -42,6 +42,7 @@ type CreateOpts struct {
 	StorageOpt map[string]string
 	*idtools.IDMappings
 	ignoreChownErrors bool
+	OmitTimestamp     bool
 }
 
 // MountOpts contains optional arguments for LayerStope.Mount() methods.
@@ -60,6 +61,7 @@ type ApplyDiffOpts struct {
 	Mappings          *idtools.IDMappings
 	MountLabel        string
 	IgnoreChownErrors bool
+	OmitTimestamp     bool
 }
 
 // InitFunc initializes the storage driver.
@@ -116,7 +118,7 @@ type ProtoDriver interface {
 type DiffDriver interface {
 	// Diff produces an archive of the changes between the specified
 	// layer and its parent layer which may be "".
-	Diff(id string, idMappings *idtools.IDMappings, parent string, parentIDMappings *idtools.IDMappings, mountLabel string) (io.ReadCloser, error)
+	Diff(id string, idMappings *idtools.IDMappings, parent string, parentIDMappings *idtools.IDMappings, mountLabel string, omitTimestamp bool) (io.ReadCloser, error)
 	// Changes produces a list of changes between the specified layer
 	// and its parent layer. If parent is "", then all changes will be ADD changes.
 	Changes(id string, idMappings *idtools.IDMappings, parent string, parentIDMappings *idtools.IDMappings, mountLabel string) ([]archive.Change, error)

--- a/drivers/fsdiff.go
+++ b/drivers/fsdiff.go
@@ -31,7 +31,7 @@ type NaiveDiffDriver struct {
 // NewNaiveDiffDriver returns a fully functional driver that wraps the
 // given ProtoDriver and adds the capability of the following methods which
 // it may or may not support on its own:
-//     Diff(id string, idMappings *idtools.IDMappings, parent string, parentMappings *idtools.IDMappings, mountLabel string) (io.ReadCloser, error)
+//     Diff(id string, idMappings *idtools.IDMappings, parent string, parentMappings *idtools.IDMappings, mountLabel string, omitTimestamp bool) (io.ReadCloser, error)
 //     Changes(id string, idMappings *idtools.IDMappings, parent string, parentMappings *idtools.IDMappings, mountLabel string) ([]archive.Change, error)
 //     ApplyDiff(id, parent string, options ApplyDiffOpts) (size int64, err error)
 //     DiffSize(id string, idMappings *idtools.IDMappings, parent, parentMappings *idtools.IDMappings, mountLabel string) (size int64, err error)
@@ -41,7 +41,7 @@ func NewNaiveDiffDriver(driver ProtoDriver, updater LayerIDMapUpdater) Driver {
 
 // Diff produces an archive of the changes between the specified
 // layer and its parent layer which may be "".
-func (gdw *NaiveDiffDriver) Diff(id string, idMappings *idtools.IDMappings, parent string, parentMappings *idtools.IDMappings, mountLabel string) (arch io.ReadCloser, err error) {
+func (gdw *NaiveDiffDriver) Diff(id string, idMappings *idtools.IDMappings, parent string, parentMappings *idtools.IDMappings, mountLabel string, omitTimestamp bool) (arch io.ReadCloser, err error) {
 	startTime := time.Now()
 	driver := gdw.ProtoDriver
 
@@ -94,7 +94,7 @@ func (gdw *NaiveDiffDriver) Diff(id string, idMappings *idtools.IDMappings, pare
 		return nil, err
 	}
 
-	archive, err := archive.ExportChanges(layerFs, changes, idMappings.UIDs(), idMappings.GIDs())
+	archive, err := archive.ExportChanges(layerFs, changes, idMappings.UIDs(), idMappings.GIDs(), omitTimestamp)
 	if err != nil {
 		return nil, err
 	}

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -1151,9 +1151,9 @@ func (d *Driver) DiffSize(id string, idMappings *idtools.IDMappings, parent stri
 
 // Diff produces an archive of the changes between the specified
 // layer and its parent layer which may be "".
-func (d *Driver) Diff(id string, idMappings *idtools.IDMappings, parent string, parentMappings *idtools.IDMappings, mountLabel string) (io.ReadCloser, error) {
+func (d *Driver) Diff(id string, idMappings *idtools.IDMappings, parent string, parentMappings *idtools.IDMappings, mountLabel string, omitTimestamp bool) (io.ReadCloser, error) {
 	if d.useNaiveDiff() || !d.isParent(id, parent) {
-		return d.naiveDiff.Diff(id, idMappings, parent, parentMappings, mountLabel)
+		return d.naiveDiff.Diff(id, idMappings, parent, parentMappings, mountLabel, omitTimestamp)
 	}
 
 	if idMappings == nil {

--- a/drivers/template.go
+++ b/drivers/template.go
@@ -28,7 +28,7 @@ func NaiveCreateFromTemplate(d TemplateDriver, id, template string, templateIDMa
 	if err != nil {
 		return err
 	}
-	diff, err := d.Diff(template, templateIDMappings, parent, parentIDMappings, opts.MountLabel)
+	diff, err := d.Diff(template, templateIDMappings, parent, parentIDMappings, opts.MountLabel, opts.OmitTimestamp)
 	if err != nil {
 		if err2 := d.Remove(id); err2 != nil {
 			logrus.Errorf("error removing layer %q: %v", id, err2)

--- a/drivers/vfs/driver.go
+++ b/drivers/vfs/driver.go
@@ -276,8 +276,8 @@ func (d *Driver) Changes(id string, idMappings *idtools.IDMappings, parent strin
 
 // Diff produces an archive of the changes between the specified
 // layer and its parent layer which may be "".
-func (d *Driver) Diff(id string, idMappings *idtools.IDMappings, parent string, parentMappings *idtools.IDMappings, mountLabel string) (io.ReadCloser, error) {
-	return d.naiveDiff.Diff(id, idMappings, parent, parentMappings, mountLabel)
+func (d *Driver) Diff(id string, idMappings *idtools.IDMappings, parent string, parentMappings *idtools.IDMappings, mountLabel string, omitTimestamp bool) (io.ReadCloser, error) {
+	return d.naiveDiff.Diff(id, idMappings, parent, parentMappings, mountLabel, omitTimestamp)
 }
 
 // DiffSize calculates the changes between the specified id

--- a/drivers/windows/windows.go
+++ b/drivers/windows/windows.go
@@ -496,7 +496,7 @@ func (d *Driver) Cleanup() error {
 // Diff produces an archive of the changes between the specified
 // layer and its parent layer which may be "".
 // The layer should be mounted when calling this function
-func (d *Driver) Diff(id string, idMappings *idtools.IDMappings, parent string, parentMappings *idtools.IDMappings, mountLabel string) (_ io.ReadCloser, err error) {
+func (d *Driver) Diff(id string, idMappings *idtools.IDMappings, parent string, parentMappings *idtools.IDMappings, mountLabel string, omitTimestamp bool) (_ io.ReadCloser, err error) {
 	panicIfUsedByLcow()
 	rID, err := d.resolveID(id)
 	if err != nil {

--- a/layers.go
+++ b/layers.go
@@ -129,6 +129,9 @@ type layerMountPoint struct {
 type DiffOptions struct {
 	// Compression, if set overrides the default compressor when generating a diff.
 	Compression *archive.Compression
+	// OmitTimestamp forces all files in the layer to be saved as epoch 0
+	// This can be used for deterministic builds
+	OmitTimestamp bool
 }
 
 // ROLayerStore wraps a graph driver, adding the ability to refer to layers by
@@ -1239,7 +1242,7 @@ func (r *layerStore) Diff(from, to string, options *DiffOptions) (io.ReadCloser,
 	}
 
 	if from != toLayer.Parent {
-		diff, err := r.driver.Diff(to, r.layerMappings(toLayer), from, r.layerMappings(fromLayer), toLayer.MountLabel)
+		diff, err := r.driver.Diff(to, r.layerMappings(toLayer), from, r.layerMappings(fromLayer), toLayer.MountLabel, options.OmitTimestamp)
 		if err != nil {
 			return nil, err
 		}
@@ -1251,7 +1254,7 @@ func (r *layerStore) Diff(from, to string, options *DiffOptions) (io.ReadCloser,
 		if !os.IsNotExist(err) {
 			return nil, err
 		}
-		diff, err := r.driver.Diff(to, r.layerMappings(toLayer), from, r.layerMappings(fromLayer), toLayer.MountLabel)
+		diff, err := r.driver.Diff(to, r.layerMappings(toLayer), from, r.layerMappings(fromLayer), toLayer.MountLabel, options.OmitTimestamp)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/archive/changes.go
+++ b/pkg/archive/changes.go
@@ -447,7 +447,7 @@ func ChangesSize(newDir string, changes []Change) int64 {
 }
 
 // ExportChanges produces an Archive from the provided changes, relative to dir.
-func ExportChanges(dir string, changes []Change, uidMaps, gidMaps []idtools.IDMap) (io.ReadCloser, error) {
+func ExportChanges(dir string, changes []Change, uidMaps, gidMaps []idtools.IDMap, omitTimestamp bool) (io.ReadCloser, error) {
 	reader, writer := io.Pipe()
 	go func() {
 		ta := newTarAppender(idtools.NewIDMappingsFromMaps(uidMaps, gidMaps), writer, nil)
@@ -467,6 +467,9 @@ func ExportChanges(dir string, changes []Change, uidMaps, gidMaps []idtools.IDMa
 				whiteOutBase := filepath.Base(change.Path)
 				whiteOut := filepath.Join(whiteOutDir, WhiteoutPrefix+whiteOutBase)
 				timestamp := time.Now()
+				if omitTimestamp {
+					timestamp = time.Unix(0, 0)
+				}
 				hdr := &tar.Header{
 					Name:       whiteOut[1:],
 					Size:       0,


### PR DESCRIPTION
If the user passes down this flag all of the files in the archive
should be treated as being created at EPOCH.

The goal is to allow a container engine to create the same content
multiple times without having to deal with changes in timestamps.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>