### PR TITLE
Allow any env variable for graphroot, runroot, storagepath

### DIFF
--- a/docs/containers-storage.conf.5.md
+++ b/docs/containers-storage.conf.5.md
@@ -33,33 +33,21 @@ The `storage` table supports the following options:
 **graphroot**=""
   container storage graph dir (default: "/var/lib/containers/storage")
   Default directory to store all writable content created by container storage programs.
-
-    The rootless graphroot path supports three substitutions:
-    * `$HOME` => Replaced by the users home directory.
-    * `$UID`  => Replaced by the users UID
-    * `$USER` => Replaced by the users name
+  The rootless graphroot path supports environment variable substitutions (ie. `$HOME/containers/storage`)
 
 **rootless_storage_path**="$HOME/.local/share/containers/storage"
   Storage path for rootless users. By default the graphroot for rootless users
   is set to `$XDG_DATA_HOME/containers/storage`, if XDG_DATA_HOME is set.
   Otherwise `$HOME/.local/share/containers/storage` is used.  This field can
   be used if administrators need to change the storage location for all users.
-
-    The rootless storage path supports three substitutions:
-    * `$HOME` => Replaced by the users home directory.
-    * `$UID`  => Replaced by the users UID
-    * `$USER` => Replaced by the users name
+  The rootless storage path supports environment variable substitutions (ie. `$HOME/containers/storage`)
 
   A common use case for this field is to provide a local storage directory when user home directories are NFS-mounted (podman does not support container storage over NFS).
 
 **runroot**=""
   container storage run dir (default: "/var/run/containers/storage")
   Default directory to store all temporary writable content created by container storage programs.
-
-    The rootless runroot path supports three substitutions:
-    * `$HOME` => Replaced by the users home directory.
-    * `$UID`  => Replaced by the users UID
-    * `$USER` => Replaced by the users name
+  The rootless runroot path supports environment variable substitutions (ie. `$HOME/containers/storage`)
 
 ### STORAGE OPTIONS TABLE
 

--- a/storage_test.conf
+++ b/storage_test.conf
@@ -1,0 +1,35 @@
+# This file is is a TEST configuration file for all tools
+# that use the containers/storage library.
+# See man 5 containers-storage.conf for more information
+# The "container storage" table contains all of the server options.
+[storage]
+
+# Default Storage Driver
+driver = ""
+
+# Temporary storage location
+runroot = "$HOME/$UID/containers/storage"
+
+# Primary Read/Write location of container storage
+graphroot = "$HOME/$UID/containers/storage"
+
+# Storage path for rootless users
+#
+rootless_storage_path = "$HOME/$UID/containers/storage"
+
+[storage.options]
+# Storage options to be passed to underlying storage drivers
+
+# AdditionalImageStores is used to pass paths to additional Read/Only image stores
+# Must be comma separated list.
+additionalimagestores = [
+]
+
+[storage.options.overlay]
+
+# mountopt specifies comma separated list of extra mount options
+mountopt = "nodev"
+
+
+[storage.options.thinpool]
+# Storage Options for thinpool

--- a/utils_test.go
+++ b/utils_test.go
@@ -12,43 +12,6 @@ import (
 	"gotest.tools/assert"
 )
 
-func TestValidStoragePathFormat(t *testing.T) {
-	// Given
-	expectErr := "Unrecognized environment variable"
-	invalidPaths := []struct {
-		path   string
-		expect string
-	}{
-		{"$", expectErr},
-		{"$HOMEDIR", expectErr},
-		{"$HOMEdir", expectErr},
-		{"/test/$HOMEDIR/$USERNAME/$UID", expectErr},
-		{"/test/$HOME/$USERNAME/$UID", expectErr},
-		{"/test/$HOME/$USER/$UIDNUM", expectErr},
-	}
-	validPaths := []string{
-		"$HOME",
-		"$HOME/",
-		"/test/path",
-		"/test/$HOME",
-		"/test/$HOME/path",
-		"/test/$HOME/$USER/$UID",
-		"/test/$HOME/$USER/$UID/path",
-		"$HOME/$USER/$UID/path",
-	}
-
-	// Then
-	for _, conf := range invalidPaths {
-		err := validEnvPathFormat(conf.path)
-		assert.Error(t, err, "Unrecognized environment variable")
-	}
-
-	for _, path := range validPaths {
-		err := validEnvPathFormat(path)
-		assert.NilError(t, err)
-	}
-}
-
 type homeRuntimeData struct {
 	dir   string
 	error error
@@ -294,4 +257,15 @@ func TestRootlessRuntimeDirRace(t *testing.T) {
 	})
 	assert.NilError(t, err)
 	assert.Assert(t, resultDir != tmpPerUserDir, "Rootless runtime dir shouldn't follow race dir.")
+}
+
+func TestDefaultStoreOpts(t *testing.T) {
+	storageOpts, err := defaultStoreOptionsIsolated(true, 1000, "./storage_test.conf")
+
+	expectedPath := filepath.Join(os.Getenv("NAME"), "1000", "containers/storage")
+
+	assert.NilError(t, err)
+	assert.Assert(t, storageOpts.RunRoot == expectedPath)
+	assert.Assert(t, storageOpts.GraphRoot == expectedPath)
+	assert.Assert(t, storageOpts.RootlessStoragePath == expectedPath)
 }


### PR DESCRIPTION
Previously only restricted to home, uid, and user

as per https://github.com/containers/buildah/issues/2311#issuecomment-671076880

Signed-off-by: Ashley Cui <acui@redhat.com>