### PR TITLE
fileutils.Pattern.compile(): end the regex with the right path separator

### DIFF
--- a/pkg/fileutils/fileutils.go
+++ b/pkg/fileutils/fileutils.go
@@ -262,7 +262,7 @@ func (p *Pattern) compile() error {
 		}
 	}
 
-	regStr += "(/.*)?$"
+	regStr += "(" + escSL + ".*)?$"
 
 	re, err := regexp.Compile(regStr)
 	if err != nil {


### PR DESCRIPTION
When building the regex that matches patterns, the ending bit that matches items below directories that match the pattern should be built using the OS-specific path separator, which is not always `/`.