### PR TITLE
Use `bash` binary from env instead of /bin/bash for scripts

### DIFF
--- a/contrib/cirrus/add_second_partition.sh
+++ b/contrib/cirrus/add_second_partition.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # N/B: This script could mega f*!@up your disks if run by mistake.
 #      it is left without the execute-bit on purpose!

--- a/contrib/cirrus/build_and_test.sh
+++ b/contrib/cirrus/build_and_test.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/contrib/cirrus/lib.sh.t
+++ b/contrib/cirrus/lib.sh.t
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Unit tests for some functions in lib.sh
 #

--- a/contrib/cirrus/ooe.sh
+++ b/contrib/cirrus/ooe.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 # This script executes a command while logging all output to a temporary
 # file.  If the command exits non-zero, then all output is sent to the console,

--- a/contrib/cirrus/setup.sh
+++ b/contrib/cirrus/setup.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/hack/btrfs_tag.sh
+++ b/hack/btrfs_tag.sh
@@ -1,17 +1,17 @@
-#!/bin/bash
-if test $(${GO:-go} env GOOS) != "linux" ; then
-	exit 0
+#!/usr/bin/env bash
+if test $(${GO:-go} env GOOS) != "linux"; then
+    exit 0
 fi
-cc -E - > /dev/null 2> /dev/null <<- EOF
+cc -E - >/dev/null 2>/dev/null <<-EOF
 #include <btrfs/ioctl.h>
 EOF
-if test $? -ne 0 ; then
-	echo exclude_graphdriver_btrfs
+if test $? -ne 0; then
+    echo exclude_graphdriver_btrfs
 else
-	cc -E - > /dev/null 2> /dev/null <<- EOF
+    cc -E - >/dev/null 2>/dev/null <<-EOF
 	#include <btrfs/version.h>
 	EOF
-	if test $? -ne 0 ; then
-		echo btrfs_noversion
-	fi
+    if test $? -ne 0; then
+        echo btrfs_noversion
+    fi
 fi

--- a/hack/gccgo-wrapper.sh
+++ b/hack/gccgo-wrapper.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 #
 # Work around, based on one described in https://github.com/golang/go/issues/15628
 #

--- a/hack/generate-authors.sh
+++ b/hack/generate-authors.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")/.."

--- a/hack/get_ci_vm.sh
+++ b/hack/get_ci_vm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 set -e
 

--- a/hack/git-validation.sh
+++ b/hack/git-validation.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 export PATH=${GOPATH%%:*}/bin:${PATH}
 export GIT_VALIDATION=tests/tools/build/git-validation
 if [ ! -x "$GIT_VALIDATION" ]; then

--- a/hack/gofmt.sh
+++ b/hack/gofmt.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if test $(find -name "*.go" -not -path "*/vendor/*" -print0 | xargs -n 1 -0 gofmt -s -l | wc -l) -ne 0 ; then
 	echo Error: source files are not formatted according to recommendations.  Run \"gofmt -s -w\" on:
 	find -name "*.go" -not -path "*/vendor/*" -print0 | xargs -n 1 -0 gofmt -s -l

--- a/hack/govet.sh
+++ b/hack/govet.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 for package in $(go list ./... | grep -v /vendor/) ; do
 	if ! go vet ${package} ; then
 		echo Error: source package ${package} does not pass go vet.

--- a/hack/libdm_tag.sh
+++ b/hack/libdm_tag.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 if test $(${GO:-go} env GOOS) != "linux" ; then
 	exit 0
 fi

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 STORAGE_BINARY=${STORAGE_BINARY:-$(dirname ${BASH_SOURCE})/../containers-storage}
 TESTSDIR=${TESTSDIR:-$(dirname ${BASH_SOURCE})}

--- a/tests/test_drivers.bash
+++ b/tests/test_drivers.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 
 TMPDIR=${TMPDIR:-/var/tmp}
 

--- a/tests/test_runner.bash
+++ b/tests/test_runner.bash
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 
 cd "$(dirname "$(readlink -f "$BASH_SOURCE")")"

--- a/vagrant/provision.sh
+++ b/vagrant/provision.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -xe
 
 source /etc/os-release

--- a/vagrant/runinvm.sh
+++ b/vagrant/runinvm.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 set -e
 export PKG='github.com/containers/storage'
 export VAGRANT_MACHINES="fedora debian"


### PR DESCRIPTION
It's not possible to run any of the scripts on distributions which do
have `bash` not in `/bin`. This is being fixed by using `/usr/bin/env
bash` instead.