### PR TITLE
counter: check for external umounts

### DIFF
--- a/drivers/counter.go
+++ b/drivers/counter.go
@@ -51,6 +51,10 @@ func (c *RefCounter) incdec(path string, infoOp func(minfo *minfo)) int {
 		if c.checker.IsMounted(path) {
 			m.count++
 		}
+	} else if !c.checker.IsMounted(path) {
+		// if the unmount was performed outside of this process (e.g. conmon cleanup)
+		//the ref counter would lose track of it.  Check if it is still mounted.
+		m.count = 0
 	}
 	infoOp(m)
 	count := m.count


### PR DESCRIPTION
if a previously mounted container was unmounted
externally (e.g. through conmon cleanup for Podman containers), the
ref counter will lose track of it and report it as still mounted.

Closes: https://github.com/containers/storage/issues/697

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>