### PR TITLE
Cirrus: Use images from automation_images

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -17,14 +17,15 @@ env:
     ####
     #### Cache-image names to test with (double-quotes around names are critical)
     ###
-    FEDORA_NAME: "fedora-32"
-    PRIOR_FEDORA_NAME: "fedora-31"
-    UBUNTU_NAME: "ubuntu-20"
-    PRIOR_UBUNTU_NAME: "ubuntu-19"
+    FEDORA_NAME: "fedora"
+    PRIOR_FEDORA_NAME: "prior-fedora"
+    UBUNTU_NAME: "ubuntu"
+    PRIOR_UBUNTU_NAME: "prior-ubuntu"
 
     # GCE project where images live
     IMAGE_PROJECT: "libpod-218412"
-    _BUILT_IMAGE_SUFFIX: "libpod-6508632441356288"
+    # VM Image built in containers/automation_images
+    _BUILT_IMAGE_SUFFIX: "c6110627968057344"
     FEDORA_CACHE_IMAGE_NAME: "${FEDORA_NAME}-${_BUILT_IMAGE_SUFFIX}"
     PRIOR_FEDORA_CACHE_IMAGE_NAME: "${PRIOR_FEDORA_NAME}-${_BUILT_IMAGE_SUFFIX}"
     UBUNTU_CACHE_IMAGE_NAME: "${UBUNTU_NAME}-${_BUILT_IMAGE_SUFFIX}"

--- a/contrib/cirrus/build_and_test.sh
+++ b/contrib/cirrus/build_and_test.sh
@@ -9,13 +9,6 @@ make install.tools
 showrun make local-binary
 showrun make local-cross
 
-# On Ubuntu w/ Bats <= 1.2.0 using more than one job throws errors like:
-# cat: /tmp/bats-run-23134/parallel_output/1/stdout: No such file or directory
-if [[ "$OS_RELEASE_ID" == "ubuntu" ]]; then
-    # See tests/test_runner.bash
-    export JOBS=1  # Only ~50 tests @ 1-second each, not so bad to do one at a time.
-fi
-
 case $TEST_DRIVER in
     overlay)
         showrun make STORAGE_DRIVER=overlay local-test-integration

--- a/tests/test_runner.bash
+++ b/tests/test_runner.bash
@@ -14,11 +14,5 @@ function execute() {
 # Tests to run. Defaults to all.
 TESTS=${@:-.}
 
-# N/B: Testing in parallel under automation is discouraged in this instance
-#      (so `export JOBS=1`).  It has been observed to cause errors on Ubuntu,
-#      and with so few tests here anyway, doesn't save much time (i.e. maybe a
-#      few seconds at most)
-export JOBS=${JOBS:-$(($(nproc --all) * 4))}
-
 # Run the tests.
-execute time bats --jobs "$JOBS" --tap $TESTS
+execute time bats --tap $TESTS


### PR DESCRIPTION
Previously, VM Images were built from a side-band process tacked onto
containers/podman automation. This has recently been split off into it's
own repository containers/automation_images. This PR makes use of
freshly built images produced using the new workflow. Additionally, to
support testing of a runc -> crun transition, both packages are
installed in the newly referenced images.

Signed-off-by: Chris Evich <cevich@redhat.com>