### PR TITLE
Fix go.mod; simplify pkg/mount.Mounted

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-go 1.15
+go 1.14
 
 module github.com/containers/storage
 

--- a/pkg/mount/mountinfo.go
+++ b/pkg/mount/mountinfo.go
@@ -1,21 +1,13 @@
 package mount
 
 import (
-	"github.com/containers/storage/pkg/fileutils"
 	"github.com/moby/sys/mountinfo"
 )
 
 type Info = mountinfo.Info
 
+var Mounted = mountinfo.Mounted
+
 func GetMounts() ([]*Info, error) {
 	return mountinfo.GetMounts(nil)
-}
-
-// Mounted determines if a specified mountpoint has been mounted.
-func Mounted(mountpoint string) (bool, error) {
-	mountpoint, err := fileutils.ReadSymlinkedPath(mountpoint)
-	if err != nil {
-		return false, err
-	}
-	return mountinfo.Mounted(mountpoint)
 }


### PR DESCRIPTION
Carry of #720 
Closes: #723 

## 1. go.mod: fix go version
    
Commit 1a2847751 (inadvertently?) changed go version in go.mod from 1.13
to 1.15.
    
A "go <version>" line in go.mod sets minimum go version required for the
package (see [1]). I don't think containers/storage suddenly requires go
1.15+.
    
Set it to 1.14, which is currently the oldest supported release.
   
[1] https://golang.org/ref/mod#go-mod-file-go

## 2. pkg/mount: rm path normalization from Mounted
    
Since moby/sys/mountinfo v0.2.0, the path does not have to be
normalized, so drop our wrapper.
    
Note this slightly change the call semantics: previously, a non-existing
path resulting in an error (wrapped ENOENT), while now it will return
"not mounted". The change is intentional -- the call is not to check if
the path exists, it is to check whether it is mounted.
