### PR TITLE
add note regarding problematic language in codebase

### DIFF
--- a/docs/containers-storage.md
+++ b/docs/containers-storage.md
@@ -163,3 +163,10 @@ This is still a work in progress, so some functionality may not yet be
 implemented, and some will be removed if it is found to be unnecessary.  That
 said, if anything isn't working correctly, please report it to [the project's
 issue tracker] (https://github.com/containers/storage/issues).
+
+## FOOTNOTES
+The Containers Storage project is committed to inclusivity, a core value of open source.
+The `master` and `slave` mount propagation terminology is used in this repository.
+This language is problematic and divisive, and should be changed.
+However, these terms are currently used within the Linux kernel and must be used as-is at this time.
+When the kernel maintainers rectify this usage, Containers Storage will follow suit immediately.


### PR DESCRIPTION
Containers storage is committed to inclusivity, a core value of open source. Historically, there have been technology terms that are problematic and divisive, and should be changed. We are currently taking time to audit our repository in order to eliminate such terminology, and replace it with more inclusive terms. We are starting where we can, with our own code, comments, and documentation. However, some of these terms are currently used within the Linux kernel and must be used as-is at this time. When the kernel maintainers rectify this usage, containers storage will follow suit immediately.

For more information: https://www.redhat.com/en/blog/making-open-source-more-inclusive-eradicating-problematic-language?sc_cid=701600000011gf0AAA

Signed-off-by: Ashley Cui <acui@redhat.com>