### PR TITLE
Fixes: sometimes should be the same with the behavior of the cp command

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 *.test
 .*.swp
 .DS_Store
+.idea*
 # a .bashrc may be added to customize the build environment
 .bashrc
 .gopath/

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -1247,10 +1247,11 @@ func (archiver *Archiver) CopyFileWithTar(src, dst string) (err error) {
 	}()
 
 	options := &TarOptions{
-		UIDMaps:   archiver.UntarIDMappings.UIDs(),
-		GIDMaps:   archiver.UntarIDMappings.GIDs(),
-		ChownOpts: archiver.ChownOpts,
-		InUserNS:  rsystem.RunningInUserNS(),
+		UIDMaps:              archiver.UntarIDMappings.UIDs(),
+		GIDMaps:              archiver.UntarIDMappings.GIDs(),
+		ChownOpts:            archiver.ChownOpts,
+		InUserNS:             rsystem.RunningInUserNS(),
+		NoOverwriteDirNonDir: true,
 	}
 	err = archiver.Untar(r, filepath.Dir(dst), options)
 	if err != nil {


### PR DESCRIPTION
check the base name of the src and dest,
if they are the same and dest is a directory, should error like cp behavior
```
$ mkdir abc
$ mkdir test
$ touch test/abc
$ cp test/abc .
cp: cannot overwrite directory './abc' with non-directory
```

```
$ docker exec test touch /root/file1
$ mkdir -p /tmp/file1
$ docker cp test:/root/file1 /tmp
cannot overwrite directory "/tmp/file1" with non-directory "/tmp"
```

Fixes: https://github.com/containers/podman/issues/7790
Signed-off-by: zhangguanzhang <zhangguanzhang@qq.com>