### PR TITLE
Fix CI for 1.11 branch

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ validate: ## validate DCO, gofmt, ./pkg/ isolation, golint,\ngo vet and vendor u
 	$(RUNINVM) make local-$@
 
 install.tools:
-	go get -u $(BUILDFLAGS) github.com/cpuguy83/go-md2man
+	go get -u $(BUILDFLAGS) gopkg.in/cpuguy83/go-md2man.v1
 	go get -u $(BUILDFLAGS) github.com/vbatts/git-validation
 	go get -u $(BUILDFLAGS) gopkg.in/alecthomas/gometalinter.v1
 	go get -u $(BUILDFLAGS) github.com/pquerna/ffjson


### PR DESCRIPTION
Targeting CI issue:

> go get -u -tags "  ostree "  github.com/cpuguy83/go-md2man
package github.com/cpuguy83/go-md2man/v2/md2man: cannot find package
"github.com/cpuguy83/go-md2man/v2/md2man" in any of:
  /root/.gimme/versions/go1.9.linux.amd64/src/github.com/cpuguy83/go-md2man/v2/md2man (from $GOROOT)
  /root/go/src/github.com/cpuguy83/go-md2man/v2/md2man (from $GOPATH)
