### PR TITLE
ParseIDMap should not ignore nonDigits

### DIFF
--- a/pkg/idtools/parser.go
+++ b/pkg/idtools/parser.go
@@ -8,13 +8,6 @@ import (
 	"strings"
 )
 
-func nonDigitsToWhitespace(r rune) rune {
-	if !strings.ContainsRune("0123456789", r) {
-		return ' '
-	}
-	return r
-}
-
 func parseTriple(spec []string) (container, host, size uint32, err error) {
 	cid, err := strconv.ParseUint(spec[0], 10, 32)
 	if err != nil {
@@ -33,9 +26,12 @@ func parseTriple(spec []string) (container, host, size uint32, err error) {
 
 // ParseIDMap parses idmap triples from string.
 func ParseIDMap(mapSpec []string, mapSetting string) (idmap []IDMap, err error) {
-	stdErr := fmt.Errorf("error initializing ID mappings: %s setting is malformed", mapSetting)
+	stdErr := fmt.Errorf("error initializing ID mappings: %s setting is malformed expected [\"uint32:uint32:uint32\"]: %q", mapSetting, mapSpec)
 	for _, idMapSpec := range mapSpec {
-		idSpec := strings.Fields(strings.Map(nonDigitsToWhitespace, idMapSpec))
+		if idMapSpec == "" {
+			continue
+		}
+		idSpec := strings.Split(idMapSpec, ":")
 		if len(idSpec)%3 != 0 {
 			return nil, stdErr
 		}

--- a/pkg/idtools/parser_test.go
+++ b/pkg/idtools/parser_test.go
@@ -1,0 +1,37 @@
+// +build !windows
+
+package idtools
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseIDMap(t *testing.T) {
+	type tests struct {
+		mapSpec    []string
+		mapSetting string
+		fail       bool
+	}
+	testList := []tests{
+		{[]string{"0:1:100000"}, "uid", false},
+		{[]string{"0:1:100000", "5:200000:100"}, "gid", false},
+		{[]string{"0:1:100000", "5:200000:x100"}, "gid", true},
+		{[]string{"0:1:100000"}, "uid", false},
+		{[]string{"0:1:1000000000000000"}, "uid", true},
+		{[]string{"b0:1:100000"}, "uid", true},
+		{[]string{"0:b1:100000"}, "uid", true},
+		{[]string{"0:1:1000b00"}, "uid", true},
+		{[]string{"0100000"}, "uid", true},
+	}
+
+	for _, test := range testList {
+		_, err := ParseIDMap(test.mapSpec, test.mapSetting)
+		if test.fail {
+			require.Error(t, err)
+		} else {
+			require.NoError(t, err)
+		}
+	}
+}


### PR DESCRIPTION
This leads to people accidently putting characters into options
and not getting back good errors.

Fixes: https://github.com/containers/storage/issues/739

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>