### PR TITLE
storage: add option force_mask= and permissions_xattr=

### DIFF
--- a/docs/containers-storage.conf.5.md
+++ b/docs/containers-storage.conf.5.md
@@ -171,8 +171,8 @@ The `storage.options.overlay` table supports the following options:
   force_mask sets an octal permission mask that is used for the new files and directories.  The values "native", "shared", "private" are also accepted.  (default: "native")
   "private": it is equivalent to 0700.  The owner has rwx access to the files.
   "shared": it is equivalent to 0755.  The owner has rwx access to the files and everyone else can read, access and execute them.
-  It is possible to use **force_mask** only when **mount_program** is specified.
   Note: The force_mask Flag is an experimental feature, it could change in the future.
+  When "force_mask" is used then the original permission mask is stored in the "user.containers.override_stat" xattr.
 
 **mount_program**=""
   Specifies the path to a custom program to use instead of using kernel defaults

--- a/docs/containers-storage.conf.5.md
+++ b/docs/containers-storage.conf.5.md
@@ -149,7 +149,7 @@ The `storage.options.thinpool` table supports the following options for the `dev
   Comma separated list of default options to be used to mount container images.  Suggested value "nodev". Mount options are documented in the mount(8) man page.
 
 **size**=""
-  Maximum size of a container image.   This flag can be used to set quota on the size of container images. (format: <number>[<unit>], where unit = b (bytes), k (kilobytes), m (megabytes), or g (gigabytes))
+  Maximum size of a container image.  This flag can be used to set quota on the size of container images. (format: <number>[<unit>], where unit = b (bytes), k (kilobytes), m (megabytes), or g (gigabytes))
 
 **use_deferred_deletion**=""
   Marks thinpool device for deferred deletion. If the thinpool is in use when the driver attempts to delete it, the driver will attempt to delete device every 30 seconds until successful, or when it restarts.  Deferred deletion permanently deletes the device and all data stored in the device will be lost. (default: true).
@@ -166,6 +166,13 @@ The `storage.options.overlay` table supports the following options:
 
 **ignore_chown_errors** = "false"
   ignore_chown_errors can be set to allow a non privileged user running with a  single UID within a user namespace to run containers. The user can pull and use any image even those with multiple uids.  Note multiple UIDs will be squashed down to the default uid in the container.  These images will have no separation between the users in the container. (default: false)
+
+**force_mask** = "0000|shared|private"
+  force_mask sets an octal permission mask that is used for the new files and directories.  The values "native", "shared", "private" are also accepted.  (default: "native")
+  "private": it is equivalent to 0700.  The owner has rwx access to the files.
+  "shared": it is equivalent to 0755.  The owner has rwx access to the files and everyone else can read, access and execute them.
+  It is possible to use **force_mask** only when **mount_program** is specified.
+  Note: The force_mask Flag is an experimental feature, it could change in the future.
 
 **mount_program**=""
   Specifies the path to a custom program to use instead of using kernel defaults

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -60,6 +60,7 @@ type ApplyDiffOpts struct {
 	Mappings          *idtools.IDMappings
 	MountLabel        string
 	IgnoreChownErrors bool
+	ForceMask         *os.FileMode
 }
 
 // InitFunc initializes the storage driver.

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -65,6 +65,8 @@ type (
 		// from the traditional behavior/format to get features like subsecond
 		// precision in timestamps.
 		CopyPass bool
+		// ForceMask, if set, indicates the permission mask used for created files.
+		ForceMask *os.FileMode
 	}
 )
 
@@ -603,18 +605,23 @@ func (ta *tarAppender) addTarFile(path, name string) error {
 	return nil
 }
 
-func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, Lchown bool, chownOpts *idtools.IDPair, inUserns, ignoreChownErrors bool, buffer []byte) error {
+func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, Lchown bool, chownOpts *idtools.IDPair, inUserns, ignoreChownErrors bool, forceMask *os.FileMode, buffer []byte) error {
 	// hdr.Mode is in linux format, which we can use for sycalls,
 	// but for os.Foo() calls we need the mode converted to os.FileMode,
 	// so use hdrInfo.Mode() (they differ for e.g. setuid bits)
 	hdrInfo := hdr.FileInfo()
+
+	mask := hdrInfo.Mode()
+	if forceMask != nil {
+		mask = *forceMask
+	}
 
 	switch hdr.Typeflag {
 	case tar.TypeDir:
 		// Create directory unless it exists as a directory already.
 		// In that case we just want to merge the two
 		if fi, err := os.Lstat(path); !(err == nil && fi.IsDir()) {
-			if err := os.Mkdir(path, hdrInfo.Mode()); err != nil {
+			if err := os.Mkdir(path, mask); err != nil {
 				return err
 			}
 		}
@@ -623,7 +630,7 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, L
 		// Source is regular file. We use system.OpenFileSequential to use sequential
 		// file access to avoid depleting the standby list on Windows.
 		// On Linux, this equates to a regular os.OpenFile
-		file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, hdrInfo.Mode())
+		file, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY, mask)
 		if err != nil {
 			return err
 		}
@@ -697,7 +704,7 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, L
 
 	// There is no LChmod, so ignore mode for symlink. Also, this
 	// must happen after chown, as that can modify the file mode
-	if err := handleLChmod(hdr, path, hdrInfo); err != nil {
+	if err := handleLChmod(hdr, path, hdrInfo, forceMask); err != nil {
 		return err
 	}
 
@@ -1041,7 +1048,7 @@ loop:
 			chownOpts = &idtools.IDPair{UID: hdr.Uid, GID: hdr.Gid}
 		}
 
-		if err := createTarFile(path, dest, hdr, trBuf, !options.NoLchown, chownOpts, options.InUserNS, options.IgnoreChownErrors, buffer); err != nil {
+		if err := createTarFile(path, dest, hdr, trBuf, !options.NoLchown, chownOpts, options.InUserNS, options.IgnoreChownErrors, options.ForceMask, buffer); err != nil {
 			return err
 		}
 

--- a/pkg/archive/archive_linux.go
+++ b/pkg/archive/archive_linux.go
@@ -142,3 +142,15 @@ func isWhiteOut(stat os.FileInfo) bool {
 	s := stat.Sys().(*syscall.Stat_t)
 	return major(uint64(s.Rdev)) == 0 && minor(uint64(s.Rdev)) == 0
 }
+
+func getFileOwner(path string) (uint32, uint32, uint32, error) {
+	f, err := os.Stat(path)
+	if err != nil {
+		return 0, 0, 0, err
+	}
+	s, ok := f.Sys().(*syscall.Stat_t)
+	if ok {
+		return s.Uid, s.Gid, s.Mode & 07777, nil
+	}
+	return 0, 0, uint32(f.Mode()), nil
+}

--- a/pkg/archive/archive_other.go
+++ b/pkg/archive/archive_other.go
@@ -5,3 +5,7 @@ package archive
 func getWhiteoutConverter(format WhiteoutFormat, data interface{}) tarWhiteoutConverter {
 	return nil
 }
+
+func getFileOwner(path string) (uint32, uint32, uint32, error) {
+	return 0, 0, 0, nil
+}

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -829,7 +829,7 @@ func TestTypeXGlobalHeaderDoesNotFail(t *testing.T) {
 	}
 	defer os.RemoveAll(tmpDir)
 	buffer := make([]byte, 1<<20)
-	err = createTarFile(filepath.Join(tmpDir, "pax_global_header"), tmpDir, &hdr, nil, true, nil, false, false, buffer)
+	err = createTarFile(filepath.Join(tmpDir, "pax_global_header"), tmpDir, &hdr, nil, true, nil, false, false, nil, buffer)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/archive/archive_unix.go
+++ b/pkg/archive/archive_unix.go
@@ -106,15 +106,19 @@ func handleTarTypeBlockCharFifo(hdr *tar.Header, path string) error {
 	return system.Mknod(path, mode, int(system.Mkdev(hdr.Devmajor, hdr.Devminor)))
 }
 
-func handleLChmod(hdr *tar.Header, path string, hdrInfo os.FileInfo) error {
+func handleLChmod(hdr *tar.Header, path string, hdrInfo os.FileInfo, forceMask *os.FileMode) error {
+	permissionsMask := hdrInfo.Mode()
+	if forceMask != nil {
+		permissionsMask = *forceMask
+	}
 	if hdr.Typeflag == tar.TypeLink {
 		if fi, err := os.Lstat(hdr.Linkname); err == nil && (fi.Mode()&os.ModeSymlink == 0) {
-			if err := os.Chmod(path, hdrInfo.Mode()); err != nil {
+			if err := os.Chmod(path, permissionsMask); err != nil {
 				return err
 			}
 		}
 	} else if hdr.Typeflag != tar.TypeSymlink {
-		if err := os.Chmod(path, hdrInfo.Mode()); err != nil {
+		if err := os.Chmod(path, permissionsMask); err != nil {
 			return err
 		}
 	}

--- a/pkg/archive/archive_windows.go
+++ b/pkg/archive/archive_windows.go
@@ -69,7 +69,7 @@ func handleTarTypeBlockCharFifo(hdr *tar.Header, path string) error {
 	return nil
 }
 
-func handleLChmod(hdr *tar.Header, path string, hdrInfo os.FileInfo) error {
+func handleLChmod(hdr *tar.Header, path string, hdrInfo os.FileInfo, forceMask *os.FileMode) error {
 	return nil
 }
 

--- a/pkg/archive/diff.go
+++ b/pkg/archive/diff.go
@@ -106,7 +106,7 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 					}
 					defer os.RemoveAll(aufsTempdir)
 				}
-				if err := createTarFile(filepath.Join(aufsTempdir, basename), dest, hdr, tr, true, nil, options.InUserNS, options.IgnoreChownErrors, buffer); err != nil {
+				if err := createTarFile(filepath.Join(aufsTempdir, basename), dest, hdr, tr, true, nil, options.InUserNS, options.IgnoreChownErrors, options.ForceMask, buffer); err != nil {
 					return 0, err
 				}
 			}
@@ -197,7 +197,7 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 				return 0, err
 			}
 
-			if err := createTarFile(path, dest, srcHdr, srcData, true, nil, options.InUserNS, options.IgnoreChownErrors, buffer); err != nil {
+			if err := createTarFile(path, dest, srcHdr, srcData, true, nil, options.InUserNS, options.IgnoreChownErrors, options.ForceMask, buffer); err != nil {
 				return 0, err
 			}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -2,6 +2,7 @@ package config
 
 import (
 	"fmt"
+	"os"
 )
 
 // ThinpoolOptionsConfig represents the "storage.options.thinpool"
@@ -94,6 +95,9 @@ type OverlayOptionsConfig struct {
 	Size string `toml:"size"`
 	// Do not create a bind mount on the storage home
 	SkipMountHome string `toml:"skip_mount_home"`
+	// ForceMask indicates the permissions mask (e.g. "0755") to use for new
+	// files and directories
+	ForceMask string `toml:"force_mask"`
 }
 
 type VfsOptionsConfig struct {
@@ -128,6 +132,10 @@ type OptionsConfig struct {
 	// IgnoreChownErrors is a flag for whether chown errors should be
 	// ignored when building an image.
 	IgnoreChownErrors string `toml:"ignore_chown_errors"`
+
+	// ForceMask indicates the permissions mask (e.g. "0755") to use for new
+	// files and directories.
+	ForceMask os.FileMode `toml:"force_mask"`
 
 	// RemapUser is the name of one or more entries in /etc/subuid which
 	// should be used to set up default UID mappings.
@@ -278,6 +286,11 @@ func GetGraphDriverOptions(driverName string, options OptionsConfig) []string {
 			doptions = append(doptions, fmt.Sprintf("%s.skip_mount_home=%s", driverName, options.Overlay.SkipMountHome))
 		} else if options.SkipMountHome != "" {
 			doptions = append(doptions, fmt.Sprintf("%s.skip_mount_home=%s", driverName, options.SkipMountHome))
+		}
+		if options.Overlay.ForceMask != "" {
+			doptions = append(doptions, fmt.Sprintf("%s.force_mask=%s", driverName, options.Overlay.ForceMask))
+		} else if options.ForceMask != 0 {
+			doptions = append(doptions, fmt.Sprintf("%s.force_mask=%s", driverName, options.ForceMask))
 		}
 	case "vfs":
 		if options.Vfs.IgnoreChownErrors != "" {

--- a/storage.conf
+++ b/storage.conf
@@ -82,6 +82,9 @@ mountopt = "nodev"
 # Size is used to set a maximum size of the container image.
 # size = ""
 
+# ForceMask specifies the permissions mask to use for created files.
+# force_mask = "native"
+
 [storage.options.thinpool]
 # Storage Options for thinpool
 

--- a/store.go
+++ b/store.go
@@ -3551,6 +3551,9 @@ func ReloadConfigurationFile(configFile string, storeOptions *StoreOptions) {
 	if config.Storage.Options.IgnoreChownErrors != "" {
 		storeOptions.GraphDriverOptions = append(storeOptions.GraphDriverOptions, fmt.Sprintf("%s.ignore_chown_errors=%s", config.Storage.Driver, config.Storage.Options.IgnoreChownErrors))
 	}
+	if config.Storage.Options.ForceMask != 0 {
+		storeOptions.GraphDriverOptions = append(storeOptions.GraphDriverOptions, fmt.Sprintf("%s.force_mask=%o", config.Storage.Driver, config.Storage.Options.ForceMask))
+	}
 	if config.Storage.Options.MountOpt != "" {
 		storeOptions.GraphDriverOptions = append(storeOptions.GraphDriverOptions, fmt.Sprintf("%s.mountopt=%s", config.Storage.Driver, config.Storage.Options.MountOpt))
 	}


### PR DESCRIPTION
force_mask sets a permission mask used for the new files and directories.

It is useful for using a NFS share for the rootless storage.  It requires this change in fuse-overlayfs:

permissions_xattr, if it is set then it for each file write its original permissions to the specified extended attribute.

Together with force_mask= it allows to use NFS as a backing store for rootless containers:

https://github.com/containers/fuse-overlayfs/pull/246

```
[storage]
  driver = "overlay"
  graphroot = "/mnt/nfs/home/storage"
  [storage.options]
    mountopt = "xattr_permissions=2"
  [storage.options.overlay]
     force_mask = "0755"
     ignore_chown_errors = "true"
```
    
Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
