### PR TITLE
Stop excessive wrapping

### DIFF
--- a/layers.go
+++ b/layers.go
@@ -907,11 +907,11 @@ func (r *layerStore) ParentOwners(id string) (uids, gids []int, err error) {
 	for dir := filepath.Dir(layer.MountPoint); dir != "" && dir != string(os.PathSeparator); dir = filepath.Dir(dir) {
 		st, err := system.Stat(dir)
 		if err != nil {
-			return nil, nil, errors.Wrapf(err, "error reading ownership of directory %q", dir)
+			return nil, nil, err
 		}
 		lst, err := system.Lstat(dir)
 		if err != nil {
-			return nil, nil, errors.Wrapf(err, "error reading ownership of directory-in-case-it's-a-symlink %q", dir)
+			return nil, nil, err
 		}
 		fsuid := int(st.UID())
 		fsgid := int(st.GID())

--- a/layers.go
+++ b/layers.go
@@ -907,7 +907,7 @@ func (r *layerStore) ParentOwners(id string) (uids, gids []int, err error) {
 	for dir := filepath.Dir(layer.MountPoint); dir != "" && dir != string(os.PathSeparator); dir = filepath.Dir(dir) {
 		st, err := system.Stat(dir)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, errors.Wrap(err, "read directory ownership")
 		}
 		lst, err := system.Lstat(dir)
 		if err != nil {

--- a/store.go
+++ b/store.go
@@ -613,14 +613,14 @@ func GetStore(options StoreOptions) (Store, error) {
 	if options.GraphRoot != "" {
 		dir, err := filepath.Abs(options.GraphRoot)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error deriving an absolute path from %q", options.GraphRoot)
+			return nil, err
 		}
 		options.GraphRoot = dir
 	}
 	if options.RunRoot != "" {
 		dir, err := filepath.Abs(options.RunRoot)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error deriving an absolute path from %q", options.RunRoot)
+			return nil, err
 		}
 		options.RunRoot = dir
 	}

--- a/utils.go
+++ b/utils.go
@@ -76,7 +76,7 @@ func GetRootlessRuntimeDir(rootlessUID int) (string, error) {
 	}
 	path = filepath.Join(path, "containers")
 	if err := os.MkdirAll(path, 0700); err != nil {
-		return "", errors.Wrapf(err, "unable to make rootless runtime dir %s", path)
+		return "", errors.Wrapf(err, "unable to make rootless runtime")
 	}
 	return path, nil
 }
@@ -154,7 +154,7 @@ func getRootlessRuntimeDirIsolated(env rootlessRuntimeDirEnvironment) (string, e
 	}
 	resolvedHomeDir, err := filepath.EvalSymlinks(homeDir)
 	if err != nil {
-		return "", errors.Wrapf(err, "cannot resolve %s", homeDir)
+		return "", err
 	}
 	return filepath.Join(resolvedHomeDir, "rundir"), nil
 }
@@ -190,7 +190,7 @@ func getRootlessDirInfo(rootlessUID int) (string, string, error) {
 	// on CoreOS /home is a symlink to /var/home, so resolve any symlink.
 	resolvedHome, err := filepath.EvalSymlinks(home)
 	if err != nil {
-		return "", "", errors.Wrapf(err, "cannot resolve %s", home)
+		return "", "", err
 	}
 	dataDir = filepath.Join(resolvedHome, ".local", "share")
 
@@ -259,7 +259,7 @@ func defaultStoreOptionsIsolated(rootless bool, rootlessUID int, storageConf str
 	}
 	_, err = os.Stat(storageConf)
 	if err != nil && !os.IsNotExist(err) {
-		return storageOpts, errors.Wrapf(err, "cannot stat %s", storageConf)
+		return storageOpts, err
 	}
 	if err == nil {
 		defaultRootlessRunRoot = storageOpts.RunRoot


### PR DESCRIPTION
Golang built in functions like os.Create and others print the name of
the file system object when they fail.  Wrapping them a second time
with the file system object, makes the error message look like crap
when reported to the user.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>