### PR TITLE
Mention /etc/subuid and /etc/subgid files in error message

### DIFF
--- a/pkg/idtools/idtools.go
+++ b/pkg/idtools/idtools.go
@@ -291,7 +291,7 @@ func parseSubidFile(path, username string) (ranges, error) {
 
 func checkChownErr(err error, name string, uid, gid int) error {
 	if e, ok := err.(*os.PathError); ok && e.Err == syscall.EINVAL {
-		return errors.Wrapf(err, "there might not be enough IDs available in the namespace (requested %d:%d for %s)", uid, gid, name)
+		return errors.Wrapf(err, "potentially insufficient UIDs or GIDs available in user namespace (requested %d:%d for %s): Check /etc/subuid and /etc/subgid", uid, gid, name)
 	}
 	return err
 }


### PR DESCRIPTION
Sometimes users are hitting errors caused by insufficient uids/gids
in their user namespace. This is often caused by bad ranges or no ranges
in /etc/subuid and /etc/subgid files.

This PR attempts to improve the error message reporting the failure and
points users at these files.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>