### PR TITLE
 Cleanup code to explain what is going on here. 

### DIFF
--- a/store.go
+++ b/store.go
@@ -2677,21 +2677,16 @@ func (s *store) MountImage(id string, mountOpts []string, mountLabel string) (st
 }
 
 func (s *store) Mount(id, mountLabel string) (string, error) {
-	container, err := s.Container(id)
-	var (
-		uidMap, gidMap []idtools.IDMap
-		mountOpts      []string
-	)
-	if err == nil {
-		uidMap, gidMap = container.UIDMap, container.GIDMap
-		id = container.LayerID
-		mountOpts = container.MountOpts()
-	}
 	options := drivers.MountOpts{
 		MountLabel: mountLabel,
-		UidMaps:    uidMap,
-		GidMaps:    gidMap,
-		Options:    mountOpts,
+	}
+	// check if `id` is a container, then grab the LayerID, uidmap and gidmap, along with
+	// otherwise we assume the id is a LayerID and attempt to mount it.
+	if container, err := s.Container(id); err == nil {
+		id = container.LayerID
+		options.UidMaps = container.UIDMap
+		options.GidMaps = container.GIDMap
+		options.Options = container.MountOpts()
 	}
 	return s.mount(id, options)
 }


### PR DESCRIPTION
I got fooled by this code, and attempted a PR to clean it up, that
was a mistake.  I assumed that the call should fail if the Container
call failed. But the store.Mount(id, mountlabel) handles container
mounts as well as layer mounts. This means the ID could be a container
or a different layer. When the attempt to read the container fails, we
continue assuming that the id is a layer and attempt to mount it as a layer.
If the id is a container then we grap the toplayer of the container and use
it is as an id.

This PR does not change the functionality of the code, but makes it easier
for future programmers to understand the functionality.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>