### PR TITLE
platformLchown: use os package instead

### DIFF
--- a/drivers/chown_unix.go
+++ b/drivers/chown_unix.go
@@ -54,7 +54,7 @@ func platformLChown(path string, info os.FileInfo, toHost, toContainer *idtools.
 		}
 
 		// Make the change.
-		if err := syscall.Lchown(path, uid, gid); err != nil {
+		if err := os.Lchown(path, uid, gid); err != nil {
 			return fmt.Errorf("%s: chown(%q): %v", os.Args[0], path, err)
 		}
 		// Restore the SUID and SGID bits if they were originally set.


### PR DESCRIPTION
go 1.14 and beyond doesn't catch EINTR in the syscall package anymore. This causes manual calls to the syscall package to fail from interrupts, which is really not a failure, as the command should just be retried.

however, the os package does this for us. Luckily, there's an `os.Lchown`

unfortunately, for the other syscall functions, there will need to be a function wrapper, but I believe that should be addressed in a separate PR

Signed-off-by: Peter Hunt <pehunt@redhat.com>