### PR TITLE
If caller Sets the DefaultConfigFilePath, we need to use it

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -260,7 +260,7 @@ func defaultStoreOptionsIsolated(rootless bool, rootlessUID int, storageConf str
 	if err != nil && !os.IsNotExist(err) {
 		return storageOpts, err
 	}
-	if err == nil {
+	if err == nil && !defaultConfigFileSet {
 		defaultRootlessRunRoot = storageOpts.RunRoot
 		defaultRootlessGraphRoot = storageOpts.GraphRoot
 		storageOpts = StoreOptions{}


### PR DESCRIPTION
Attempting to override the location of the storage.conf file, using
the SetDefaultConfigFilePath for testing is failing in Podman.

This patch will use the replace configuration file.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>