### PR TITLE
archive: defer close after DecompressStream to fix resource leak

### DIFF
--- a/layers.go
+++ b/layers.go
@@ -1329,6 +1329,7 @@ func (r *layerStore) ApplyDiff(to string, diff io.Reader) (size int64, err error
 	if err != nil {
 		return -1, err
 	}
+	defer uncompressed.Close()
 	uncompressedDigest := digest.Canonical.Digester()
 	uncompressedCounter := ioutils.NewWriteCounter(uncompressedDigest.Hash())
 	uidLog := make(map[uint32]struct{})

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -139,6 +139,7 @@ func IsArchivePath(path string) bool {
 	if err != nil {
 		return false
 	}
+	defer rdr.Close()
 	r := tar.NewReader(rdr)
 	_, err = r.Next()
 	return err == nil


### PR DESCRIPTION
Archive: defer close after DecompressStream to fix resource leak

Signed-off-by: yangfeiyu <yangfeiyu20102011@163.com>