### PR TITLE
chmod/chown: handle EINTR

### DIFF
--- a/drivers/chown_unix.go
+++ b/drivers/chown_unix.go
@@ -54,12 +54,12 @@ func platformLChown(path string, info os.FileInfo, toHost, toContainer *idtools.
 		}
 
 		// Make the change.
-		if err := os.Lchown(path, uid, gid); err != nil {
+		if err := system.Lchown(path, uid, gid); err != nil {
 			return fmt.Errorf("%s: %v", os.Args[0], err)
 		}
 		// Restore the SUID and SGID bits if they were originally set.
 		if (info.Mode()&os.ModeSymlink == 0) && info.Mode()&(os.ModeSetuid|os.ModeSetgid) != 0 {
-			if err := os.Chmod(path, info.Mode()); err != nil {
+			if err := system.Chmod(path, info.Mode()); err != nil {
 				return fmt.Errorf("%s: %v", os.Args[0], err)
 			}
 		}

--- a/drivers/chown_unix.go
+++ b/drivers/chown_unix.go
@@ -55,12 +55,12 @@ func platformLChown(path string, info os.FileInfo, toHost, toContainer *idtools.
 
 		// Make the change.
 		if err := os.Lchown(path, uid, gid); err != nil {
-			return fmt.Errorf("%s: chown(%q): %v", os.Args[0], path, err)
+			return fmt.Errorf("%s: %v", os.Args[0], err)
 		}
 		// Restore the SUID and SGID bits if they were originally set.
 		if (info.Mode()&os.ModeSymlink == 0) && info.Mode()&(os.ModeSetuid|os.ModeSetgid) != 0 {
 			if err := os.Chmod(path, info.Mode()); err != nil {
-				return fmt.Errorf("%s: chmod(%q): %v", os.Args[0], path, err)
+				return fmt.Errorf("%s: %v", os.Args[0], err)
 			}
 		}
 		if cap != nil {

--- a/pkg/system/chmod.go
+++ b/pkg/system/chmod.go
@@ -1,0 +1,17 @@
+package system
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+func Chmod(name string, mode os.FileMode) error {
+	err := os.Chmod(name, mode)
+
+	for err != nil && errors.Is(err, syscall.EINTR) {
+		err = os.Chmod(name, mode)
+	}
+
+	return err
+}

--- a/pkg/system/lchown.go
+++ b/pkg/system/lchown.go
@@ -1,0 +1,20 @@
+package system
+
+import (
+	"os"
+	"syscall"
+)
+
+func Lchown(name string, uid, gid int) error {
+	err := syscall.Lchown(name, uid, gid)
+
+	for err == syscall.EINTR {
+		err = syscall.Lchown(name, uid, gid)
+	}
+
+	if err != nil {
+		return &os.PathError{Op: "lchown", Path: name, Err: err}
+	}
+
+	return nil
+}


### PR DESCRIPTION
The following failure has been observed in CI (see [1], [2]):
    
        storage-chown-by-maps: chown("xxx"): interrupted system call
    
While chown and chmod should be auto-restartable by the kernel (provided
all the signal handlers are installed with SA_RESTART flag), it looks
like it is not always the case, or there might be some exclusions,
so this should be handled.
    
Surely, the possibility of getting EINTR is amplified since Go 1.14
introduced async preemptible goroutimes (see [3]), the feature that
is implemented via frequently sending signal 22 to all threads.
    
Add and use wrappers for Chmod and Lchown that retry on EINTR.

[1] https://github.com/containers/podman/issues/8152
[2] https://github.com/cri-o/cri-o/pull/4310#issuecomment-718361022
[3] https://golang.org/doc/go1.14#runtime

Previous attempt to fix this: https://github.com/containers/storage/pull/751