### PR TITLE
system.*xattr: wrap errors into os.PathError

### DIFF
--- a/drivers/chown_unix.go
+++ b/drivers/chown_unix.go
@@ -50,7 +50,7 @@ func platformLChown(path string, info os.FileInfo, toHost, toContainer *idtools.
 	if uid != int(st.Uid) || gid != int(st.Gid) {
 		cap, err := system.Lgetxattr(path, "security.capability")
 		if err != nil && err != system.ErrNotSupportedPlatform {
-			return fmt.Errorf("%s: Lgetxattr(%q): %v", os.Args[0], path, err)
+			return fmt.Errorf("%s: %v", os.Args[0], err)
 		}
 
 		// Make the change.
@@ -65,7 +65,7 @@ func platformLChown(path string, info os.FileInfo, toHost, toContainer *idtools.
 		}
 		if cap != nil {
 			if err := system.Lsetxattr(path, "security.capability", cap, 0); err != nil {
-				return fmt.Errorf("%s: Lsetxattr(%q): %v", os.Args[0], path, err)
+				return fmt.Errorf("%s: %v", os.Args[0], err)
 			}
 		}
 

--- a/drivers/copy/copy_linux.go
+++ b/drivers/copy/copy_linux.go
@@ -12,6 +12,7 @@ package copy
 import "C"
 import (
 	"container/list"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -98,7 +99,7 @@ func legacyCopy(srcFile io.Reader, dstFile io.Writer) error {
 
 func copyXattr(srcPath, dstPath, attr string) error {
 	data, err := system.Lgetxattr(srcPath, attr)
-	if err != nil && err != unix.EOPNOTSUPP {
+	if err != nil && !errors.Is(err, unix.EOPNOTSUPP) {
 		return err
 	}
 	if data != nil {
@@ -269,7 +270,7 @@ func doCopyXattrs(srcPath, dstPath string) error {
 	}
 
 	xattrs, err := system.Llistxattr(srcPath)
-	if err != nil && err != unix.EOPNOTSUPP {
+	if err != nil && !errors.Is(err, unix.EOPNOTSUPP) {
 		return err
 	}
 

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -399,7 +399,7 @@ func ReadSecurityXattrToTarHeader(path string, hdr *tar.Header) error {
 	}
 	for _, xattr := range []string{"security.capability", "security.ima"} {
 		capability, err := system.Lgetxattr(path, xattr)
-		if err != nil && err != system.EOPNOTSUPP && err != system.ErrNotSupportedPlatform {
+		if err != nil && !errors.Is(err, system.EOPNOTSUPP) && err != system.ErrNotSupportedPlatform {
 			return errors.Wrapf(err, "failed to read %q attribute from %q", xattr, path)
 		}
 		if capability != nil {
@@ -412,17 +412,17 @@ func ReadSecurityXattrToTarHeader(path string, hdr *tar.Header) error {
 // ReadUserXattrToTarHeader reads user.* xattr from filesystem to a tar header
 func ReadUserXattrToTarHeader(path string, hdr *tar.Header) error {
 	xattrs, err := system.Llistxattr(path)
-	if err != nil && err != system.EOPNOTSUPP && err != system.ErrNotSupportedPlatform {
+	if err != nil && !errors.Is(err, system.EOPNOTSUPP) && err != system.ErrNotSupportedPlatform {
 		return err
 	}
 	for _, key := range xattrs {
 		if strings.HasPrefix(key, "user.") {
 			value, err := system.Lgetxattr(path, key)
-			if err == system.E2BIG {
-				logrus.Errorf("archive: Skipping xattr for file %s since value is too big: %s", path, key)
-				continue
-			}
 			if err != nil {
+				if errors.Is(err, system.E2BIG) {
+					logrus.Errorf("archive: Skipping xattr for file %s since value is too big: %s", path, key)
+					continue
+				}
 				return err
 			}
 			if hdr.Xattrs == nil {
@@ -725,16 +725,16 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, L
 		}
 	}
 
-	var errors []string
+	var errs []string
 	for key, value := range hdr.Xattrs {
 		if err := system.Lsetxattr(path, key, []byte(value), 0); err != nil {
-			if err == syscall.ENOTSUP || (err == syscall.EPERM && inUserns) {
+			if errors.Is(err, syscall.ENOTSUP) || (inUserns && errors.Is(err, syscall.EPERM)) {
 				// We ignore errors here because not all graphdrivers support
 				// xattrs *cough* old versions of AUFS *cough*. However only
 				// ENOTSUP should be emitted in that case, otherwise we still
 				// bail.  We also ignore EPERM errors if we are running in a
 				// user namespace.
-				errors = append(errors, err.Error())
+				errs = append(errs, err.Error())
 				continue
 			}
 			return err
@@ -742,9 +742,9 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, L
 
 	}
 
-	if len(errors) > 0 {
+	if len(errs) > 0 {
 		logrus.WithFields(logrus.Fields{
-			"errors": errors,
+			"errors": errs,
 		}).Warn("ignored xattrs in archive: underlying filesystem doesn't support them")
 	}
 


### PR DESCRIPTION
This way the error messages are more informative, and the use of the functions are more in-line with the standard ones (from `os). From the other side, it introduces a hassle of properly unwinding the errors (and this is why I hesitated to make this change).

Convert all the users accordingly (assuming there are no users outside of this repo).
