### PR TITLE
Restore usage of rootless_storage_path in user storage.conf

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -273,7 +273,11 @@ func defaultStoreOptionsIsolated(rootless bool, rootlessUID int, storageConf str
 				storageOpts.RunRoot = defaultRootlessRunRoot
 			}
 			if storageOpts.GraphRoot == "" {
-				storageOpts.GraphRoot = defaultRootlessGraphRoot
+				if storageOpts.RootlessStoragePath != "" {
+					storageOpts.GraphRoot = storageOpts.RootlessStoragePath
+				} else {
+					storageOpts.GraphRoot = defaultRootlessGraphRoot
+				}
 			}
 		}
 	}


### PR DESCRIPTION
Ref: #733
With this PR the usage of rootless_storage_path from user configuration is restored.
The order of precedence in which the storage path for rootless run is taken is as follows:

1. graphroot defined in $HOME/.config/containers/storage.conf
2. rootless_storage_path defined in $HOME/.config/containers/storage.conf
3. rootless_storage_path defined in /etc/containers/storage.conf
4. podman default ($HOME/.local/share/containers/storage)