### PR TITLE
Cirrus: Avoid upgrading grub-efi-amd64-signed

### DIFF
--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -99,6 +99,9 @@ RPMS_CONFLICTING="gcc-go"
 # https://github.com/containers/libpod/blob/master/contrib/cirrus/packer/ubuntu_setup.sh
 DEBS_REQUIRED="parallel"
 DEBS_CONFLICTING=""
+# Upgrading grub-efi-amd64-signed doesn't make sense at test-runtime
+# and has some config. scripts which frequently fail.  Block updates
+DEBS_HOLD="grub-efi-amd64-signed"
 
 # For devicemapper testing, device names need to be passed down for use in tests
 if [[ "$TEST_DRIVER" == "devicemapper" ]]; then

--- a/contrib/cirrus/setup.sh
+++ b/contrib/cirrus/setup.sh
@@ -26,6 +26,8 @@ case "$OS_RELEASE_ID" in
         ;;
     ubuntu)
         $SHORT_APTGET update  # Fetch latest package metadata
+        [[ -z "$DEBS_HOLD" ]] || \
+            apt-mark hold $DEBS_HOLD
         $LONG_APTGET upgrade # install latest packages
         [[ -z "$DEBS_REQUIRED" ]] || \
             $SHORT_APTGET -q install $DEBS_REQUIRED


### PR DESCRIPTION
Fixes error encountered in #757 CI:

```
[+0546s] Attempt 7 of 7 (retry on non-zero exit):
[+0546s] Reading package lists...
[+0546s] Building dependency tree...
[+0546s] Reading state information...
[+0546s] Calculating upgrade...
[+0546s] The following packages have been kept back:
[+0546s]   base-files linux-gcp linux-headers-gcp linux-image-gcp sosreport
[+0546s]   ubuntu-server
[+0547s] 0 upgraded, 0 newly installed, 0 to remove and 6 not upgraded.
[+0547s] 1 not fully installed or removed.
[+0547s] After this operation, 0 B of additional disk space will be used.
[+0547s] Setting up grub-efi-amd64-signed (1.142.8+2.04-1ubuntu26.6) ...
[+0547s] mount: /var/lib/grub/esp: special device /dev/disk/by-id/google-persistent-disk-0-part15 does not exist.
[+0547s] dpkg: error processing package grub-efi-amd64-signed (--configure):
[+0547s]  installed grub-efi-amd64-signed package post-installation script subprocess returned error exit status 32
[+0547s] Errors were encountered while processing:
[+0547s]  grub-efi-amd64-signed
[+0548s] E: Sub-process /usr/bin/dpkg returned an error code (1)
[+0548s]     exit(100)
[+0548s] Retry attempts exhausted
```