### PR TITLE
chmod/chown: handle EINTR

### DIFF
--- a/drivers/chown_unix.go
+++ b/drivers/chown_unix.go
@@ -54,12 +54,12 @@ func platformLChown(path string, info os.FileInfo, toHost, toContainer *idtools.
 		}
 
 		// Make the change.
-		if err := syscall.Lchown(path, uid, gid); err != nil {
+		if err := system.Lchown(path, uid, gid); err != nil {
 			return fmt.Errorf("%s: %v", os.Args[0], err)
 		}
 		// Restore the SUID and SGID bits if they were originally set.
 		if (info.Mode()&os.ModeSymlink == 0) && info.Mode()&(os.ModeSetuid|os.ModeSetgid) != 0 {
-			if err := os.Chmod(path, info.Mode()); err != nil {
+			if err := system.Chmod(path, info.Mode()); err != nil {
 				return fmt.Errorf("%s: %v", os.Args[0], err)
 			}
 		}

--- a/drivers/chown_unix.go
+++ b/drivers/chown_unix.go
@@ -55,12 +55,12 @@ func platformLChown(path string, info os.FileInfo, toHost, toContainer *idtools.
 
 		// Make the change.
 		if err := syscall.Lchown(path, uid, gid); err != nil {
-			return fmt.Errorf("%s: chown(%q): %v", os.Args[0], path, err)
+			return fmt.Errorf("%s: %v", os.Args[0], err)
 		}
 		// Restore the SUID and SGID bits if they were originally set.
 		if (info.Mode()&os.ModeSymlink == 0) && info.Mode()&(os.ModeSetuid|os.ModeSetgid) != 0 {
 			if err := os.Chmod(path, info.Mode()); err != nil {
-				return fmt.Errorf("%s: chmod(%q): %v", os.Args[0], path, err)
+				return fmt.Errorf("%s: %v", os.Args[0], err)
 			}
 		}
 		if cap != nil {

--- a/pkg/system/chmod.go
+++ b/pkg/system/chmod.go
@@ -1,0 +1,17 @@
+package system
+
+import (
+	"errors"
+	"os"
+	"syscall"
+)
+
+func Chmod(name string, mode os.FileMode) error {
+	err := os.Chmod(name, mode)
+
+	for err != nil && errors.Is(err, syscall.EINTR) {
+		err = os.Chmod(name, mode)
+	}
+
+	return err
+}

--- a/pkg/system/chmod.go
+++ b/pkg/system/chmod.go
@@ -1,7 +1,6 @@
 package system
 
 import (
-	"errors"
 	"os"
 	"syscall"
 )
@@ -9,9 +8,24 @@ import (
 func Chmod(name string, mode os.FileMode) error {
 	err := os.Chmod(name, mode)
 
-	for err != nil && errors.Is(err, syscall.EINTR) {
+	for isEINTR(err) {
 		err = os.Chmod(name, mode)
 	}
 
 	return err
+}
+
+func isEINTR(err error) bool {
+	if err == nil {
+		return false
+	}
+	pathErr, ok := err.(*os.PathError)
+	if !ok {
+		return false
+	}
+	syscallErr, ok := pathErr.Err.(*syscall.Errno)
+	if !ok {
+		return false
+	}
+	return *syscallErr == syscall.EINTR
 }

--- a/pkg/system/lchown.go
+++ b/pkg/system/lchown.go
@@ -1,0 +1,20 @@
+package system
+
+import (
+	"os"
+	"syscall"
+)
+
+func Lchown(name string, uid, gid int) error {
+	err := syscall.Lchown(name, uid, gid)
+
+	for err == syscall.EINTR {
+		err = syscall.Lchown(name, uid, gid)
+	}
+
+	if err != nil {
+		return &os.PathError{Op: "lchown", Path: name, Err: err}
+	}
+
+	return nil
+}


### PR DESCRIPTION
release 1.20 cherry-pick of https://github.com/containers/storage/pull/757, which will go into cri-o 1.19 (which builds off of go 1.15, and is susceptible to this problem)