### PR TITLE
Need to load nsswitch based config outside of container

### DIFF
--- a/pkg/chrootarchive/archive.go
+++ b/pkg/chrootarchive/archive.go
@@ -5,7 +5,9 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"os"
+	"os/user"
 	"path/filepath"
 	"sync"
 
@@ -14,6 +16,13 @@ import (
 	rsystem "github.com/opencontainers/runc/libcontainer/system"
 	"github.com/pkg/errors"
 )
+
+func init() {
+	// initialize nss libraries in Glibc so that the dynamic libraries are loaded in the host
+	// environment not in the chroot from untrusted files.
+	_, _ = user.Lookup("storage")
+	_, _ = net.LookupHost("localhost")
+}
 
 // NewArchiver returns a new Archiver which uses chrootarchive.Untar
 func NewArchiver(idMappings *idtools.IDMappings) *archive.Archiver {


### PR DESCRIPTION
Fix CVE-2019-14271 loading of nsswitch based config inside chroot under Glibc

Based on code from moby

https://github.com/moby/moby/pull/39612/files

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>