### PR TITLE
Fix unshare.HomeDir to use entry in /etc/passwd

### DIFF
--- a/pkg/unshare/unshare.go
+++ b/pkg/unshare/unshare.go
@@ -26,6 +26,7 @@ func HomeDir() (string, error) {
 				return
 			}
 			homeDir, homeDirErr = usr.HomeDir, nil
+			return
 		}
 		homeDir, homeDirErr = home, nil
 	})


### PR DESCRIPTION
We were never using the entry in the /etc/passwd file
if $HOME was not set.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>