### PR TITLE
Fix reading of ~/.config/containers/storage.conf

### DIFF
--- a/utils.go
+++ b/utils.go
@@ -255,6 +255,7 @@ func defaultStoreOptionsIsolated(rootless bool, rootlessUID int, storageConf str
 		if err != nil {
 			return storageOpts, err
 		}
+		return storageOpts, nil
 	}
 	_, err = os.Stat(storageConf)
 	if err != nil && !os.IsNotExist(err) {


### PR DESCRIPTION
Currently rootless users of storage.conf in the home
dir ignore the storage options.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>