### PR TITLE
Revert returning storageOpts

### DIFF
--- a/docs/containers-storage.conf.5.md
+++ b/docs/containers-storage.conf.5.md
@@ -27,8 +27,9 @@ No bare options are used. The format of TOML can be simplified to:
 The `storage` table supports the following options:
 
 **driver**=""
-  container storage driver (default: "overlay")
+  container storage driver
   Default Copy On Write (COW) container storage driver. Valid drivers are "overlay", "vfs", "devmapper", "aufs", "btrfs", and "zfs". Some drivers (for example, "zfs", "btrfs", and "aufs") may not work if your kernel lacks support for the filesystem.
+  This field is requiered to guarantee proper operation.
 
 **graphroot**=""
   container storage graph dir (default: "/var/lib/containers/storage")

--- a/storage.conf
+++ b/storage.conf
@@ -4,7 +4,7 @@
 # The "container storage" table contains all of the server options.
 [storage]
 
-# Default Storage Driver
+# Default Storage Driver, Must be set for proper operation.
 driver = ""
 
 # Temporary storage location

--- a/store.go
+++ b/store.go
@@ -30,6 +30,7 @@ import (
 	digest "github.com/opencontainers/go-digest"
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 )
 
 var (
@@ -3526,6 +3527,9 @@ func ReloadConfigurationFile(configFile string, storeOptions *StoreOptions) {
 	}
 	if config.Storage.Driver != "" {
 		storeOptions.GraphDriverName = config.Storage.Driver
+	}
+	if storeOptions.GraphDriverName == "" {
+		logrus.Errorf("The storage 'driver' option must be set in %s, guarantee proper operation.", configFile)
 	}
 	if config.Storage.RunRoot != "" {
 		storeOptions.RunRoot = config.Storage.RunRoot

--- a/utils.go
+++ b/utils.go
@@ -255,7 +255,6 @@ func defaultStoreOptionsIsolated(rootless bool, rootlessUID int, storageConf str
 		if err != nil {
 			return storageOpts, err
 		}
-		return storageOpts, nil
 	}
 	_, err = os.Stat(storageConf)
 	if err != nil && !os.IsNotExist(err) {


### PR DESCRIPTION
I merged a patch that was a mistake that returned
rootless storage opts early. User had a broken
storage.conf that caused me to get confused.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>