### PR TITLE
archive: Skip FIFO creation in userns

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -641,16 +641,10 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, L
 		}
 		file.Close()
 
-	case tar.TypeBlock, tar.TypeChar:
+	case tar.TypeBlock, tar.TypeChar, tar.TypeFifo:
 		if inUserns { // cannot create devices in a userns
 			return nil
 		}
-		// Handle this is an OS-specific way
-		if err := handleTarTypeBlockCharFifo(hdr, path); err != nil {
-			return err
-		}
-
-	case tar.TypeFifo:
 		// Handle this is an OS-specific way
 		if err := handleTarTypeBlockCharFifo(hdr, path); err != nil {
 			return err


### PR DESCRIPTION
handleTarTypeBlockCharFifo() would skip the creation anyway, so let's return earlier and avoid later problems with failing chown/chmod calls.

Reproducer:
1. Configure ~/.config/containers/storage.conf to use the "vfs" driver for a non-root user
2. As non-root run: `podman pull docker.io/library/openjdk:14`

It will fail with:

```
ERRO[0048] Error while applying layer: ApplyLayer exit status 1 stdout:  stderr: lchown /dev/initctl: no such file or directory 
```