### PR TITLE
layers: support BigData

### DIFF
--- a/docs/containers-storage-get-layer-data.md
+++ b/docs/containers-storage-get-layer-data.md
@@ -1,0 +1,21 @@
+## containers-storage-get-layer-data 1 "December 2020"
+
+## NAME
+containers-storage get-layer-data - Retrieve lookaside data for a layer
+
+## SYNOPSIS
+**containers-storage** **get-layer-data** [*options* [...]] *layerID* *dataName*
+
+## DESCRIPTION
+Retrieves a piece of named data which is associated with a layer.
+
+## OPTIONS
+**-f | --file** *file*
+
+Write the data to a file instead of stdout.
+
+## EXAMPLE
+**containers-storage get-layer-data -f config.json 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824 configuration**
+
+## SEE ALSO
+containers-storage-set-layer-data(1)

--- a/docs/containers-storage-list-layer-data.md
+++ b/docs/containers-storage-list-layer-data.md
@@ -1,0 +1,18 @@
+## containers-storage-list-layer-data 1 "December 2020"
+
+## NAME
+containers-storage list-layer-data - List lookaside data for an layer
+
+## SYNOPSIS
+**containers-storage** **list-layer-data** *layerID*
+
+## DESCRIPTION
+List the pieces of named data which are associated with an layer.
+
+## EXAMPLE
+**containers-storage list-layer-data 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824**
+
+## SEE ALSO
+containers-storage-get-layer-data(1)
+containers-storage-get-layer-data-digest(1)
+containers-storage-set-layer-data(1)

--- a/docs/containers-storage-set-layer-data.md
+++ b/docs/containers-storage-set-layer-data.md
@@ -1,0 +1,21 @@
+## containers-storage-set-layer-data 1 "December 2020"
+
+## NAME
+containers-storage set-layer-data - Set lookaside data for a layer
+
+## SYNOPSIS
+**containers-storage** **set-layer-data** [*options* [...]] *layerID* *dataName*
+
+## DESCRIPTION
+Sets a piece of named data which is associated with a layer.
+
+## OPTIONS
+**-f | --file** *filename*
+
+Read the data contents from a file instead of stdin.
+
+## EXAMPLE
+**containers-storage set-layer-data -f ./config.json 2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824 configuration**
+
+## SEE ALSO
+containers-storage-get-layer-data(1)

--- a/store.go
+++ b/store.go
@@ -122,6 +122,30 @@ type ContainerBigDataStore interface {
 	SetBigData(id, key string, data []byte) error
 }
 
+// A ROLayerBigDataStore wraps up how we store RO big-data associated with layers.
+type ROLayerBigDataStore interface {
+	// SetBigData stores a (potentially large) piece of data associated
+	// with this ID.
+	BigData(id, key string) (io.ReadCloser, error)
+
+	// BigDataNames() returns a list of the names of previously-stored pieces of
+	// data.
+	BigDataNames(id string) ([]string, error)
+}
+
+// A RWLayerBigDataStore wraps up how we store big-data associated with layers.
+type RWLayerBigDataStore interface {
+	// SetBigData stores a (potentially large) piece of data associated
+	// with this ID.
+	SetBigData(id, key string, data io.Reader) error
+}
+
+// A LayerBigDataStore wraps up how we store big-data associated with layers.
+type LayerBigDataStore interface {
+	ROLayerBigDataStore
+	RWLayerBigDataStore
+}
+
 // A FlaggableStore can have flags set and cleared on items which it manages.
 type FlaggableStore interface {
 	// ClearFlag removes a named flag from an item in the store.
@@ -384,6 +408,18 @@ type Store interface {
 	// github.com/containers/image/manifest.Digest as digestManifest to
 	// allow ImagesByDigest to find images by their correct digests.
 	SetImageBigData(id, key string, data []byte, digestManifest func([]byte) (digest.Digest, error)) error
+
+	// ListLayerBigData retrieves a list of the (possibly large) chunks of
+	// named data associated with an layer.
+	ListLayerBigData(id string) ([]string, error)
+
+	// LayerBigData retrieves a (possibly large) chunk of named data
+	// associated with a layer.
+	LayerBigData(id, key string) (io.ReadCloser, error)
+
+	// SetLayerBigData stores a (possibly large) chunk of named data
+	// associated with a layer.
+	SetLayerBigData(id, key string, data io.Reader) error
 
 	// ImageSize computes the size of the image's layers and ancillary data.
 	ImageSize(id string) (int64, error)
@@ -1625,6 +1661,95 @@ func (s *store) ImageBigData(id, key string) ([]byte, error) {
 		return nil, errors.Wrapf(os.ErrNotExist, "error locating item named %q for image with ID %q", key, id)
 	}
 	return nil, errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
+}
+
+// ListLayerBigData retrieves a list of the (possibly large) chunks of
+// named data associated with an layer.
+func (s *store) ListLayerBigData(id string) ([]string, error) {
+	lstore, err := s.LayerStore()
+	if err != nil {
+		return nil, err
+	}
+	lstores, err := s.ROLayerStores()
+	if err != nil {
+		return nil, err
+	}
+	foundLayer := false
+	for _, s := range append([]ROLayerStore{lstore}, lstores...) {
+		store := s
+		store.RLock()
+		defer store.Unlock()
+		if modified, err := store.Modified(); modified || err != nil {
+			if err = store.Load(); err != nil {
+				return nil, err
+			}
+		}
+		data, err := store.BigDataNames(id)
+		if err == nil {
+			return data, nil
+		}
+		if store.Exists(id) {
+			foundLayer = true
+		}
+	}
+	if foundLayer {
+		return nil, errors.Wrapf(os.ErrNotExist, "error locating big data for layer with ID %q", id)
+	}
+	return nil, errors.Wrapf(ErrLayerUnknown, "error locating layer with ID %q", id)
+}
+
+// LayerBigData retrieves a (possibly large) chunk of named data
+// associated with a layer.
+func (s *store) LayerBigData(id, key string) (io.ReadCloser, error) {
+	lstore, err := s.LayerStore()
+	if err != nil {
+		return nil, err
+	}
+	lstores, err := s.ROLayerStores()
+	if err != nil {
+		return nil, err
+	}
+	foundLayer := false
+	for _, s := range append([]ROLayerStore{lstore}, lstores...) {
+		store := s
+		store.RLock()
+		defer store.Unlock()
+		if modified, err := store.Modified(); modified || err != nil {
+			if err = store.Load(); err != nil {
+				return nil, err
+			}
+		}
+		data, err := store.BigData(id, key)
+		if err == nil {
+			return data, nil
+		}
+		if store.Exists(id) {
+			foundLayer = true
+		}
+	}
+	if foundLayer {
+		return nil, errors.Wrapf(os.ErrNotExist, "error locating item named %q for layer with ID %q", key, id)
+	}
+	return nil, errors.Wrapf(ErrLayerUnknown, "error locating layer with ID %q", id)
+}
+
+// SetLayerBigData stores a (possibly large) chunk of named data
+// associated with a layer.
+func (s *store) SetLayerBigData(id, key string, data io.Reader) error {
+	store, err := s.LayerStore()
+	if err != nil {
+		return err
+	}
+
+	store.Lock()
+	defer store.Unlock()
+	if modified, err := store.Modified(); modified || err != nil {
+		if err = store.Load(); err != nil {
+			return nil
+		}
+	}
+
+	return store.SetBigData(id, key, data)
 }
 
 func (s *store) SetImageBigData(id, key string, data []byte, digestManifest func([]byte) (digest.Digest, error)) error {


### PR DESCRIPTION
similarly to containers and images, add support for storing big data
also for layers, so that it is possible to store arbitrary data when
it is not feasible to embed it in the layers JSON metadata file.

Subset of: https://github.com/containers/storage/pull/775
    
Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
