### PR TITLE
Switch references of /var/run -> /run

### DIFF
--- a/docs/containers-storage.conf.5.md
+++ b/docs/containers-storage.conf.5.md
@@ -46,7 +46,7 @@ The `storage` table supports the following options:
   A common use case for this field is to provide a local storage directory when user home directories are NFS-mounted (podman does not support container storage over NFS).
 
 **runroot**=""
-  container storage run dir (default: "/var/run/containers/storage")
+  container storage run dir (default: "/run/containers/storage")
   Default directory to store all temporary writable content created by container storage programs.
   The rootless runroot path supports environment variable substitutions (ie. `$HOME/containers/storage`)
 

--- a/docs/containers-storage.md
+++ b/docs/containers-storage.md
@@ -135,7 +135,7 @@ Increases the amount of debugging information which is printed.
 Overrides the root of the storage tree, used for storing layer contents and
 information about layers, images, and containers.
 
-**--run, -R=/var/run/containers/storage**
+**--run, -R=/run/containers/storage**
 
 Overrides the root of the runtime state tree, currently used mainly for noting
 the location where a given layer is mounted (see **containers-storage mount**) so that

--- a/storage.conf
+++ b/storage.conf
@@ -8,7 +8,7 @@
 driver = ""
 
 # Temporary storage location
-runroot = "/var/run/containers/storage"
+runroot = "/run/containers/storage"
 
 # Primary Read/Write location of container storage
 graphroot = "/var/lib/containers/storage"

--- a/store.go
+++ b/store.go
@@ -3640,7 +3640,7 @@ func reloadConfigurationFileIfNeeded(configFile string, storeOptions *StoreOptio
 }
 
 func init() {
-	defaultStoreOptions.RunRoot = "/var/run/containers/storage"
+	defaultStoreOptions.RunRoot = "/run/containers/storage"
 	defaultStoreOptions.GraphRoot = "/var/lib/containers/storage"
 	defaultStoreOptions.GraphDriverName = ""
 


### PR DESCRIPTION
Systemd is now complaining or mentioning /var/run as a legacy directory.
It has been many years where /var/run is a symlink to /run on all
most distributions, make the change to the default.

Partial fix for https://github.com/containers/podman/issues/8369

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>