### PR TITLE
idtools: handle single user mapped as root

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -761,19 +761,29 @@ func (d *Driver) optsAppendMappings(opts string, uidMaps, gidMaps []idtools.IDMa
 	}
 	if uidMaps != nil {
 		var uids, gids bytes.Buffer
-		for _, i := range uidMaps {
-			if uids.Len() > 0 {
-				uids.WriteString(":")
+		if len(uidMaps) == 1 && uidMaps[0].Size == 1 {
+			uids.WriteString(fmt.Sprintf("squash_to_uid=%d", uidMaps[0].HostID))
+		} else {
+			uids.WriteString("uidmapping=")
+			for _, i := range uidMaps {
+				if uids.Len() > 0 {
+					uids.WriteString(":")
+				}
+				uids.WriteString(fmt.Sprintf("%d:%d:%d", i.ContainerID, i.HostID, i.Size))
 			}
-			uids.WriteString(fmt.Sprintf("%d:%d:%d", i.ContainerID, i.HostID, i.Size))
 		}
-		for _, i := range gidMaps {
-			if gids.Len() > 0 {
-				gids.WriteString(":")
+		if len(gidMaps) == 1 && gidMaps[0].Size == 1 {
+			gids.WriteString(fmt.Sprintf("squash_to_gid=%d", gidMaps[0].HostID))
+		} else {
+			gids.WriteString("gidmapping=")
+			for _, i := range gidMaps {
+				if gids.Len() > 0 {
+					gids.WriteString(":")
+				}
+				gids.WriteString(fmt.Sprintf("%d:%d:%d", i.ContainerID, i.HostID, i.Size))
 			}
-			gids.WriteString(fmt.Sprintf("%d:%d:%d", i.ContainerID, i.HostID, i.Size))
 		}
-		return fmt.Sprintf("%s,uidmapping=%s,gidmapping=%s", opts, uids.String(), gids.String())
+		return fmt.Sprintf("%s,%s,%s", opts, uids.String(), gids.String())
 	}
 	return opts
 }

--- a/pkg/idtools/idtools.go
+++ b/pkg/idtools/idtools.go
@@ -77,13 +77,23 @@ func MkdirAllAndChownNew(path string, mode os.FileMode, ids IDPair) error {
 // GetRootUIDGID retrieves the remapped root uid/gid pair from the set of maps.
 // If the maps are empty, then the root uid/gid will default to "real" 0/0
 func GetRootUIDGID(uidMap, gidMap []IDMap) (int, int, error) {
-	uid, err := toHost(0, uidMap)
-	if err != nil {
-		return -1, -1, err
+	var uid, gid int
+	var err error
+	if len(uidMap) == 1 && uidMap[0].Size == 1 {
+		uid = uidMap[0].HostID
+	} else {
+		uid, err = toHost(0, uidMap)
+		if err != nil {
+			return -1, -1, err
+		}
 	}
-	gid, err := toHost(0, gidMap)
-	if err != nil {
-		return -1, -1, err
+	if len(gidMap) == 1 && gidMap[0].Size == 1 {
+		gid = gidMap[0].HostID
+	} else {
+		gid, err = toHost(0, gidMap)
+		if err != nil {
+			return -1, -1, err
+		}
 	}
 	return uid, gid, nil
 }

--- a/pkg/idtools/idtools_test.go
+++ b/pkg/idtools/idtools_test.go
@@ -1,0 +1,105 @@
+package idtools
+
+import (
+	"testing"
+)
+
+func TestGetRootUIDGID(t *testing.T) {
+	mappingsUIDs := []IDMap{
+		{
+			ContainerID: 0,
+			HostID:      1000,
+			Size:        100,
+		},
+	}
+	mappingsGIDs := []IDMap{
+		{
+			ContainerID: 0,
+			HostID:      2000,
+			Size:        100,
+		},
+	}
+	uid, gid, err := GetRootUIDGID(mappingsUIDs, mappingsGIDs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if uid != 1000 {
+		t.Fatalf("Detected wrong root uid in the host")
+	}
+	if gid != 2000 {
+		t.Fatalf("Detected wrong root uid in the host")
+	}
+
+	mappingsUIDs = []IDMap{
+		{
+			ContainerID: 100,
+			HostID:      1001,
+			Size:        1,
+		},
+	}
+	mappingsGIDs = []IDMap{
+		{
+			ContainerID: 200,
+			HostID:      2002,
+			Size:        1,
+		},
+	}
+	uid, gid, err = GetRootUIDGID(mappingsUIDs, mappingsGIDs)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if uid != 1001 {
+		t.Fatalf("Detected wrong root uid in the host")
+	}
+	if gid != 2002 {
+		t.Fatalf("Detected wrong root uid in the host")
+	}
+
+	mappingsUIDs = []IDMap{
+		{
+			ContainerID: 100,
+			HostID:      1001,
+			Size:        100,
+		},
+	}
+	mappingsGIDs = []IDMap{
+		{
+			ContainerID: 200,
+			HostID:      2002,
+			Size:        100,
+		},
+	}
+	_, _, err = GetRootUIDGID(mappingsUIDs, mappingsGIDs)
+	if err == nil {
+		t.Fatalf("Detected root user")
+	}
+
+	mappingsUIDs = []IDMap{
+		{
+			ContainerID: 100,
+			HostID:      1001,
+			Size:        1,
+		},
+		{
+			ContainerID: 200,
+			HostID:      2001,
+			Size:        1,
+		},
+	}
+	mappingsGIDs = []IDMap{
+		{
+			ContainerID: 100,
+			HostID:      1001,
+			Size:        1,
+		},
+		{
+			ContainerID: 200,
+			HostID:      2001,
+			Size:        1,
+		},
+	}
+	_, _, err = GetRootUIDGID(mappingsUIDs, mappingsGIDs)
+	if err == nil {
+		t.Fatalf("Detected root user")
+	}
+}


### PR DESCRIPTION
if a single user is mapped in the user namespace, handle it as root.

It is needed for running unprivileged containers with a single user available without being forced to run with euid and egid set to 0.

Needs: https://github.com/containers/fuse-overlayfs/pull/268

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
