### PR TITLE
Support additional layer store (patch for containers/storage)

### DIFF
--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -14,6 +14,7 @@ import (
 	"github.com/containers/storage/pkg/archive"
 	"github.com/containers/storage/pkg/directory"
 	"github.com/containers/storage/pkg/idtools"
+	digest "github.com/opencontainers/go-digest"
 )
 
 // FsMagic unsigned id of the filesystem in use.
@@ -33,7 +34,9 @@ var (
 	// ErrPrerequisites returned when driver does not meet prerequisites.
 	ErrPrerequisites = errors.New("prerequisites for driver not satisfied (wrong filesystem?)")
 	// ErrIncompatibleFS returned when file system is not supported.
-	ErrIncompatibleFS = fmt.Errorf("backing file system is unsupported for this graph driver")
+	ErrIncompatibleFS = errors.New("backing file system is unsupported for this graph driver")
+	// ErrLayerUnknown returned when the specified layer is unknown by the driver.
+	ErrLayerUnknown = errors.New("unknown layer")
 )
 
 //CreateOpts contains optional arguments for Create() and CreateReadWrite()
@@ -117,6 +120,7 @@ type ProtoDriver interface {
 	// known to this driver.
 	Cleanup() error
 	// AdditionalImageStores returns additional image stores supported by the driver
+	// This API is experimental and can be changed without bumping the major version number.
 	AdditionalImageStores() []string
 }
 
@@ -178,6 +182,30 @@ type Capabilities struct {
 // can report on their Capabilities.
 type CapabilityDriver interface {
 	Capabilities() Capabilities
+}
+
+// AdditionalLayer reprents a layer that is stored in the additional layer store
+// This API is experimental and can be changed without bumping the major version number.
+type AdditionalLayer interface {
+	// CreateAs creates a new layer from this additional layer
+	CreateAs(id, parent string) error
+
+	// Info returns arbitrary information stored along with this layer (i.e. `info` file)
+	Info() (io.ReadCloser, error)
+
+	// Release tells the additional layer store that we don't use this handler.
+	Release()
+}
+
+// AdditionalLayerStoreDriver is the interface for driver that supports
+// additional layer store functionality.
+// This API is experimental and can be changed without bumping the major version number.
+type AdditionalLayerStoreDriver interface {
+	Driver
+
+	// LookupAdditionalLayer looks up additional layer store by the specified
+	// digest and ref and returns an object representing that layer.
+	LookupAdditionalLayer(d digest.Digest, ref string) (AdditionalLayer, error)
 }
 
 // DiffGetterDriver is the interface for layered file system drivers that

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -4,6 +4,7 @@ package overlay
 
 import (
 	"bytes"
+	"encoding/base64"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -31,6 +32,7 @@ import (
 	"github.com/containers/storage/pkg/unshare"
 	units "github.com/docker/go-units"
 	"github.com/hashicorp/go-multierror"
+	digest "github.com/opencontainers/go-digest"
 	rsystem "github.com/opencontainers/runc/libcontainer/system"
 	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/opencontainers/selinux/go-selinux/label"
@@ -94,6 +96,7 @@ const (
 
 type overlayOptions struct {
 	imageStores       []string
+	layerStores       []additionalLayerStore
 	quota             quota.Quota
 	mountProgram      string
 	skipMountHome     bool
@@ -117,6 +120,17 @@ type Driver struct {
 	supportsVolatile bool
 	usingMetacopy    bool
 	locker           *locker.Locker
+}
+
+type additionalLayerStore struct {
+
+	// path is the directory where this store is available on the host.
+	path string
+
+	// withReference is true when the store contains image reference information (base64-encoded)
+	// in its layer search path so the path to the diff will be
+	//  <path>/base64(reference)/<layerdigest>/
+	withReference bool
 }
 
 var (
@@ -397,6 +411,42 @@ func parseOptions(options []string) (*overlayOptions, error) {
 				}
 				o.imageStores = append(o.imageStores, store)
 			}
+		case "additionallayerstore":
+			logrus.Debugf("overlay: additionallayerstore=%s", val)
+			// Additional read only layer stores to use for lower paths
+			if val == "" {
+				continue
+			}
+			for _, lstore := range strings.Split(val, ",") {
+				elems := strings.Split(lstore, ":")
+				lstore = filepath.Clean(elems[0])
+				if !filepath.IsAbs(lstore) {
+					return nil, fmt.Errorf("overlay: additionallayerstore path %q is not absolute.  Can not be relative", lstore)
+				}
+				st, err := os.Stat(lstore)
+				if err != nil {
+					return nil, errors.Wrap(err, "overlay: can't stat additionallayerstore dir")
+				}
+				if !st.IsDir() {
+					return nil, fmt.Errorf("overlay: additionallayerstore path %q must be a directory", lstore)
+				}
+				var withReference bool
+				for _, e := range elems[1:] {
+					switch e {
+					case "ref":
+						if withReference {
+							return nil, fmt.Errorf("overlay: additionallayerstore config of %q contains %q option twice", lstore, e)
+						}
+						withReference = true
+					default:
+						return nil, fmt.Errorf("overlay: additionallayerstore config %q contains unknown option %q", lstore, e)
+					}
+				}
+				o.layerStores = append(o.layerStores, additionalLayerStore{
+					path:          lstore,
+					withReference: withReference,
+				})
+			}
 		case "mount_program":
 			logrus.Debugf("overlay: mount_program=%s", val)
 			if val != "" {
@@ -655,6 +705,24 @@ func (d *Driver) Metadata(id string) (map[string]string, error) {
 // we had created.
 func (d *Driver) Cleanup() error {
 	return mount.Unmount(d.home)
+}
+
+// LookupAdditionalLayer looks up additional layer store by the specified
+// digest and ref and returns an object representing that layer.
+// This API is experimental and can be changed without bumping the major version number.
+func (d *Driver) LookupAdditionalLayer(dgst digest.Digest, ref string) (graphdriver.AdditionalLayer, error) {
+	l, err := d.getAdditionalLayerPath(dgst, ref)
+	if err != nil {
+		return nil, err
+	}
+	// Tell the additional layer store that we use this layer.
+	// This will increase reference counter on the store's side.
+	// This will be decreased on Release() method.
+	notifyUseAdditionalLayer(l)
+	return &additionalLayer{
+		path: l,
+		d:    d,
+	}, nil
 }
 
 // CreateFromTemplate creates a layer with the same contents and parent as another layer.
@@ -958,6 +1026,8 @@ func (d *Driver) Remove(id string) error {
 			logrus.Debugf("Failed to remove link: %v", err)
 		}
 	}
+
+	d.releaseAdditionalLayerByID(id)
 
 	if err := system.EnsureRemoveAll(dir); err != nil && !os.IsNotExist(err) {
 		return err
@@ -1422,7 +1492,10 @@ func (f fileGetNilCloser) Close() error {
 // DiffGetter returns a FileGetCloser that can read files from the directory that
 // contains files for the layer differences. Used for direct access for tar-split.
 func (d *Driver) DiffGetter(id string) (graphdriver.FileGetCloser, error) {
-	p := d.getDiffPath(id)
+	p, err := d.getDiffPath(id)
+	if err != nil {
+		return nil, err
+	}
 	return fileGetNilCloser{storage.NewPathFileGetter(p)}, nil
 }
 
@@ -1444,7 +1517,10 @@ func (d *Driver) ApplyDiff(id, parent string, options graphdriver.ApplyDiffOpts)
 		idMappings = &idtools.IDMappings{}
 	}
 
-	applyDir := d.getDiffPath(id)
+	applyDir, err := d.getDiffPath(id)
+	if err != nil {
+		return 0, err
+	}
 
 	logrus.Debugf("Applying tar in %s", applyDir)
 	// Overlay doesn't need the parent id to apply the diff
@@ -1462,10 +1538,23 @@ func (d *Driver) ApplyDiff(id, parent string, options graphdriver.ApplyDiffOpts)
 	return directory.Size(applyDir)
 }
 
-func (d *Driver) getDiffPath(id string) string {
+func (d *Driver) getDiffPath(id string) (string, error) {
 	dir := d.dir(id)
+	return redirectDiffIfAdditionalLayer(path.Join(dir, "diff"))
+}
 
-	return path.Join(dir, "diff")
+func (d *Driver) getLowerDiffPaths(id string) ([]string, error) {
+	layers, err := d.getLowerDirs(id)
+	if err != nil {
+		return nil, err
+	}
+	for i, l := range layers {
+		layers[i], err = redirectDiffIfAdditionalLayer(l)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return layers, nil
 }
 
 // DiffSize calculates the changes between the specified id
@@ -1476,7 +1565,11 @@ func (d *Driver) DiffSize(id string, idMappings *idtools.IDMappings, parent stri
 		return d.naiveDiff.DiffSize(id, idMappings, parent, parentMappings, mountLabel)
 	}
 
-	return directory.Size(d.getDiffPath(id))
+	p, err := d.getDiffPath(id)
+	if err != nil {
+		return 0, err
+	}
+	return directory.Size(p)
 }
 
 // Diff produces an archive of the changes between the specified
@@ -1490,12 +1583,15 @@ func (d *Driver) Diff(id string, idMappings *idtools.IDMappings, parent string, 
 		idMappings = &idtools.IDMappings{}
 	}
 
-	lowerDirs, err := d.getLowerDirs(id)
+	lowerDirs, err := d.getLowerDiffPaths(id)
 	if err != nil {
 		return nil, err
 	}
 
-	diffPath := d.getDiffPath(id)
+	diffPath, err := d.getDiffPath(id)
+	if err != nil {
+		return nil, err
+	}
 	logrus.Debugf("Tar with options on %s", diffPath)
 	return archive.TarWithOptions(diffPath, &archive.TarOptions{
 		Compression:    archive.Uncompressed,
@@ -1514,8 +1610,11 @@ func (d *Driver) Changes(id string, idMappings *idtools.IDMappings, parent strin
 	}
 	// Overlay doesn't have snapshots, so we need to get changes from all parent
 	// layers.
-	diffPath := d.getDiffPath(id)
-	layers, err := d.getLowerDirs(id)
+	diffPath, err := d.getDiffPath(id)
+	if err != nil {
+		return nil, err
+	}
+	layers, err := d.getLowerDiffPaths(id)
 	if err != nil {
 		return nil, err
 	}
@@ -1626,4 +1725,140 @@ func nameWithSuffix(name string, number int) string {
 		return name
 	}
 	return fmt.Sprintf("%s%d", name, number)
+}
+
+func (d *Driver) getAdditionalLayerPath(dgst digest.Digest, ref string) (string, error) {
+	refElem := base64.StdEncoding.EncodeToString([]byte(ref))
+	for _, ls := range d.options.layerStores {
+		ref := ""
+		if ls.withReference {
+			ref = refElem
+		}
+		target := path.Join(ls.path, ref, dgst.String())
+		// Check if all necessary files exist
+		for _, p := range []string{
+			filepath.Join(target, "diff"),
+			filepath.Join(target, "info"),
+			// TODO(ktock): We should have an API to expose the stream data of this layer
+			//              to enable the client to retrieve the entire contents of this
+			//              layer when it exports this layer.
+		} {
+			if _, err := os.Stat(p); err != nil {
+				return "", errors.Wrapf(graphdriver.ErrLayerUnknown,
+					"failed to stat additional layer %q: %v", p, err)
+			}
+		}
+		return target, nil
+	}
+
+	return "", errors.Wrapf(graphdriver.ErrLayerUnknown,
+		"additional layer (%q, %q) not found", dgst, ref)
+}
+
+func (d *Driver) releaseAdditionalLayerByID(id string) {
+	if al, err := ioutil.ReadFile(path.Join(d.dir(id), "additionallayer")); err == nil {
+		notifyReleaseAdditionalLayer(string(al))
+	} else if !os.IsNotExist(err) {
+		logrus.Warnf("unexpected error on reading Additional Layer Store pointer %v", err)
+	}
+}
+
+// additionalLayer represents a layer in Additional Layer Store.
+type additionalLayer struct {
+	path        string
+	d           *Driver
+	releaseOnce sync.Once
+}
+
+// Info returns arbitrary information stored along with this layer (i.e. `info` file).
+// This API is experimental and can be changed without bumping the major version number.
+func (al *additionalLayer) Info() (io.ReadCloser, error) {
+	return os.Open(filepath.Join(al.path, "info"))
+}
+
+// CreateAs creates a new layer from this additional layer.
+// This API is experimental and can be changed without bumping the major version number.
+func (al *additionalLayer) CreateAs(id, parent string) error {
+	// TODO: support opts
+	if err := al.d.Create(id, parent, nil); err != nil {
+		return err
+	}
+	dir := al.d.dir(id)
+	diffDir := path.Join(dir, "diff")
+	if err := os.RemoveAll(diffDir); err != nil {
+		return err
+	}
+	// tell the additional layer store that we use this layer.
+	// mark this layer as "additional layer"
+	if err := ioutil.WriteFile(path.Join(dir, "additionallayer"), []byte(al.path), 0644); err != nil {
+		return err
+	}
+	notifyUseAdditionalLayer(al.path)
+	return os.Symlink(filepath.Join(al.path, "diff"), diffDir)
+}
+
+// Release tells the additional layer store that we don't use this handler.
+// This API is experimental and can be changed without bumping the major version number.
+func (al *additionalLayer) Release() {
+	// Tell the additional layer store that we don't use this layer handler.
+	// This will decrease the reference counter on the store's side, which was
+	// increased in LookupAdditionalLayer (so this must be called only once).
+	al.releaseOnce.Do(func() {
+		notifyReleaseAdditionalLayer(al.path)
+	})
+}
+
+// notifyUseAdditionalLayer notifies Additional Layer Store that we use the specified layer.
+// This is done by creating "use" file in the layer directory. This is useful for
+// Additional Layer Store to consider when to perform GC. Notification-aware Additional
+// Layer Store must return ENOENT.
+func notifyUseAdditionalLayer(al string) {
+	if !path.IsAbs(al) {
+		logrus.Warnf("additionallayer must be absolute (got: %v)", al)
+		return
+	}
+	useFile := path.Join(al, "use")
+	f, err := os.Create(useFile)
+	if os.IsNotExist(err) {
+		return
+	} else if err == nil {
+		f.Close()
+		if err := os.Remove(useFile); err != nil {
+			logrus.Warnf("failed to remove use file")
+		}
+	}
+	logrus.Warnf("unexpected error by Additional Layer Store %v during use; GC doesn't seem to be supported", err)
+}
+
+// notifyReleaseAdditionalLayer notifies Additional Layer Store that we don't use the specified
+// layer anymore. This is done by rmdir-ing the layer directory. This is useful for
+// Additional Layer Store to consider when to perform GC. Notification-aware Additional
+// Layer Store must return ENOENT.
+func notifyReleaseAdditionalLayer(al string) {
+	if !path.IsAbs(al) {
+		logrus.Warnf("additionallayer must be absolute (got: %v)", al)
+		return
+	}
+	// tell the additional layer store that we don't use this layer anymore.
+	err := unix.Rmdir(al)
+	if os.IsNotExist(err) {
+		return
+	}
+	logrus.Warnf("unexpected error by Additional Layer Store %v during release; GC doesn't seem to be supported", err)
+}
+
+// redirectDiffIfAdditionalLayer checks if the passed diff path is Additional Layer and
+// returns the redirected path. If the passed diff is not the one in Additional Layer
+// Store, it returns the original path without changes.
+func redirectDiffIfAdditionalLayer(diffPath string) (string, error) {
+	if ld, err := os.Readlink(diffPath); err == nil {
+		// diff is the link to Additional Layer Store
+		if !path.IsAbs(ld) {
+			return "", fmt.Errorf("linkpath must be absolute (got: %q)", ld)
+		}
+		diffPath = ld
+	} else if err.(*os.PathError).Err != syscall.EINVAL {
+		return "", err
+	}
+	return diffPath, nil
 }

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -122,6 +122,13 @@ type OptionsConfig struct {
 	// for shared image content
 	AdditionalImageStores []string `toml:"additionalimagestores"`
 
+	// AdditionalLayerStores is the location of additional read/only
+	// Layer stores.  Usually used to access Networked File System
+	// for shared image content
+	// This API is experimental and can be changed without bumping the
+	// major version number.
+	AdditionalLayerStores []string `toml:"additionallayerstores"`
+
 	// Size
 	Size string `toml:"size"`
 

--- a/store.go
+++ b/store.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"encoding/base64"
+	"encoding/json"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -489,6 +490,30 @@ type Store interface {
 
 	// GetDigestLock returns digest-specific Locker.
 	GetDigestLock(digest.Digest) (Locker, error)
+
+	// LayerFromAdditionalLayerStore searches layers from the additional layer store and
+	// returns the object for handling this. Note that this hasn't been stored to this store
+	// yet so this needs to be done through PutAs method.
+	// Releasing AdditionalLayer handler is caller's responsibility.
+	// This API is experimental and can be changed without bumping the major version number.
+	LookupAdditionalLayer(d digest.Digest, imageref string) (AdditionalLayer, error)
+}
+
+// AdditionalLayer reprents a layer that is contained in the additional layer store
+// This API is experimental and can be changed without bumping the major version number.
+type AdditionalLayer interface {
+	// PutAs creates layer based on this handler, using diff contents from the additional
+	// layer store.
+	PutAs(id, parent string, names []string) (*Layer, error)
+
+	// UncompressedDigest returns the uncompressed digest of this layer
+	UncompressedDigest() digest.Digest
+
+	// CompressedSize returns the compressed size of this layer
+	CompressedSize() int64
+
+	// Release tells the additional layer store that we don't use this handler.
+	Release()
 }
 
 type AutoUserNsOptions = types.AutoUserNsOptions
@@ -3132,6 +3157,91 @@ func (s *store) Layer(id string) (*Layer, error) {
 		}
 	}
 	return nil, ErrLayerUnknown
+}
+
+func (s *store) LookupAdditionalLayer(d digest.Digest, imageref string) (AdditionalLayer, error) {
+	adriver, ok := s.graphDriver.(drivers.AdditionalLayerStoreDriver)
+	if !ok {
+		return nil, ErrLayerUnknown
+	}
+
+	al, err := adriver.LookupAdditionalLayer(d, imageref)
+	if err != nil {
+		if errors.Is(err, drivers.ErrLayerUnknown) {
+			return nil, ErrLayerUnknown
+		}
+		return nil, err
+	}
+	info, err := al.Info()
+	if err != nil {
+		return nil, err
+	}
+	defer info.Close()
+	var layer Layer
+	if err := json.NewDecoder(info).Decode(&layer); err != nil {
+		return nil, err
+	}
+	return &additionalLayer{&layer, al, s}, nil
+}
+
+type additionalLayer struct {
+	layer   *Layer
+	handler drivers.AdditionalLayer
+	s       *store
+}
+
+func (al *additionalLayer) UncompressedDigest() digest.Digest {
+	return al.layer.UncompressedDigest
+}
+
+func (al *additionalLayer) CompressedSize() int64 {
+	return al.layer.CompressedSize
+}
+
+func (al *additionalLayer) PutAs(id, parent string, names []string) (*Layer, error) {
+	rlstore, err := al.s.LayerStore()
+	if err != nil {
+		return nil, err
+	}
+	rlstore.Lock()
+	defer rlstore.Unlock()
+	if modified, err := rlstore.Modified(); modified || err != nil {
+		if err = rlstore.Load(); err != nil {
+			return nil, err
+		}
+	}
+	rlstores, err := al.s.ROLayerStores()
+	if err != nil {
+		return nil, err
+	}
+
+	var parentLayer *Layer
+	if parent != "" {
+		for _, lstore := range append([]ROLayerStore{rlstore}, rlstores...) {
+			if lstore != rlstore {
+				lstore.RLock()
+				defer lstore.Unlock()
+				if modified, err := lstore.Modified(); modified || err != nil {
+					if err = lstore.Load(); err != nil {
+						return nil, err
+					}
+				}
+			}
+			parentLayer, err = lstore.Get(parent)
+			if err == nil {
+				break
+			}
+		}
+		if parentLayer == nil {
+			return nil, ErrLayerUnknown
+		}
+	}
+
+	return rlstore.PutAdditionalLayer(id, parentLayer, names, al.handler)
+}
+
+func (al *additionalLayer) Release() {
+	al.handler.Release()
 }
 
 func (s *store) Image(id string) (*Image, error) {

--- a/types/options.go
+++ b/types/options.go
@@ -300,6 +300,9 @@ func ReloadConfigurationFile(configFile string, storeOptions *StoreOptions) {
 	for _, s := range config.Storage.Options.AdditionalImageStores {
 		storeOptions.GraphDriverOptions = append(storeOptions.GraphDriverOptions, fmt.Sprintf("%s.imagestore=%s", config.Storage.Driver, s))
 	}
+	for _, s := range config.Storage.Options.AdditionalLayerStores {
+		storeOptions.GraphDriverOptions = append(storeOptions.GraphDriverOptions, fmt.Sprintf("%s.additionallayerstore=%s", config.Storage.Driver, s))
+	}
 	if config.Storage.Options.Size != "" {
 		storeOptions.GraphDriverOptions = append(storeOptions.GraphDriverOptions, fmt.Sprintf("%s.size=%s", config.Storage.Driver, config.Storage.Options.Size))
 	}


### PR DESCRIPTION
https://github.com/containers/podman/issues/4739

## Reconsidered the design on 2021/1/12

This enables podman to create containers using layers stored in a specified directory instead of pulling them from the registry. Leveraging this feature with remotely-mountable layers provided by stargz/zstd:chunked or CVMFS, podman can achieve lazy pulling.

### Changes in contianers/storage: https://github.com/containers/storage/pull/795

That directory is named "additional layer store" (call ALS in this doc) and has the following structure.

```
<ALS root>/base64("key1=value1")/base64("key2=value2")/.../
`-- diff
`-- info
```

`diff` directory contains the extracted layer diff contents specified by the key-value pairs.
`info` file contains `*c/storage.Layer` struct that indicates the information of this layer contents (`*c/storage.Layer.ID`, `*c/storage.Layer.Parent` and `*c/storage.Layer.Created` can be empty as it'll be filled by `c/storage.Store`).

On each pull, `c/storage.Store` searches the layer diff contents from ALS using pre-configured key-value pairs.
Each key-value pair is base64 encoded.
By default, the following `key=value` pairs can be used as elements of the path in ALS,

- `reference=<image reference>`
- `layerdigest=<digest of the compressed layer contents>`

Additionally, layer annotations (defined in the image manifest) prefixed by `containers/image/target.` can be used as well.
The prefix `containers/image/target.` will be trimmed from the key when it's used in the path on ALS.

Overlay driver supports an option to specify which key-value pair to be used and how the order should they be when `c/storage.Store` searches layers in the ALS.

```
layerstore=<ALS root directory>:<key1>:<key2>:...:<keyX>
```

In the above case, on each pull, `c/storage.Store` searches the following path in ALS,

```
<ALS root>/base64("key1=value1")/base64("key2=value2")/.../base64("keyX=valueX")/
`-- diff
`-- info
```

The underlying filesystem (e.g. stargz/zstd:chunked-based filesystem or CVMFS) should show the exploded view of the target layer diff and its information at these locations.
Example filesystem implementation (currently stargz-based) is https://github.com/ktock/stargz-snapshotter/tree/als-pool-example (this must be mounted on <ALS root>)

If the layer content is found in ALS, `c/storage.Store` creates layer using `<ALS root>/.../info` as `*c/storage.Layer` and using `<ALS root>/.../diff` as its diff directory.
So `c/image`'s copier doesn't need to pull this layer from the registry.

### Changes in containers/image: https://github.com/containers/image/pull/1109

Now `c/image`'s copier leverages this store. 
Every time this pulls an image, it first tries to reuse blobs from ALS.
That copier passes each layer's OCI annotations (key-value pairs) + the following key-value to `c/storage.Store`.

- containers/image/target.reference: The image reference of an image that contains the target layer.  This is needed for supporting registry-backed filesystems (e.g. estargz, zstd:chunked).

`*c/image.storageImageDestination.TryReusingBlob()` cannot pass image reference to `c/storage.Store` so this commit adds a new API `*c/image.storageImageDestination.TryReusingBlobWithRef() for achieving this.
When this copier successfully acquires that layer, this reuses this layer without pulling.

### Changes in containers/podman: *none*

### Command exapmle

```
podman --storage-opt "layerstore=/tmp/storage:reference:layerdigest" pull ghcr.io/stargz-containers/rethinkdb:2.3.6-esgz
podman --storage-opt "layerstore=/tmp/storage:reference:layerdigest" run --rm -it ghcr.io/stargz-containers/rethinkdb:2.3.6-esgz /bin/echo 'Hello, World!'
```

In the above cases, `c/storage.Store` looks up `/tmp/storage/base64("reference=ghcr.io/stargz-containers/rethinkdb:2.3.6-esgz")/base64(<layer digests>)/{diff, info}` in ALS.
The example filesystem implementation (https://github.com/ktock/stargz-snapshotter/tree/als-pool-example) is mounted at `/tmp/storage` shows the extracted layer at that location.
Then `rethinkdb:2.3.6-esgz` can run without pulling it from registry.

## Known limitation and request for comments

Some operations (e.g. save) requires correct value to be set to `c/storage.Layer.UncompressedSize`. This field seems to be the size of the layer but without compression (i.e. the size of the tar-archived format of that layer). For registry-backed ALS, getting this information is difficult because neither of OCI/Docker image nor registry API provides the way to get the uncompressed size of layers. We cannot get this information without actually pull and decompress the layer, which is not lazy pulling that this PR aims to.

I'll check the codebase deeper to come up with the way to get this information from somewhere or the way to safely allow `c/storage.Layer.UncompressedSize` to be *unknown* during operations. But if someone has good idea for solving this, please let me know.

cc: @siscia @giuseppe 