### PR TITLE
Let STORAGE_DRIVER env be used even after getting from configfile

### DIFF
--- a/store.go
+++ b/store.go
@@ -3522,11 +3522,11 @@ func ReloadConfigurationFile(configFile string, storeOptions *StoreOptions) {
 		fmt.Printf("Failed to parse %s %v\n", configFile, err.Error())
 		return
 	}
-	if os.Getenv("STORAGE_DRIVER") != "" {
-		config.Storage.Driver = os.Getenv("STORAGE_DRIVER")
-	}
 	if config.Storage.Driver != "" {
 		storeOptions.GraphDriverName = config.Storage.Driver
+	}
+	if os.Getenv("STORAGE_DRIVER") != "" {
+		config.Storage.Driver = os.Getenv("STORAGE_DRIVER")
 	}
 	if storeOptions.GraphDriverName == "" {
 		logrus.Errorf("The storage 'driver' option must be set in %s, guarantee proper operation.", configFile)


### PR DESCRIPTION
Currently when we have a storage driver set in storage.conf and we have a
STORAGE_DRIVER environement variable, the value from the storage.conf file is
used. While it would be expected to use the value from the environement variable
instead of the storage.conf (which make it easy to override in kubernetes env).

This goes in line of how we do it for STORAGE_OPT later in the same function
where the env variable here overrides the value form the file.

Signed-off-by: Chmouel Boudjnah <chmouel@redhat.com>