### PR TITLE
store: STORAGE_DRIVER has higher precedence

### DIFF
--- a/store.go
+++ b/store.go
@@ -3522,11 +3522,11 @@ func ReloadConfigurationFile(configFile string, storeOptions *StoreOptions) {
 		fmt.Printf("Failed to parse %s %v\n", configFile, err.Error())
 		return
 	}
-	if os.Getenv("STORAGE_DRIVER") != "" {
-		config.Storage.Driver = os.Getenv("STORAGE_DRIVER")
-	}
 	if config.Storage.Driver != "" {
 		storeOptions.GraphDriverName = config.Storage.Driver
+	}
+	if os.Getenv("STORAGE_DRIVER") != "" {
+		config.Storage.Driver = os.Getenv("STORAGE_DRIVER")
 	}
 	if storeOptions.GraphDriverName == "" {
 		logrus.Errorf("The storage 'driver' option must be set in %s, guarantee proper operation.", configFile)


### PR DESCRIPTION
the value specified in the environment variable should have a higher
precedence that the value in the configuration file.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>