### PR TITLE
Use STORAGE_DRIVER environment variable in rootless mode

### DIFF
--- a/store.go
+++ b/store.go
@@ -3522,10 +3522,11 @@ func ReloadConfigurationFile(configFile string, storeOptions *StoreOptions) {
 		fmt.Printf("Failed to parse %s %v\n", configFile, err.Error())
 		return
 	}
+	if config.Storage.Driver != "" {
+		storeOptions.GraphDriverName = config.Storage.Driver
+	}
 	if os.Getenv("STORAGE_DRIVER") != "" {
 		config.Storage.Driver = os.Getenv("STORAGE_DRIVER")
-	}
-	if config.Storage.Driver != "" {
 		storeOptions.GraphDriverName = config.Storage.Driver
 	}
 	if storeOptions.GraphDriverName == "" {


### PR DESCRIPTION
Currently we ignore STORAGE_DRIVER enviroment variable in
rootless mode, always forcing it to be Overlay if fuse-overlay
is installed of vfs.

This patch will respect both the STORAGE_DRIVER and STORAGE_OPT
environment variable if set in rootless mode.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>