### PR TITLE
Improve project quota to support querying disk usage

### DIFF
--- a/drivers/aufs/aufs.go
+++ b/drivers/aufs/aufs.go
@@ -482,6 +482,21 @@ func (a *Driver) Put(id string) error {
 	return err
 }
 
+// ReadWriteDiskUsage returns the disk usage of the writable directory for the ID.
+// For AUFS, it queries the mountpoint for this ID.
+func (a *Driver) ReadWriteDiskUsage(id string) (*directory.DiskUsage, error) {
+	a.locker.Lock(id)
+	defer a.locker.Unlock(id)
+	a.pathCacheLock.Lock()
+	m, exists := a.pathCache[id]
+	if !exists {
+		m = a.getMountpoint(id)
+		a.pathCache[id] = m
+	}
+	a.pathCacheLock.Unlock()
+	return directory.Usage(m)
+}
+
 // isParent returns if the passed in parent is the direct parent of the passed in layer
 func (a *Driver) isParent(id, parent string) bool {
 	parents, _ := getParentIDs(a.rootPath(), id)

--- a/drivers/btrfs/btrfs.go
+++ b/drivers/btrfs/btrfs.go
@@ -27,6 +27,7 @@ import (
 	"unsafe"
 
 	graphdriver "github.com/containers/storage/drivers"
+	"github.com/containers/storage/pkg/directory"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/mount"
 	"github.com/containers/storage/pkg/parsers"
@@ -685,6 +686,12 @@ func (d *Driver) Put(id string) error {
 	// Get() creates no runtime resources (like e.g. mounts)
 	// so this doesn't need to do anything.
 	return nil
+}
+
+// ReadWriteDiskUsage returns the disk usage of the writable directory for the ID.
+// For BTRFS, it queries the subvolumes path for this ID.
+func (d *Driver) ReadWriteDiskUsage(id string) (*directory.DiskUsage, error) {
+	return directory.Usage(d.subvolumesDirID(id))
 }
 
 // Exists checks if the id exists in the filesystem.

--- a/drivers/devmapper/driver.go
+++ b/drivers/devmapper/driver.go
@@ -11,6 +11,7 @@ import (
 
 	graphdriver "github.com/containers/storage/drivers"
 	"github.com/containers/storage/pkg/devicemapper"
+	"github.com/containers/storage/pkg/directory"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/locker"
 	"github.com/containers/storage/pkg/mount"
@@ -249,6 +250,14 @@ func (d *Driver) Put(id string) error {
 	}
 
 	return err
+}
+
+// ReadWriteDiskUsage returns the disk usage of the writable directory for the ID.
+// For devmapper, it queries the mnt path for this ID.
+func (d *Driver) ReadWriteDiskUsage(id string) (*directory.DiskUsage, error) {
+	d.locker.Lock(id)
+	defer d.locker.Unlock(id)
+	return directory.Usage(path.Join(d.home, "mnt", id))
 }
 
 // Exists checks to see if the device exists.

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -12,6 +12,7 @@ import (
 	"github.com/vbatts/tar-split/tar/storage"
 
 	"github.com/containers/storage/pkg/archive"
+	"github.com/containers/storage/pkg/directory"
 	"github.com/containers/storage/pkg/idtools"
 )
 
@@ -105,6 +106,8 @@ type ProtoDriver interface {
 	// Returns a set of key-value pairs which give low level information
 	// about the image/container driver is managing.
 	Metadata(id string) (map[string]string, error)
+	// ReadWriteDiskUsage returns the disk usage of the writable directory for the specified ID.
+	ReadWriteDiskUsage(id string) (*directory.DiskUsage, error)
 	// Cleanup performs necessary tasks to release resources
 	// held by the driver, e.g., unmounting all layered filesystems
 	// known to this driver.

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -521,6 +521,13 @@ func (d *Driver) Metadata(id string) (map[string]string, error) {
 	return metadata, nil
 }
 
+// ReadWriteDiskUsage returns the disk usage of the writable directory for the ID.
+// For Overlay, it attempts to check the XFS quota for size, and falls back to
+// finding the size of the "diff" directory.
+func (d *Driver) ReadWriteDiskUsage(id string) (*directory.DiskUsage, error) {
+	return directory.Usage(path.Join(d.dir(id), "diff"))
+}
+
 // Cleanup any state created by overlay which should be cleaned when daemon
 // is being shutdown. For now, we just have to unmount the bind mounted
 // we had created.
@@ -1221,6 +1228,7 @@ func (d *Driver) DiffSize(id string, idMappings *idtools.IDMappings, parent stri
 	if d.useNaiveDiff() || !d.isParent(id, parent) {
 		return d.naiveDiff.DiffSize(id, idMappings, parent, parentMappings, mountLabel)
 	}
+
 	return directory.Size(d.getDiffPath(id))
 }
 

--- a/drivers/vfs/driver.go
+++ b/drivers/vfs/driver.go
@@ -10,6 +10,7 @@ import (
 
 	graphdriver "github.com/containers/storage/drivers"
 	"github.com/containers/storage/pkg/archive"
+	"github.com/containers/storage/pkg/directory"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/parsers"
 	"github.com/containers/storage/pkg/system"
@@ -241,6 +242,12 @@ func (d *Driver) Put(id string) error {
 	// The vfs driver has no runtime resources (e.g. mounts)
 	// to clean up, so we don't need anything here
 	return nil
+}
+
+// ReadWriteDiskUsage returns the disk usage of the writable directory for the ID.
+// For VFS, it queries the directory for this ID.
+func (d *Driver) ReadWriteDiskUsage(id string) (*directory.DiskUsage, error) {
+	return directory.Usage(d.dir(id))
 }
 
 // Exists checks to see if the directory exists for the given id.

--- a/drivers/windows/windows.go
+++ b/drivers/windows/windows.go
@@ -26,6 +26,7 @@ import (
 	"github.com/Microsoft/hcsshim"
 	"github.com/containers/storage/drivers"
 	"github.com/containers/storage/pkg/archive"
+	"github.com/containers/storage/pkg/directory"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/ioutils"
 	"github.com/containers/storage/pkg/longpath"
@@ -434,6 +435,12 @@ func (d *Driver) Get(id string, options graphdriver.MountOpts) (string, error) {
 	}
 
 	return dir, nil
+}
+
+// ReadWriteDiskUsage returns the disk usage of the writable directory for the ID.
+// For VFS, it queries the directory for this ID.
+func (d *Driver) ReadWriteDiskUsage(id string) (*directory.DiskUsage, error) {
+	return directory.Usage(d.dir(id))
 }
 
 // Put adds a new layer to the driver.

--- a/drivers/zfs/zfs.go
+++ b/drivers/zfs/zfs.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	graphdriver "github.com/containers/storage/drivers"
+	"github.com/containers/storage/pkg/directory"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/mount"
 	"github.com/containers/storage/pkg/parsers"
@@ -453,6 +454,12 @@ func (d *Driver) Put(id string) error {
 	}
 
 	return nil
+}
+
+// ReadWriteDiskUsage returns the disk usage of the writable directory for the ID.
+// For ZFS, it queries the full mount path for this ID.
+func (d *Driver) ReadWriteDiskUsage(id string) (*directory.DiskUsage, error) {
+	return directory.Usage(d.mountPath(id))
 }
 
 // Exists checks to see if the cache entry exists for the given id.

--- a/pkg/directory/directory.go
+++ b/pkg/directory/directory.go
@@ -6,9 +6,15 @@ import (
 	"path/filepath"
 )
 
+// DiskUsage is a structure that describes the disk usage (size and inode count)
+// of a particular directory.
+type DiskUsage struct {
+	Size       int64
+	InodeCount int64
+}
+
 // MoveToSubdir moves all contents of a directory to a subdirectory underneath the original path
 func MoveToSubdir(oldpath, subdir string) error {
-
 	infos, err := ioutil.ReadDir(oldpath)
 	if err != nil {
 		return err

--- a/pkg/directory/directory_windows.go
+++ b/pkg/directory/directory_windows.go
@@ -7,8 +7,18 @@ import (
 	"path/filepath"
 )
 
-// Size walks a directory tree and returns its total size in bytes.
+// Size walks a directory tree and returns its total size in bytes
 func Size(dir string) (size int64, err error) {
+	usage, err := Usage(dir)
+	if err != nil {
+		return 0, nil
+	}
+	return usage.Size, nil
+}
+
+// Usage walks a directory tree and returns its total size in bytes and the number of inodes.
+func Usage(dir string) (usage *DiskUsage, err error) {
+	usage = &DiskUsage{}
 	err = filepath.Walk(dir, func(d string, fileInfo os.FileInfo, err error) error {
 		if err != nil {
 			// if dir does not exist, Size() returns the error.
@@ -29,7 +39,8 @@ func Size(dir string) (size int64, err error) {
 			return nil
 		}
 
-		size += s
+		usage.Size += s
+		usage.InodeCount++
 
 		return nil
 	})


### PR DESCRIPTION
To convert to CRI stats for CRI-O, we need to improve the performance of finding the disk stats. The current implementation walks the `/diff` directory and adds up the size and inodes.

Luckily, with XFS and project quotas, we can simply query the value.

This PR adds a couple of things, broken into smaller commits:
- updates pkg/directory to have a function GetDiskUsage, which does what directory.Size did, but also counts the inodes
- Add a similar GetDiskUsage function to the projectquota package, but this one queries the quota instead of walking
- Adds a ReadWriteDiskUsage endpoint for all drivers, most of which simply call directory.GetDiskUsage
- updates overlay to call projectquota.GetDiskUsage (if we successfully initialized our quota object)