### PR TITLE
store: support volatile containers

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -313,6 +313,9 @@ func (r *containerStore) Create(id string, names []string, image, layer, metadat
 	if options.MountOpts != nil {
 		options.Flags["MountOpts"] = append([]string{}, options.MountOpts...)
 	}
+	if options.Volatile {
+		options.Flags["Volatile"] = true
+	}
 	names = dedupeNames(names)
 	for _, name := range names {
 		if _, nameInUse := r.byname[name]; nameInUse {

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -53,6 +53,10 @@ type MountOpts struct {
 	UidMaps []idtools.IDMap // nolint: golint
 	GidMaps []idtools.IDMap // nolint: golint
 	Options []string
+
+	// Volatile specifies whether the container storage can be optimized
+	// at the cost of not syncing all the dirty files in memory.
+	Volatile bool
 }
 
 // ApplyDiffOpts contains optional arguments for ApplyDiff methods.

--- a/drivers/overlay/check.go
+++ b/drivers/overlay/check.go
@@ -163,3 +163,40 @@ func doesMetacopy(d, mountOpts string) (bool, error) {
 	}
 	return metacopy != nil, nil
 }
+
+// doesVolatile checks if the filesystem supports the "volatile" mount option
+func doesVolatile(d string) (bool, error) {
+	td, err := ioutil.TempDir(d, "volatile-check")
+	if err != nil {
+		return false, err
+	}
+	defer func() {
+		if err := os.RemoveAll(td); err != nil {
+			logrus.Warnf("Failed to remove check directory %v: %v", td, err)
+		}
+	}()
+
+	if err := os.MkdirAll(filepath.Join(td, "lower"), 0755); err != nil {
+		return false, err
+	}
+	if err := os.MkdirAll(filepath.Join(td, "upper"), 0755); err != nil {
+		return false, err
+	}
+	if err := os.Mkdir(filepath.Join(td, "work"), 0755); err != nil {
+		return false, err
+	}
+	if err := os.Mkdir(filepath.Join(td, "merged"), 0755); err != nil {
+		return false, err
+	}
+	// Mount using the mandatory options and configured options
+	opts := fmt.Sprintf("volatile,lowerdir=%s,upperdir=%s,workdir=%s", path.Join(td, "lower"), path.Join(td, "upper"), path.Join(td, "work"))
+	if err := unix.Mount("overlay", filepath.Join(td, "merged"), "overlay", 0, opts); err != nil {
+		return false, errors.Wrapf(err, "failed to mount overlay for volatile check")
+	}
+	defer func() {
+		if err := unix.Unmount(filepath.Join(td, "merged"), 0); err != nil {
+			logrus.Warnf("Failed to unmount check directory %v: %v", filepath.Join(td, "merged"), err)
+		}
+	}()
+	return true, nil
+}

--- a/store.go
+++ b/store.go
@@ -599,6 +599,7 @@ type ContainerOptions struct {
 	LabelOpts []string
 	Flags     map[string]interface{}
 	MountOpts []string
+	Volatile  bool
 }
 
 type store struct {
@@ -2813,6 +2814,9 @@ func (s *store) Mount(id, mountLabel string) (string, error) {
 		options.UidMaps = container.UIDMap
 		options.GidMaps = container.GIDMap
 		options.Options = container.MountOpts()
+		if v, found := container.Flags["Volatile"]; found {
+			options.Volatile = v.(bool)
+		}
 	}
 	return s.mount(id, options)
 }


### PR DESCRIPTION
add a new class of containers that are not guaranteed to survive a crash.  The advantage of such containers is that storage can be
optimized to skip some synchronizations with the underlying storage.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>