### PR TITLE
overlay: support native rootless mounts

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -28,6 +28,7 @@ import (
 	"github.com/containers/storage/pkg/mount"
 	"github.com/containers/storage/pkg/parsers"
 	"github.com/containers/storage/pkg/system"
+	"github.com/containers/storage/pkg/unshare"
 	units "github.com/docker/go-units"
 	rsystem "github.com/opencontainers/runc/libcontainer/system"
 	"github.com/opencontainers/selinux/go-selinux/label"
@@ -1023,6 +1024,11 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 	} else if d.options.mountOptions != "" {
 		opts = fmt.Sprintf("%s,%s", d.options.mountOptions, opts)
 	}
+
+	if d.options.mountProgram == "" && unshare.IsRootless() {
+		opts = fmt.Sprintf("%s,userxattr", opts)
+	}
+
 	mountData := label.FormatMountLabel(opts, options.MountLabel)
 	mountFunc := unix.Mount
 	mountTarget := mergedDir


### PR DESCRIPTION
tested on Fedora Rawhide with kernel
5.11.0-0.rc6.20210204git61556703b610.144.fc34.x86_64

There is currently an issue when context= is specified and the mount
fails with EACCES.  We can drop it once it works in the kernel.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>