### PR TITLE
We should ignore metacopy option on kernels that do not support it

### DIFF
--- a/drivers/overlay/check.go
+++ b/drivers/overlay/check.go
@@ -145,6 +145,10 @@ func doesMetacopy(d, mountOpts string) (bool, error) {
 		opts = fmt.Sprintf("%s,%s", opts, data)
 	}
 	if err := unix.Mount("overlay", filepath.Join(td, "merged"), "overlay", uintptr(flags), opts); err != nil {
+		if errors.Cause(err) == unix.EINVAL {
+			logrus.Info("metacopy option not supported on this kernel", mountOpts)
+			return false, nil
+		}
 		return false, errors.Wrapf(err, "failed to mount overlay for metacopy check with %q options", mountOpts)
 	}
 	defer func() {

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -941,7 +941,11 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 		// If metacopy=on is present in d.options.mountOptions it must be present in the mount
 		// options otherwise the kernel refuses to follow the metacopy xattr.
 		if hasMetacopyOption(strings.Split(d.options.mountOptions, ",")) && !hasMetacopyOption(options.Options) {
-			optsList = append(optsList, "metacopy=on")
+			if d.usingMetacopy {
+				optsList = append(optsList, "metacopy=on")
+			} else {
+				logrus.Warnf("ignoring metacopy option from storage.conf, not supported with booted kernel")
+			}
 		}
 	}
 	for _, o := range optsList {


### PR DESCRIPTION
Distributions are shipping metacopy option along with kernels that do
not support it.  We should warn on this situation rather then fail.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>