### PR TITLE
homedir: add GetCacheHome

### DIFF
--- a/pkg/homedir/homedir_others.go
+++ b/pkg/homedir/homedir_others.go
@@ -28,3 +28,8 @@ func GetDataHome() (string, error) {
 func GetConfigHome() (string, error) {
 	return "", errors.New("homedir.GetConfigHome() is not supported on this system")
 }
+
+// GetCacheHome is unsupported on non-linux system.
+func GetCacheHome() (string, error) {
+	return "", errors.New("homedir.GetCacheHome() is not supported on this system")
+}

--- a/pkg/homedir/homedir_unix.go
+++ b/pkg/homedir/homedir_unix.go
@@ -123,3 +123,18 @@ func GetConfigHome() (string, error) {
 	}
 	return filepath.Join(home, ".config"), nil
 }
+
+// GetCacheHome returns XDG_CACHE_HOME.
+// GetCacheHome returns $HOME/.cache and nil error if XDG_CACHE_HOME is not set.
+//
+// See also https://standards.freedesktop.org/basedir-spec/latest/ar01s03.html
+func GetCacheHome() (string, error) {
+	if xdgCacheHome := os.Getenv("XDG_CACHE_HOME"); xdgCacheHome != "" {
+		return xdgCacheHome, nil
+	}
+	home := Get()
+	if home == "" {
+		return "", errors.New("could not get either XDG_CACHE_HOME or HOME")
+	}
+	return filepath.Join(home, ".cache"), nil
+}


### PR DESCRIPTION
There's already GetDataHome for getting XDG_DATA_HOME and GetConfigHome
for getting XDG_CONFIG_HOME. So add GetCacheHome for getting
XDG_CACHE_HOME, for use by containers/image.

See also containers/image#1142

Signed-off-by: G.I. Doe <gogit@pm.me>