### PR TITLE
pkg/lockfile: fix a race and re-enable unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,7 @@ NATIVETAGS :=
 AUTOTAGS := $(shell ./hack/btrfs_tag.sh) $(shell ./hack/libdm_tag.sh)
 BUILDFLAGS := -tags "$(AUTOTAGS) $(TAGS)" $(FLAGS)
 GO ?= go
+TESTFLAGS := $(shell go test -race $(BUILDFLAGS) ./pkg/stringutils 2>&1 > /dev/null && echo -race)
 
 # Go module support: set `-mod=vendor` to use the vendored sources
 ifeq ($(shell $(GO) help mod >/dev/null 2>&1 && echo true), true)
@@ -95,7 +96,7 @@ test: local-binary ## build the binaries and run the tests using VMs
 	$(RUNINVM) make local-binary local-cross local-test-unit local-test-integration
 
 local-test-unit: local-binary ## run the unit tests on the host (requires\nsuperuser privileges)
-	@$(GO) test $(MOD_VENDOR) $(BUILDFLAGS) $(shell $(GO) list ./... | grep -v ^$(PACKAGE)/vendor)
+	@$(GO) test $(MOD_VENDOR) $(BUILDFLAGS) $(TESTFLAGS) $(shell $(GO) list ./... | grep -v ^$(PACKAGE)/vendor)
 
 test-unit: local-binary ## run the unit tests using VMs
 	$(RUNINVM) make local-$@

--- a/contrib/cirrus/build_and_test.sh
+++ b/contrib/cirrus/build_and_test.sh
@@ -11,19 +11,19 @@ showrun make local-cross
 
 case $TEST_DRIVER in
     overlay)
-        showrun make STORAGE_DRIVER=overlay local-test-integration
+        showrun make STORAGE_DRIVER=overlay local-test-integration local-test-unit
         ;;
     fuse-overlay)
-        showrun make STORAGE_DRIVER=overlay STORAGE_OPTION=overlay.mount_program=/usr/bin/fuse-overlayfs local-test-integration
+        showrun make STORAGE_DRIVER=overlay STORAGE_OPTION=overlay.mount_program=/usr/bin/fuse-overlayfs local-test-integration local-test-unit
         ;;
     fuse-overlay-whiteout)
-        showrun make STORAGE_DRIVER=overlay FUSE_OVERLAYFS_DISABLE_OVL_WHITEOUT=1 STORAGE_OPTION=overlay.mount_program=/usr/bin/fuse-overlayfs local-test-integration
+        showrun make STORAGE_DRIVER=overlay FUSE_OVERLAYFS_DISABLE_OVL_WHITEOUT=1 STORAGE_OPTION=overlay.mount_program=/usr/bin/fuse-overlayfs local-test-integration local-test-unit
         ;;
     vfs)
-        showrun make STORAGE_DRIVER=vfs local-test-integration
+        showrun make STORAGE_DRIVER=vfs local-test-integration local-test-unit
         ;;
     aufs)
-        showrun make STORAGE_DRIVER=aufs local-test-integration
+        showrun make STORAGE_DRIVER=aufs local-test-integration local-test-unit
         ;;
     *)
         die "Unknown/Unsupported \$TEST_DRIVER=$TEST_DRIVER (see .cirrus.yml and $(basename $0))"

--- a/drivers/btrfs/btrfs.go
+++ b/drivers/btrfs/btrfs.go
@@ -39,6 +39,8 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+const defaultPerms = os.FileMode(0555)
+
 func init() {
 	graphdriver.Register("btrfs", Init)
 }
@@ -515,6 +517,9 @@ func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) error {
 	}
 	if parent == "" {
 		if err := subvolCreate(subvolumes, id); err != nil {
+			return err
+		}
+		if err := os.Chmod(path.Join(subvolumes, id), defaultPerms); err != nil {
 			return err
 		}
 	} else {

--- a/drivers/devmapper/driver.go
+++ b/drivers/devmapper/driver.go
@@ -20,6 +20,8 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+const defaultPerms = os.FileMode(0555)
+
 func init() {
 	graphdriver.Register("devicemapper", Init)
 }
@@ -215,7 +217,7 @@ func (d *Driver) Get(id string, options graphdriver.MountOpts) (string, error) {
 		return "", err
 	}
 
-	if err := idtools.MkdirAllAs(rootFs, 0755, uid, gid); err != nil {
+	if err := idtools.MkdirAllAs(rootFs, defaultPerms, uid, gid); err != nil {
 		d.ctr.Decrement(mp)
 		d.DeviceSet.UnmountDevice(id, mp)
 		return "", err

--- a/drivers/graphtest/testutil_unix.go
+++ b/drivers/graphtest/testutil_unix.go
@@ -53,10 +53,12 @@ func createBase(t testing.TB, driver graphdriver.Driver, name string) {
 	require.NoError(t, err)
 }
 
-func verifyBase(t testing.TB, driver graphdriver.Driver, name string) {
+func verifyBase(t testing.TB, driver graphdriver.Driver, name string, defaultPerm os.FileMode) {
 	dir, err := driver.Get(name, graphdriver.MountOpts{})
 	require.NoError(t, err)
 	defer driver.Put(name)
+
+	verifyFile(t, dir, defaultPerm|os.ModeDir, 0, 0)
 
 	subdir := path.Join(dir, "a subdir")
 	verifyFile(t, subdir, 0705|os.ModeDir|os.ModeSticky, 1, 2)

--- a/drivers/vfs/driver.go
+++ b/drivers/vfs/driver.go
@@ -24,6 +24,8 @@ var (
 	CopyDir = dirCopy
 )
 
+const defaultPerms = os.FileMode(0555)
+
 func init() {
 	graphdriver.Register("vfs", Init)
 }
@@ -167,15 +169,17 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts, ro bool
 		}
 	}()
 
+	rootPerms := defaultPerms
 	if parent != "" {
 		st, err := system.Stat(d.dir(parent))
 		if err != nil {
 			return err
 		}
+		rootPerms = os.FileMode(st.Mode())
 		rootIDs.UID = int(st.UID())
 		rootIDs.GID = int(st.GID())
 	}
-	if err := idtools.MkdirAndChown(dir, 0755, rootIDs); err != nil {
+	if err := idtools.MkdirAndChown(dir, rootPerms, rootIDs); err != nil {
 		return err
 	}
 	labelOpts := []string{"level:s0"}

--- a/drivers/zfs/zfs.go
+++ b/drivers/zfs/zfs.go
@@ -30,6 +30,8 @@ type zfsOptions struct {
 	mountOptions string
 }
 
+const defaultPerms = os.FileMode(0555)
+
 func init() {
 	graphdriver.Register("zfs", Init)
 }
@@ -106,7 +108,7 @@ func Init(base string, opt graphdriver.Options) (graphdriver.Driver, error) {
 
 	rootUID, rootGID, err := idtools.GetRootUIDGID(opt.UIDMaps, opt.GIDMaps)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to get root uid/guid: %v", err)
+		return nil, fmt.Errorf("Failed to get root uid/gid: %v", err)
 	}
 	if err := idtools.MkdirAllAs(base, 0700, rootUID, rootGID); err != nil {
 		return nil, fmt.Errorf("Failed to create '%s': %v", base, err)
@@ -273,12 +275,7 @@ func (d *Driver) CreateReadWrite(id, parent string, opts *graphdriver.CreateOpts
 
 // Create prepares the dataset and filesystem for the ZFS driver for the given id under the parent.
 func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) error {
-	var storageOpt map[string]string
-	if opts != nil {
-		storageOpt = opts.StorageOpt
-	}
-
-	err := d.create(id, parent, storageOpt)
+	err := d.create(id, parent, opts)
 	if err == nil {
 		return nil
 	}
@@ -297,16 +294,31 @@ func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) error {
 	}
 
 	// retry
-	return d.create(id, parent, storageOpt)
+	return d.create(id, parent, opts)
 }
 
-func (d *Driver) create(id, parent string, storageOpt map[string]string) error {
+func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts) error {
+	var storageOpt map[string]string
+	if opts != nil {
+		storageOpt = opts.StorageOpt
+	}
+
 	name := d.zfsPath(id)
+	mountpoint := d.mountPath(id)
 	quota, err := parseStorageOpt(storageOpt)
 	if err != nil {
 		return err
 	}
 	if parent == "" {
+		var rootUID, rootGID int
+		var mountLabel string
+		if opts != nil {
+			rootUID, rootGID, err = idtools.GetRootUIDGID(opts.UIDs(), opts.GIDs())
+			if err != nil {
+				return fmt.Errorf("Failed to get root uid/gid: %v", err)
+			}
+			mountLabel = opts.MountLabel
+		}
 		mountoptions := map[string]string{"mountpoint": "legacy"}
 		fs, err := zfs.CreateFilesystem(name, mountoptions)
 		if err == nil {
@@ -316,6 +328,37 @@ func (d *Driver) create(id, parent string, storageOpt map[string]string) error {
 				d.filesystemsCache[fs.Name] = true
 				d.Unlock()
 			}
+
+			if err := idtools.MkdirAllAs(mountpoint, defaultPerms, rootUID, rootGID); err != nil {
+				return err
+			}
+			defer func() {
+				if err := unix.Rmdir(mountpoint); err != nil && !os.IsNotExist(err) {
+					logrus.Debugf("Failed to remove %s mount point %s: %v", id, mountpoint, err)
+				}
+			}()
+
+			mountOpts := label.FormatMountLabel(d.options.mountOptions, mountLabel)
+
+			if err := mount.Mount(name, mountpoint, "zfs", mountOpts); err != nil {
+				return errors.Wrap(err, "error creating zfs mount")
+			}
+			defer func() {
+				if err := unix.Unmount(mountpoint, unix.MNT_DETACH); err != nil {
+					logrus.Warnf("Failed to unmount %s mount %s: %v", id, mountpoint, err)
+				}
+			}()
+
+			if err := os.Chmod(mountpoint, defaultPerms); err != nil {
+				return errors.Wrap(err, "error setting permissions on zfs mount")
+			}
+
+			// this is our first mount after creation of the filesystem, and the root dir may still have root
+			// permissions instead of the remapped root uid:gid (if user namespaces are enabled):
+			if err := os.Chown(mountpoint, rootUID, rootGID); err != nil {
+				return errors.Wrapf(err, "modifying zfs mountpoint (%s) ownership", mountpoint)
+			}
+
 		}
 		return err
 	}
@@ -417,12 +460,6 @@ func (d *Driver) Get(id string, options graphdriver.MountOpts) (_ string, retErr
 
 	if err := mount.Mount(filesystem, mountpoint, "zfs", opts); err != nil {
 		return "", errors.Wrap(err, "error creating zfs mount")
-	}
-
-	// this could be our first mount after creation of the filesystem, and the root dir may still have root
-	// permissions instead of the remapped root uid:gid (if user namespaces are enabled):
-	if err := os.Chown(mountpoint, rootUID, rootGID); err != nil {
-		return "", errors.Wrapf(err, "modifying zfs mountpoint (%s) ownership", mountpoint)
 	}
 
 	if remountReadOnly {

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -99,6 +99,12 @@ func NewDefaultArchiver() *Archiver {
 // in order for the test to pass.
 type breakoutError error
 
+// overwriteError is used to differentiate errors related to attempting to
+// overwrite a directory with a non-directory or vice-versa.  When testing
+// copying a file over a directory, this error is expected in order for the
+// test to pass.
+type overwriteError error
+
 const (
 	// Uncompressed represents the uncompressed.
 	Uncompressed Compression = iota
@@ -1020,13 +1026,13 @@ loop:
 			if options.NoOverwriteDirNonDir && fi.IsDir() && hdr.Typeflag != tar.TypeDir {
 				// If NoOverwriteDirNonDir is true then we cannot replace
 				// an existing directory with a non-directory from the archive.
-				return fmt.Errorf("cannot overwrite directory %q with non-directory %q", path, dest)
+				return overwriteError(fmt.Errorf("cannot overwrite directory %q with non-directory %q", path, dest))
 			}
 
 			if options.NoOverwriteDirNonDir && !fi.IsDir() && hdr.Typeflag == tar.TypeDir {
 				// If NoOverwriteDirNonDir is true then we cannot replace
 				// an existing non-directory with a directory from the archive.
-				return fmt.Errorf("cannot overwrite non-directory %q with directory %q", path, dest)
+				return overwriteError(fmt.Errorf("cannot overwrite non-directory %q with directory %q", path, dest))
 			}
 
 			if fi.IsDir() && hdr.Name == "." {

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -472,15 +472,51 @@ func TestCopyWithTarSrcFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	ioutil.WriteFile(src, []byte("content"), 0777)
+	err = ioutil.WriteFile(src, []byte("content"), 0777)
+	if err != nil {
+		t.Fatalf("archiver.CopyWithTar couldn't write content, %s.", err)
+	}
+	err = defaultCopyWithTar(src, dest)
+	if err == nil {
+		t.Fatalf("archiver.CopyWithTar should have thrown an overwrite error.")
+	} else if _, isOverwriteError := err.(overwriteError); !isOverwriteError {
+		t.Fatalf("archiver.CopyWithTar shouldn't throw an error other than overwrite, %s.", err)
+	}
+	err = os.Remove(dest)
+	if err != nil {
+		t.Fatalf("archiver.CopyWithTar couldn't remove dest dir, %s.", err)
+	}
 	err = defaultCopyWithTar(src, dest)
 	if err != nil {
-		t.Fatalf("archiver.CopyWithTar shouldn't throw an error, %s.", err)
+		t.Fatalf("archiver.CopyWithTar shouldn't have thrown an error, %s.", err)
 	}
-	_, err = os.Stat(dest)
-	// FIXME Check the content
+	err = ioutil.WriteFile(dest, []byte("modified content"), 0751)
 	if err != nil {
-		t.Fatalf("Destination file should be the same as the source.")
+		t.Fatalf("archiver.CopyWithTar couldn't write modified content, %s.", err)
+	}
+	err = defaultCopyWithTar(src, dest)
+	if err != nil {
+		t.Fatalf("archiver.CopyWithTar shouldn't have thrown an error, %s.", err)
+	}
+	srcInfo, err := os.Stat(src)
+	if err != nil {
+		t.Fatalf("archiver.CopyWithTar should be able to stat the source, %s.", err)
+	}
+	destInfo, err := os.Stat(dest)
+	if err != nil {
+		t.Fatalf("archiver.CopyWithTar should be able to stat the destination, %s.", err)
+	}
+	if srcInfo.IsDir() != destInfo.IsDir() {
+		t.Fatalf("Destination (dir=%t) should be the same as the source (dir=%t).", destInfo.IsDir(), srcInfo.IsDir())
+	}
+	if srcInfo.Mode() != destInfo.Mode() {
+		t.Fatalf("Destination (mode=%0o) should be the same as the source (mode=%0o).", destInfo.Mode(), srcInfo.Mode())
+	}
+	if srcInfo.Size() != destInfo.Size() {
+		t.Fatalf("Destination (size=%d) should be the same as the source (size=%d).", destInfo.Size(), srcInfo.Size())
+	}
+	if !srcInfo.ModTime().Equal(destInfo.ModTime()) {
+		t.Fatalf("Destination (date=%s) should be the same as the source (date=%s).", destInfo.ModTime(), srcInfo.ModTime())
 	}
 }
 

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -136,7 +136,7 @@ func TestDecompressStreamXz(t *testing.T) {
 func TestCompressStreamXzUnsupported(t *testing.T) {
 	dest, err := os.Create(tmp + "dest")
 	if err != nil {
-		t.Fatalf("Fail to create the destination file")
+		t.Fatalf("Fail to create the destination file: %v", err)
 	}
 	defer dest.Close()
 
@@ -149,7 +149,7 @@ func TestCompressStreamXzUnsupported(t *testing.T) {
 func TestCompressStreamBzip2Unsupported(t *testing.T) {
 	dest, err := os.Create(tmp + "dest")
 	if err != nil {
-		t.Fatalf("Fail to create the destination file")
+		t.Fatalf("Fail to create the destination file: %v", err)
 	}
 	defer dest.Close()
 
@@ -162,7 +162,7 @@ func TestCompressStreamBzip2Unsupported(t *testing.T) {
 func TestCompressStreamInvalid(t *testing.T) {
 	dest, err := os.Create(tmp + "dest")
 	if err != nil {
-		t.Fatalf("Fail to create the destination file")
+		t.Fatalf("Fail to create the destination file: %v", err)
 	}
 	defer dest.Close()
 

--- a/pkg/archive/changes_linux.go
+++ b/pkg/archive/changes_linux.go
@@ -296,23 +296,20 @@ func parseDirent(buf []byte, names []nameIno) (consumed int, newnames []nameIno)
 		if dirent.Ino == 0 { // File absent in directory.
 			continue
 		}
-		bytes := (*[10000]byte)(unsafe.Pointer(&dirent.Name[0]))
-		var name = string(bytes[0:clen(bytes[:])])
+		builder := make([]byte, 0, dirent.Reclen)
+		for i := 0; i < len(dirent.Name); i++ {
+			if dirent.Name[i] == 0 {
+				break
+			}
+			builder = append(builder, byte(dirent.Name[i]))
+		}
+		name := string(builder)
 		if name == "." || name == ".." { // Useless names
 			continue
 		}
 		names = append(names, nameIno{name, dirent.Ino})
 	}
 	return origlen - len(buf), names
-}
-
-func clen(n []byte) int {
-	for i := 0; i < len(n); i++ {
-		if n[i] == 0 {
-			return i
-		}
-	}
-	return len(n)
 }
 
 // OverlayChanges walks the path rw and determines changes for the files in the path,

--- a/pkg/chrootarchive/archive_test.go
+++ b/pkg/chrootarchive/archive_test.go
@@ -103,7 +103,7 @@ func TestChrootUntarWithHugeExcludesList(t *testing.T) {
 	//on most systems when passed via environment or command line arguments
 	excludes := make([]string, 65534)
 	for i := 0; i < 65534; i++ {
-		excludes[i] = strings.Repeat(string(i), 64)
+		excludes[i] = strings.Repeat(fmt.Sprintf("%d", i), 64)
 	}
 	options.ExcludePatterns = excludes
 	if err := Untar(stream, dest, options); err != nil {

--- a/pkg/directory/directory_unix.go
+++ b/pkg/directory/directory_unix.go
@@ -35,7 +35,7 @@ func Usage(dir string) (usage *DiskUsage, err error) {
 			return nil
 		}
 
-		// Check inode to handle hard links correctly
+		// Check inode to only count the sizes of files with multiple hard links once.
 		inode := fileInfo.Sys().(*syscall.Stat_t).Ino
 		// inode is not a uint64 on all platforms. Cast it to avoid issues.
 		if _, exists := data[uint64(inode)]; exists {
@@ -44,9 +44,6 @@ func Usage(dir string) (usage *DiskUsage, err error) {
 
 		// inode is not a uint64 on all platforms. Cast it to avoid issues.
 		data[uint64(inode)] = struct{}{}
-
-		// Count the unique inode
-		usage.InodeCount++
 
 		// Ignore directory sizes
 		if fileInfo.IsDir() {
@@ -57,5 +54,7 @@ func Usage(dir string) (usage *DiskUsage, err error) {
 
 		return nil
 	})
+	// inode count is the number of unique inode numbers we saw
+	usage.InodeCount = int64(len(data))
 	return
 }

--- a/pkg/directory/directory_windows.go
+++ b/pkg/directory/directory_windows.go
@@ -29,6 +29,8 @@ func Usage(dir string) (usage *DiskUsage, err error) {
 			return err
 		}
 
+		usage.InodeCount++
+
 		// Ignore directory sizes
 		if fileInfo == nil {
 			return nil
@@ -40,7 +42,6 @@ func Usage(dir string) (usage *DiskUsage, err error) {
 		}
 
 		usage.Size += s
-		usage.InodeCount++
 
 		return nil
 	})

--- a/pkg/idtools/idtools_unix_test.go
+++ b/pkg/idtools/idtools_unix_test.go
@@ -229,6 +229,8 @@ func TestParseSubidFileWithNewlinesAndComments(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	defer os.RemoveAll(tmpDir)
+
 	fnamePath := filepath.Join(tmpDir, "testsubuid")
 	fcontent := `tss:100000:65536
 # empty default subuid/subgid file

--- a/pkg/lockfile/lockfile_unix.go
+++ b/pkg/lockfile/lockfile_unix.go
@@ -191,7 +191,7 @@ func (l *lockfile) Touch() error {
 	if !l.locked || (l.locktype != unix.F_WRLCK) {
 		panic("attempted to update last-writer in lockfile without the write lock")
 	}
-	l.stateMutex.Unlock()
+	defer l.stateMutex.Unlock()
 	l.lw = stringid.GenerateRandomID()
 	id := []byte(l.lw)
 	_, err := unix.Seek(int(l.fd), 0, os.SEEK_SET)
@@ -211,12 +211,12 @@ func (l *lockfile) Touch() error {
 // Modified indicates if the lockfile has been updated since the last time it
 // was loaded.
 func (l *lockfile) Modified() (bool, error) {
-	id := []byte(l.lw)
 	l.stateMutex.Lock()
+	id := []byte(l.lw)
 	if !l.locked {
 		panic("attempted to check last-writer in lockfile without locking it first")
 	}
-	l.stateMutex.Unlock()
+	defer l.stateMutex.Unlock()
 	_, err := unix.Seek(int(l.fd), 0, os.SEEK_SET)
 	if err != nil {
 		return true, err

--- a/pkg/mount/mount.go
+++ b/pkg/mount/mount.go
@@ -41,6 +41,11 @@ func (e *mountError) Cause() error {
 	return e.err
 }
 
+// Unwrap returns the underlying cause of the error
+func (e *mountError) Unwrap() error {
+	return e.err
+}
+
 // Mount will mount filesystem according to the specified configuration, on the
 // condition that the target path is *not* already mounted. Options must be
 // specified like the mount or fstab unix commands: "opt1=val1,opt2=val2". See

--- a/pkg/mount/mounter_linux_test.go
+++ b/pkg/mount/mounter_linux_test.go
@@ -138,7 +138,7 @@ func validateMount(t *testing.T, mnt string, opts, optional, vfs string) {
 			wantedVFS[opt] = struct{}{}
 		}
 	}
-	volunteeredVFS := map[string]struct{}{"seclabel": {}}
+	volunteeredVFS := map[string]struct{}{"seclabel": {}, "inode32": {}, "inode64": {}}
 	volunteeredOPT := map[string]struct{}{"relatime": {}}
 
 	mnts := make(map[int]*Info, len(info))

--- a/pkg/mount/sharedsubtree_linux_test.go
+++ b/pkg/mount/sharedsubtree_linux_test.go
@@ -1,6 +1,7 @@
 package mount
 
 import (
+	"errors"
 	"os"
 	"path"
 	"testing"
@@ -324,7 +325,7 @@ func TestSubtreeUnbindable(t *testing.T) {
 	}()
 
 	// then attempt to mount it to target. It should fail
-	if err := Mount(sourceDir, targetDir, "none", "bind,rw"); err != nil && err != unix.EINVAL {
+	if err := Mount(sourceDir, targetDir, "none", "bind,rw"); err != nil && !errors.Is(err, unix.EINVAL) {
 		t.Fatal(err)
 	} else if err == nil {
 		t.Fatalf("%q should not have been bindable", sourceDir)

--- a/utils.go
+++ b/utils.go
@@ -138,14 +138,16 @@ func getRootlessRuntimeDirIsolated(env rootlessRuntimeDirEnvironment) (string, e
 	}
 
 	tmpPerUserDir := env.getTmpPerUserDir()
-	if _, err := env.systemLstat(tmpPerUserDir); os.IsNotExist(err) {
-		if err := os.Mkdir(tmpPerUserDir, 0700); err != nil {
-			logrus.Errorf("failed to create temp directory for user: %v", err)
-		} else {
+	if tmpPerUserDir != "" {
+		if _, err := env.systemLstat(tmpPerUserDir); os.IsNotExist(err) {
+			if err := os.Mkdir(tmpPerUserDir, 0700); err != nil {
+				logrus.Errorf("failed to create temp directory for user: %v", err)
+			} else {
+				return tmpPerUserDir, nil
+			}
+		} else if isRootlessRuntimeDirOwner(tmpPerUserDir, env) {
 			return tmpPerUserDir, nil
 		}
-	} else if isRootlessRuntimeDirOwner(tmpPerUserDir, env) {
-		return tmpPerUserDir, nil
 	}
 
 	homeDir := env.homedirGet()

--- a/utils.go
+++ b/utils.go
@@ -306,6 +306,13 @@ func defaultStoreOptionsIsolated(rootless bool, rootlessUID int, storageConf str
 		}
 		storageOpts.GraphRoot = graphRoot
 	}
+	if storageOpts.RootlessStoragePath != "" {
+		storagePath, err := expandEnvPath(storageOpts.RootlessStoragePath, rootlessUID)
+		if err != nil {
+			return storageOpts, err
+		}
+		storageOpts.RootlessStoragePath = storagePath
+	}
 
 	return storageOpts, nil
 }

--- a/utils_test.go
+++ b/utils_test.go
@@ -262,7 +262,7 @@ func TestRootlessRuntimeDirRace(t *testing.T) {
 func TestDefaultStoreOpts(t *testing.T) {
 	storageOpts, err := defaultStoreOptionsIsolated(true, 1000, "./storage_test.conf")
 
-	expectedPath := filepath.Join(os.Getenv("NAME"), "1000", "containers/storage")
+	expectedPath := filepath.Join(os.Getenv("HOME"), "1000", "containers/storage")
 
 	assert.NilError(t, err)
 	assert.Equal(t, storageOpts.RunRoot, expectedPath)

--- a/utils_test.go
+++ b/utils_test.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -13,8 +14,8 @@ import (
 )
 
 type homeRuntimeData struct {
-	dir   string
-	error error
+	dir string
+	err error
 }
 
 type rootlessRuntimeDirEnvironmentTest struct {
@@ -36,7 +37,7 @@ func (env rootlessRuntimeDirEnvironmentTest) getTmpPerUserDir() string {
 	return env.tmpPerUserDir
 }
 func (env rootlessRuntimeDirEnvironmentTest) homeDirGetRuntimeDir() (string, error) {
-	return env.homeRuntime.dir, env.homeRuntime.error
+	return env.homeRuntime.dir, env.homeRuntime.err
 }
 func (env rootlessRuntimeDirEnvironmentTest) systemLstat(path string) (*system.StatT, error) {
 	return system.Lstat(path)
@@ -54,7 +55,7 @@ func TestRootlessRuntimeDir(t *testing.T) {
 	err = os.Mkdir(homeRuntimeDir, 0700)
 	assert.NilError(t, err)
 
-	homeRuntimeDisabled := homeRuntimeData{error: errors.New("homedirGetRuntimeDir is disabled")}
+	homeRuntimeDisabled := homeRuntimeData{err: errors.New("homedirGetRuntimeDir is disabled")}
 
 	systemdCommandFile := filepath.Join(testDir, "systemd-command")
 	err = ioutil.WriteFile(systemdCommandFile, []byte("systemd"), 0644)
@@ -199,12 +200,14 @@ func TestRootlessRuntimeDir(t *testing.T) {
 		},
 	}
 
-	for _, env := range envs {
-		os.Remove(dirToBeCreated)
+	for i, env := range envs {
+		t.Run(fmt.Sprintf("%d", i), func(t *testing.T) {
+			os.Remove(dirToBeCreated)
 
-		resultDir, err := getRootlessRuntimeDirIsolated(env)
-		assert.NilError(t, err)
-		assert.Assert(t, resultDir == env.result)
+			resultDir, err := getRootlessRuntimeDirIsolated(env)
+			assert.NilError(t, err)
+			assert.Assert(t, resultDir == env.result)
+		})
 	}
 }
 


### PR DESCRIPTION
Fix a race where the state lock in a Unixy lockfile structure wasn't being used to protect access to all of the structure's state fields, fixing #831.

Fix usage of sync/atomic in the corresponding unit tests to not mix atomic adds and reads with non-atomic reads, something which the race detector complained about.

Start running unit tests again in CI.  It was not intentionally that we stopped doing that.