### PR TITLE
overlay: fix path to incompat/volatile

### DIFF
--- a/cmd/containers-storage/create.go
+++ b/cmd/containers-storage/create.go
@@ -32,6 +32,7 @@ var (
 	paramSubUIDMap    = ""
 	paramSubGIDMap    = ""
 	paramReadOnly     = false
+	paramVolatile     = false
 )
 
 func paramIDMapping() (*types.IDMappingOptions, error) {
@@ -192,7 +193,7 @@ func createContainer(flags *mflag.FlagSet, action string, m storage.Store, args 
 		fmt.Fprintf(os.Stderr, "%v\n", err)
 		return 1
 	}
-	options := &storage.ContainerOptions{IDMappingOptions: *mappings}
+	options := &storage.ContainerOptions{IDMappingOptions: *mappings, Volatile: paramVolatile}
 	image := args[0]
 	container, err := m.CreateContainer(paramID, paramNames, image, paramLayer, paramMetadata, options)
 	if err != nil {
@@ -277,6 +278,7 @@ func init() {
 		action:      createContainer,
 		addFlags: func(flags *mflag.FlagSet, cmd *command) {
 			flags.Var(opts.NewListOptsRef(&paramNames, nil), []string{"-name", "n"}, "Container name")
+			flags.BoolVar(&paramVolatile, []string{"-volatile"}, false, "Mark as volatile")
 			flags.StringVar(&paramID, []string{"-id", "i"}, "", "Container ID")
 			flags.StringVar(&paramMetadata, []string{"-metadata", "m"}, "", "Metadata")
 			flags.StringVar(&paramMetadataFile, []string{"-metadata-file", "f"}, "", "Metadata File")

--- a/tests/create-container.bats
+++ b/tests/create-container.bats
@@ -75,3 +75,35 @@ load helpers
 	[ "${lines[2]}" = "$zerothcontainer" ] || [ "${lines[2]}" = "$firstcontainer" ] || [ "${lines[2]}" = "$secondcontainer" ] || [ "${lines[2]}" = "$thirdcontainer" ]
 	[ "${lines[3]}" = "$zerothcontainer" ] || [ "${lines[3]}" = "$firstcontainer" ] || [ "${lines[3]}" = "$secondcontainer" ] || [ "${lines[3]}" = "$thirdcontainer" ]
 }
+
+@test "create-and-mount-volatile-container" {
+	# Create a container based on no image.
+	run storage --debug=false create-container --volatile ""
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	container=${output%%	*}
+
+	run storage --debug=false mount $container
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	path=${output%%	*}
+
+	echo test > $path/newfile
+
+	run storage --debug=false unmount $container
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+
+	run storage --debug=false mount $container
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	path=${output%%	*}
+
+	run cat $path/newfile
+	[ "$status" -eq 0 ]
+	[ "$output" == "test" ]
+
+	run storage --debug=false unmount $container
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+}


### PR DESCRIPTION
overlay creates the directory "$workdir/work/incompat/volatile", not
"$workdir/incompat/volatile".

commit ffe1eb2df5e0ecac7ce794a1925dece6890579c5 introduced the issue.

Closes: https://github.com/containers/podman/issues/9507

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>