### PR TITLE
Inherit system storage driver in rootless configurations

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -703,6 +703,7 @@ Joost Cassee <joost@cassee.net>
 Jordan <jjn2009@users.noreply.github.com>
 Jordan Arentsen <blissdev@gmail.com>
 Jordan Sissel <jls@semicomplete.com>
+Jordan Williams <jordan@jwillikers.com>
 Jose Diaz-Gonzalez <josegonzalez@users.noreply.github.com>
 Joseph Anthony Pasquale Holsten <joseph@josephholsten.com>
 Joseph Hager <ajhager@gmail.com>

--- a/docs/containers-storage.conf.5.md
+++ b/docs/containers-storage.conf.5.md
@@ -29,7 +29,10 @@ The `storage` table supports the following options:
 **driver**=""
   container storage driver
   Default Copy On Write (COW) container storage driver. Valid drivers are "overlay", "vfs", "devmapper", "aufs", "btrfs", and "zfs". Some drivers (for example, "zfs", "btrfs", and "aufs") may not work if your kernel lacks support for the filesystem.
-  This field is requiered to guarantee proper operation.
+  This field is required to guarantee proper operation.
+  Valid rootless drivers are "btrfs", "overlay", and "vfs".
+  Rootless users default to the driver defined in the system configuration when possible.
+  When the system configuration uses an unsupported rootless driver, rootless users default to "overlay" if available, otherwise "vfs".
 
 **graphroot**=""
   container storage graph dir (default: "/var/lib/containers/storage")

--- a/types/options_test.go
+++ b/types/options_test.go
@@ -1,0 +1,99 @@
+package types
+
+import (
+	"fmt"
+	"os"
+	"testing"
+
+	"gotest.tools/assert"
+)
+
+func TestGetRootlessStorageOpts(t *testing.T) {
+	envDriver, envDriverSet := os.LookupEnv("STORAGE_DRIVER")
+	os.Unsetenv("STORAGE_DRIVER")
+
+	const vfsDriver = "vfs"
+	const overlayDriver = "overlay"
+
+	t.Run("systemDriver=btrfs", func(t *testing.T) {
+		systemOpts := StoreOptions{}
+		systemOpts.GraphDriverName = "btrfs"
+		storageOpts, err := getRootlessStorageOpts(1000, systemOpts)
+		assert.NilError(t, err)
+		assert.Equal(t, storageOpts.GraphDriverName, "btrfs")
+	})
+
+	t.Run("systemDriver=overlay", func(t *testing.T) {
+		systemOpts := StoreOptions{}
+		systemOpts.GraphDriverName = overlayDriver
+		storageOpts, err := getRootlessStorageOpts(1000, systemOpts)
+		assert.NilError(t, err)
+		assert.Equal(t, storageOpts.GraphDriverName, overlayDriver)
+	})
+
+	t.Run("systemDriver=overlay2", func(t *testing.T) {
+		systemOpts := StoreOptions{}
+		systemOpts.GraphDriverName = "overlay2"
+		storageOpts, err := getRootlessStorageOpts(1000, systemOpts)
+		assert.NilError(t, err)
+		assert.Equal(t, storageOpts.GraphDriverName, "overlay2")
+	})
+
+	t.Run("systemDriver=vfs", func(t *testing.T) {
+		systemOpts := StoreOptions{}
+		systemOpts.GraphDriverName = vfsDriver
+		storageOpts, err := getRootlessStorageOpts(1000, systemOpts)
+		assert.NilError(t, err)
+		assert.Equal(t, storageOpts.GraphDriverName, vfsDriver)
+	})
+
+	t.Run("systemDriver=aufs", func(t *testing.T) {
+		systemOpts := StoreOptions{}
+		systemOpts.GraphDriverName = "aufs"
+		storageOpts, err := getRootlessStorageOpts(1000, systemOpts)
+		assert.NilError(t, err)
+		assert.Assert(t, storageOpts.GraphDriverName == overlayDriver || storageOpts.GraphDriverName == vfsDriver, fmt.Sprintf("The rootless driver should be set to 'overlay' or 'vfs' not '%v'", storageOpts.GraphDriverName))
+	})
+
+	t.Run("systemDriver=devmapper", func(t *testing.T) {
+		systemOpts := StoreOptions{}
+		systemOpts.GraphDriverName = "devmapper"
+		storageOpts, err := getRootlessStorageOpts(1000, systemOpts)
+		assert.NilError(t, err)
+		assert.Assert(t, storageOpts.GraphDriverName == overlayDriver || storageOpts.GraphDriverName == vfsDriver, fmt.Sprintf("The rootless driver should be set to 'overlay' or 'vfs' not '%v'", storageOpts.GraphDriverName))
+	})
+
+	t.Run("systemDriver=zfs", func(t *testing.T) {
+		systemOpts := StoreOptions{}
+		systemOpts.GraphDriverName = "zfs"
+		storageOpts, err := getRootlessStorageOpts(1000, systemOpts)
+		assert.NilError(t, err)
+		assert.Assert(t, storageOpts.GraphDriverName == overlayDriver || storageOpts.GraphDriverName == vfsDriver, fmt.Sprintf("The rootless driver should be set to 'overlay' or 'vfs' not '%v'", storageOpts.GraphDriverName))
+	})
+
+	t.Run("STORAGE_DRIVER=btrfs", func(t *testing.T) {
+		os.Setenv("STORAGE_DRIVER", "btrfs")
+		defer os.Unsetenv("STORAGE_DRIVER")
+		systemOpts := StoreOptions{}
+		systemOpts.GraphDriverName = vfsDriver
+		storageOpts, err := getRootlessStorageOpts(1000, systemOpts)
+		assert.NilError(t, err)
+		assert.Equal(t, storageOpts.GraphDriverName, "btrfs")
+	})
+
+	t.Run("STORAGE_DRIVER=zfs", func(t *testing.T) {
+		os.Setenv("STORAGE_DRIVER", "zfs")
+		defer os.Unsetenv("STORAGE_DRIVER")
+		systemOpts := StoreOptions{}
+		systemOpts.GraphDriverName = vfsDriver
+		storageOpts, err := getRootlessStorageOpts(1000, systemOpts)
+		assert.NilError(t, err)
+		assert.Equal(t, storageOpts.GraphDriverName, "zfs")
+	})
+
+	if envDriverSet {
+		os.Setenv("STORAGE_DRIVER", envDriver)
+	} else {
+		os.Unsetenv("STORAGE_DRIVER")
+	}
+}


### PR DESCRIPTION
Fixes containers/podman#9547

The storage driver set in `/etc/containers/storage.conf` was ignored for rootless configurations.
Rootless configurations would use overlay or vfs by default.
If the `STORAGE_DRIVER` environment was variable set, this value would be used instead.

This commit changes this behavior to inherit the driver set in `/etc/containers/storage.conf`.
To inherit the driver in rootless configurations, the driver must be valid in a rootless context.
The valid rootless drivers are btrfs, overlay, and vfs at this time.
To remain consistent with previous behavior, the `STORAGE_DRIVER` environment variable supersedes any driver set in `/etc/containers/storage.conf` and does not need to be a valid rootless driver.

buildah's documentation for the `--storage-driver` command [here](https://github.com/containers/buildah/blob/master/docs/buildah.md#options) will need to be updated to reflect these changes.