### PR TITLE
Add dependabot.yml configuration file

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,7 @@
+version: 2
+updates:
+- package-ecosystem: gomod
+  directory: "/"
+  schedule:
+    interval: daily
+  open-pull-requests-limit: 10


### PR DESCRIPTION
We now follow the official [dependabot guide][0] for this repository,
which should work with vendoring of go modules, too.

[0]: https://docs.github.com/en/github/administering-a-repository/enabling-and-disabling-version-updates
