### PR TITLE
overlay: add detection for overlay support in a user namespace

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -145,6 +145,10 @@ func hasVolatileOption(opts []string) bool {
 	return false
 }
 
+func getMountProgramFlagFile(path string) string {
+	return filepath.Join(path, ".has-mount-program")
+}
+
 func checkSupportVolatile(home, runhome string) (bool, error) {
 	feature := fmt.Sprintf("volatile")
 	volatileCacheResult, _, err := cachedFeatureCheck(runhome, feature)
@@ -230,8 +234,13 @@ func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) 
 		backingFs = fsName
 	}
 
-	// check if they are running over btrfs, aufs, zfs, overlay, or ecryptfs
-	if opts.mountProgram == "" {
+	if opts.mountProgram != "" {
+		f, err := os.Create(getMountProgramFlagFile(home))
+		if err == nil {
+			f.Close()
+		}
+	} else {
+		// check if they are running over btrfs, aufs, zfs, overlay, or ecryptfs
 		if opts.forceMask != nil {
 			return nil, errors.New("'force_mask' is supported only with 'mount_program'")
 		}

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -533,7 +533,7 @@ func supportsOverlay(home string, homeMagic graphdriver.FsMagic, rootUID, rootGI
 		_ = idtools.MkdirAs(workDir, 0700, rootUID, rootGID)
 		flags := fmt.Sprintf("lowerdir=%s:%s,upperdir=%s,workdir=%s", lower1Dir, lower2Dir, upperDir, workDir)
 		if len(flags) < unix.Getpagesize() {
-			err := mountFrom(filepath.Dir(home), "overlay", mergedDir, "overlay", 0, flags)
+			err := unix.Mount("overlay", mergedDir, "overlay", 0, flags)
 			if err == nil {
 				logrus.Debugf("overlay test mount with multiple lowers succeeded")
 				return supportsDType, nil
@@ -542,7 +542,7 @@ func supportsOverlay(home string, homeMagic graphdriver.FsMagic, rootUID, rootGI
 		}
 		flags = fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", lower1Dir, upperDir, workDir)
 		if len(flags) < unix.Getpagesize() {
-			err := mountFrom(filepath.Dir(home), "overlay", mergedDir, "overlay", 0, flags)
+			err := unix.Mount("overlay", mergedDir, "overlay", 0, flags)
 			if err == nil {
 				logrus.Errorf("overlay test mount with multiple lowers failed, but succeeded with a single lower")
 				return supportsDType, errors.Wrap(graphdriver.ErrNotSupported, "kernel too old to provide multiple lowers feature for overlay")

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -630,18 +630,6 @@ func (d *Driver) Metadata(id string) (map[string]string, error) {
 	return metadata, nil
 }
 
-// ReadWriteDiskUsage returns the disk usage of the writable directory for the ID.
-// For Overlay, it attempts to check the XFS quota for size, and falls back to
-// finding the size of the "diff" directory.
-func (d *Driver) ReadWriteDiskUsage(id string) (*directory.DiskUsage, error) {
-	usage := &directory.DiskUsage{}
-	if d.quotaCtl != nil {
-		err := d.quotaCtl.GetDiskUsage(d.dir(id), usage)
-		return usage, err
-	}
-	return directory.Usage(path.Join(d.dir(id), "diff"))
-}
-
 // Cleanup any state created by overlay which should be cleaned when daemon
 // is being shutdown. For now, we just have to unmount the bind mounted
 // we had created.

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -494,6 +494,11 @@ func supportsOverlay(home string, homeMagic graphdriver.FsMagic, rootUID, rootGI
 
 	exec.Command("modprobe", "overlay").Run()
 
+	logLevel := logrus.ErrorLevel
+	if unshare.IsRootless() {
+		logLevel = logrus.DebugLevel
+	}
+
 	layerDir, err := ioutil.TempDir(home, "compat")
 	if err != nil {
 		patherr, ok := err.(*os.PathError)
@@ -549,11 +554,11 @@ func supportsOverlay(home string, homeMagic graphdriver.FsMagic, rootUID, rootGI
 			}
 			logrus.Debugf("overlay test mount with a single lower failed %v", err)
 		}
-		logrus.Errorf("'overlay' is not supported over %s at %q", backingFs, home)
+		logrus.StandardLogger().Logf(logLevel, "'overlay' is not supported over %s at %q", backingFs, home)
 		return supportsDType, errors.Wrapf(graphdriver.ErrIncompatibleFS, "'overlay' is not supported over %s at %q", backingFs, home)
 	}
 
-	logrus.Error("'overlay' not found as a supported filesystem on this host. Please ensure kernel is new enough and has overlay support loaded.")
+	logrus.StandardLogger().Logf(logLevel, "'overlay' not found as a supported filesystem on this host. Please ensure kernel is new enough and has overlay support loaded.")
 	return supportsDType, errors.Wrap(graphdriver.ErrNotSupported, "'overlay' not found as a supported filesystem on this host. Please ensure kernel is new enough and has overlay support loaded.")
 }
 

--- a/drivers/overlay/overlay_cgo.go
+++ b/drivers/overlay/overlay_cgo.go
@@ -1,0 +1,21 @@
+// +build linux,cgo
+
+package overlay
+
+import (
+	"path"
+
+	"github.com/containers/storage/pkg/directory"
+)
+
+// ReadWriteDiskUsage returns the disk usage of the writable directory for the ID.
+// For Overlay, it attempts to check the XFS quota for size, and falls back to
+// finding the size of the "diff" directory.
+func (d *Driver) ReadWriteDiskUsage(id string) (*directory.DiskUsage, error) {
+	usage := &directory.DiskUsage{}
+	if d.quotaCtl != nil {
+		err := d.quotaCtl.GetDiskUsage(d.dir(id), usage)
+		return usage, err
+	}
+	return directory.Usage(path.Join(d.dir(id), "diff"))
+}

--- a/drivers/overlay/overlay_nocgo.go
+++ b/drivers/overlay/overlay_nocgo.go
@@ -1,0 +1,16 @@
+// +build linux,!cgo
+
+package overlay
+
+import (
+	"path"
+
+	"github.com/containers/storage/pkg/directory"
+)
+
+// ReadWriteDiskUsage returns the disk usage of the writable directory for the ID.
+// For Overlay, it attempts to check the XFS quota for size, and falls back to
+// finding the size of the "diff" directory.
+func (d *Driver) ReadWriteDiskUsage(id string) (*directory.DiskUsage, error) {
+	return directory.Usage(path.Join(d.dir(id), "diff"))
+}

--- a/drivers/overlay/overlay_unsupported.go
+++ b/drivers/overlay/overlay_unsupported.go
@@ -1,3 +1,7 @@
 // +build !linux
 
 package overlay
+
+func SupportsNativeOverlay(graphroot, rundir string) (bool, error) {
+	return false, nil
+}


### PR DESCRIPTION
add a public function to check whether the kernel supports native overlay.

If the existing storage was created using a mount_program, refuse to use the native overlay as they are not fully compatible, e.g. native overlay uses device whiteout files while a mount_program such as fuse-overlayfs could be using a different format to accomodate older kernels where unprivileged users cannot create whiteout devices.

Users will need the equivalent of "podman system reset" to move to native support.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
