### PR TITLE
overlay: allow to reset mount_program

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -397,7 +397,7 @@ func parseOptions(options []string) (*overlayOptions, error) {
 			if val != "" {
 				_, err := os.Stat(val)
 				if err != nil {
-					return nil, fmt.Errorf("overlay: can't stat program %s: %v", val, err)
+					return nil, errors.Wrapf(err, "overlay: can't stat program %q", val)
 				}
 			}
 			o.mountProgram = val

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -394,9 +394,11 @@ func parseOptions(options []string) (*overlayOptions, error) {
 			}
 		case "mount_program":
 			logrus.Debugf("overlay: mount_program=%s", val)
-			_, err := os.Stat(val)
-			if err != nil {
-				return nil, fmt.Errorf("overlay: can't stat program %s: %v", val, err)
+			if val != "" {
+				_, err := os.Stat(val)
+				if err != nil {
+					return nil, fmt.Errorf("overlay: can't stat program %s: %v", val, err)
+				}
 			}
 			o.mountProgram = val
 		case "skip_mount_home":


### PR DESCRIPTION
if the mount_program is set to the empty string then clear its value
and not use a mount program instead of failing.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>