### PR TITLE
chown: ignore both pkg/system.EOPNOTSUPP and pkg/system.ErrNotSupportedPlatform

### DIFF
--- a/drivers/chown_unix.go
+++ b/drivers/chown_unix.go
@@ -3,6 +3,7 @@
 package graphdriver
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"syscall"
@@ -49,7 +50,7 @@ func platformLChown(path string, info os.FileInfo, toHost, toContainer *idtools.
 	}
 	if uid != int(st.Uid) || gid != int(st.Gid) {
 		cap, err := system.Lgetxattr(path, "security.capability")
-		if err != nil && err != system.ErrNotSupportedPlatform {
+		if err != nil && !errors.Is(err, system.EOPNOTSUPP) && err != system.ErrNotSupportedPlatform {
 			return fmt.Errorf("%s: %v", os.Args[0], err)
 		}
 


### PR DESCRIPTION
Where we ignored a pkg/system.ErrNotSupportedPlatform error from pkg/system.Lgetxattr(), also ignore ENOTSUP/EOPNOTSUPP, as we already do elsewhere.  Should fix https://github.com/containers/podman/issues/9687.