### PR TITLE
copy: create a unix socket with os.ModeSocket

### DIFF
--- a/drivers/copy/copy_linux.go
+++ b/drivers/copy/copy_linux.go
@@ -15,6 +15,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -192,12 +193,16 @@ func DirCopy(srcDir, dstDir string, copyMode Mode, copyXattrs bool) error {
 			}
 
 		case mode&os.ModeNamedPipe != 0:
-			fallthrough
-
-		case mode&os.ModeSocket != 0:
 			if err := unix.Mkfifo(dstPath, stat.Mode); err != nil {
 				return err
 			}
+
+		case mode&os.ModeSocket != 0:
+			s, err := net.Listen("unix", dstPath)
+			if err != nil {
+				return err
+			}
+			s.Close()
 
 		case mode&os.ModeDevice != 0:
 			if rsystem.RunningInUserNS() {


### PR DESCRIPTION
os.ModeSocket refers to a UNIX socket, not a FIFO.

I've noticed the issue while working on https://github.com/containers/buildah/pull/3075

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>