### PR TITLE
Rework autons ID mapping generation.

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/Microsoft/go-winio v0.4.17-0.20210211115548-6eac466e5fa3
 	github.com/Microsoft/hcsshim v0.8.15
 	github.com/docker/go-units v0.4.0
+	github.com/google/go-intervals v0.0.2
 	github.com/hashicorp/go-multierror v1.1.1
 	github.com/klauspost/compress v1.11.13
 	github.com/klauspost/pgzip v1.2.5

--- a/go.sum
+++ b/go.sum
@@ -258,6 +258,8 @@ github.com/google/go-cmp v0.5.0/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/
 github.com/google/go-cmp v0.5.1/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
 github.com/google/go-cmp v0.5.2 h1:X2ev0eStA3AbceY54o37/0PQ/UWqKEiiO2dKL5OPaFM=
 github.com/google/go-cmp v0.5.2/go.mod h1:v8dTdLbMG2kIc/vJvl+f65V22dbkXbowE6jgT/gNBxE=
+github.com/google/go-intervals v0.0.2 h1:FGrVEiUnTRKR8yE04qzXYaJMtnIYqobR5QbblK3ixcM=
+github.com/google/go-intervals v0.0.2/go.mod h1:MkaR3LNRfeKLPmqgJYs4E66z5InYjmCjbbr4TQlcT6Y=
 github.com/google/gofuzz v1.0.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/gofuzz v1.1.0/go.mod h1:dBl0BpW6vV/+mYPU4Po3pmUjxk6FQPldtuIdl/M65Eg=
 github.com/google/martian v2.1.0+incompatible/go.mod h1:9I4somxYTbIHy5NJKHRl3wXiIaQGbYVAs8BPL6v8lEs=

--- a/idset.go
+++ b/idset.go
@@ -1,0 +1,220 @@
+package storage
+
+import (
+	"github.com/containers/storage/pkg/idtools"
+	"github.com/google/go-intervals/intervalset"
+	"github.com/pkg/errors"
+)
+
+// idSet represents a set of integer IDs. It is stored as an ordered set of intervals.
+type idSet struct {
+	set *intervalset.ImmutableSet
+}
+
+func newIDSet(intervals []interval) *idSet {
+	s := intervalset.Empty()
+	for _, i := range intervals {
+		s.Add(intervalset.NewSet([]intervalset.Interval{i}))
+	}
+	return &idSet{set: s.ImmutableSet()}
+}
+
+// getHostIDs returns all the host ids in the id map.
+func getHostIDs(idMaps []idtools.IDMap) *idSet {
+	var intervals []interval
+	for _, m := range idMaps {
+		intervals = append(intervals, interval{start: m.HostID, end: m.HostID + m.Size})
+	}
+	return newIDSet(intervals)
+}
+
+// getContainerIDs returns all the container ids in the id map.
+func getContainerIDs(idMaps []idtools.IDMap) *idSet {
+	var intervals []interval
+	for _, m := range idMaps {
+		intervals = append(intervals, interval{start: m.ContainerID, end: m.ContainerID + m.Size})
+	}
+	return newIDSet(intervals)
+}
+
+// subtract returns the subtraction of `s` and `t`. `s` and `t` are unchanged.
+func (s *idSet) subtract(t *idSet) *idSet {
+	if s == nil || t == nil {
+		return s
+	}
+	return &idSet{set: s.set.Sub(t.set)}
+}
+
+// union returns the union of `s` and `t`. `s` and `t` are unchanged.
+func (s *idSet) union(t *idSet) *idSet {
+	if s == nil {
+		return t
+	} else if t == nil {
+		return s
+	}
+	return &idSet{set: s.set.Union(t.set)}
+}
+
+// Methods to iterate over the intervals of the idSet. intervalset doesn't provide one :-(
+
+// iterator to idSet. Returns nil if iteration finishes.
+type iteratorFn func() *interval
+
+// cancelFn must be called exactly once unless iteratorFn returns nil, otherwise go routine might
+// leak.
+type cancelFn func()
+
+func (s *idSet) iterator() (iteratorFn, cancelFn) {
+	if s == nil {
+		return func() *interval { return nil }, func() {}
+	}
+	cancelCh := make(chan byte)
+	dataCh := make(chan interval)
+	go func() {
+		s.set.Intervals(func(ii intervalset.Interval) bool {
+			select {
+			case <-cancelCh:
+				return false
+			case dataCh <- ii.(interval):
+				return true
+			}
+		})
+		close(dataCh)
+	}()
+	iterator := func() *interval {
+		i, ok := <-dataCh
+		if !ok {
+			return nil
+		}
+		return &i
+	}
+	return iterator, func() { close(cancelCh) }
+}
+
+// size returns the total number of ids in the ID set.
+func (s *idSet) size() int {
+	var size int
+	iterator, cancel := s.iterator()
+	defer cancel()
+	for i := iterator(); i != nil; i = iterator() {
+		size += i.length()
+	}
+	return size
+}
+
+// findAvailable finds the `n` ids from `s`.
+func (s *idSet) findAvailable(n int) (*idSet, error) {
+	var intervals []intervalset.Interval
+	iterator, cancel := s.iterator()
+	defer cancel()
+	for i := iterator(); n > 0 && i != nil; i = iterator() {
+		i.end = minInt(i.end, i.start+n)
+		intervals = append(intervals, *i)
+		n -= i.length()
+	}
+	if n > 0 {
+		return nil, errors.New("could not find enough available IDs")
+	}
+	return &idSet{set: intervalset.NewImmutableSet(intervals)}, nil
+}
+
+// zip creates an id map from `s` (host ids) and container ids.
+func (s *idSet) zip(container *idSet) []idtools.IDMap {
+	hostIterator, hostCancel := s.iterator()
+	defer hostCancel()
+	containerIterator, containerCancel := container.iterator()
+	defer containerCancel()
+	var out []idtools.IDMap
+	for h, c := hostIterator(), containerIterator(); h != nil && c != nil; {
+		if n := minInt(h.length(), c.length()); n > 0 {
+			out = append(out, idtools.IDMap{
+				ContainerID: c.start,
+				HostID:      h.start,
+				Size:        n,
+			})
+			h.start += n
+			c.start += n
+		}
+		if h.IsZero() {
+			h = hostIterator()
+		}
+		if c.IsZero() {
+			c = containerIterator()
+		}
+	}
+	return out
+}
+
+// interval represents an interval of integers [start, end). Note it is allowed to have
+// start >= end, in which case it is treated as an empty interval. It implements interface
+// intervalset.Interval.
+type interval struct {
+	// Start of the interval (inclusive).
+	start int
+	// End of the interval (exclusive).
+	end int
+}
+
+func (i interval) length() int {
+	return maxInt(0, i.end-i.start)
+}
+
+func (i interval) Intersect(other intervalset.Interval) intervalset.Interval {
+	j := other.(interval)
+	return interval{start: maxInt(i.start, j.start), end: minInt(i.end, j.end)}
+}
+
+func (i interval) Before(other intervalset.Interval) bool {
+	j := other.(interval)
+	return !i.IsZero() && !j.IsZero() && i.end < j.start
+}
+
+func (i interval) IsZero() bool {
+	return i.length() <= 0
+}
+
+func (i interval) Bisect(other intervalset.Interval) (intervalset.Interval, intervalset.Interval) {
+	j := other.(interval)
+	if j.IsZero() {
+		return i, interval{}
+	}
+	// Subtracting [j.start, j.end) is equivalent to the union of intersecting (-inf, j.start) and
+	// [j.end, +inf).
+	left := interval{start: i.start, end: minInt(i.end, j.start)}
+	right := interval{start: maxInt(i.start, j.end), end: i.end}
+	return left, right
+}
+
+func (i interval) Adjoin(other intervalset.Interval) intervalset.Interval {
+	j := other.(interval)
+	if !i.IsZero() && !j.IsZero() && (i.end == j.start || j.end == i.start) {
+		return interval{start: minInt(i.start, j.start), end: maxInt(i.end, j.end)}
+	}
+	return interval{}
+}
+
+func (i interval) Encompass(other intervalset.Interval) intervalset.Interval {
+	j := other.(interval)
+	switch {
+	case i.IsZero():
+		return j
+	case j.IsZero():
+		return i
+	default:
+		return interval{start: minInt(i.start, j.start), end: maxInt(i.end, j.end)}
+	}
+}
+
+func minInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+func maxInt(a, b int) int {
+	if a < b {
+		return b
+	}
+	return a
+}

--- a/idset_test.go
+++ b/idset_test.go
@@ -1,0 +1,924 @@
+package storage
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/containers/storage/pkg/idtools"
+	"github.com/google/go-intervals/intervalset"
+	"github.com/stretchr/testify/assert"
+)
+
+func TestMinMaxInt(t *testing.T) {
+	assert.Equal(t, 5, minInt(5, 8))
+	assert.Equal(t, 3, minInt(10, 3))
+	assert.Equal(t, 2, minInt(2, 2))
+	assert.Equal(t, 8, maxInt(5, 8))
+	assert.Equal(t, 10, maxInt(10, 3))
+	assert.Equal(t, 2, maxInt(2, 2))
+}
+
+func allIntervals(s *idSet) []interval {
+	iterator, cancel := s.iterator()
+	defer cancel()
+	var out []interval
+	for i := iterator(); i != nil; i = iterator() {
+		out = append(out, *i)
+	}
+	return out
+}
+
+func idSetsEqual(x, y *idSet) bool {
+	return reflect.DeepEqual(allIntervals(x), allIntervals(y))
+}
+
+func TestNewIDSet(t *testing.T) {
+	tests := []struct {
+		name      string
+		intervals []interval
+		want      *idSet
+	}{
+		{
+			"Nil",
+			nil,
+			&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{})},
+		},
+		{
+			"Empty",
+			[]interval{},
+			&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{})},
+		},
+		{
+			"OneValidRange",
+			[]interval{{3, 4}},
+			&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{3, 4}})},
+		},
+		{
+			"OneEmptyRange",
+			[]interval{{3, 3}},
+			&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{})},
+		},
+		{
+			"OneInvalidRange",
+			[]interval{{3, 2}},
+			&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{})},
+		},
+		{
+			"TwoRanges",
+			[]interval{{1, 4}, {6, 8}},
+			&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{1, 4}, interval{6, 8}})},
+		},
+		{
+			"SecondRangeEmpty",
+			[]interval{{1, 4}, {6, 6}},
+			&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{1, 4}})},
+		},
+		{
+			"SecondRangeInvalid",
+			[]interval{{1, 4}, {6, 5}},
+			&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{1, 4}})},
+		},
+		{
+			"TwoOverlappingRanges",
+			[]interval{{1, 4}, {3, 6}},
+			&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{1, 6}})},
+		},
+		{
+			"TwoAdjacentRanges",
+			[]interval{{1, 4}, {4, 6}},
+			&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{1, 6}})},
+		},
+		{
+			"TwoUnorderedRanges",
+			[]interval{{6, 8}, {1, 4}},
+			&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{1, 4}, interval{6, 8}})},
+		},
+		{
+			"ThreeRanges",
+			[]interval{{1, 4}, {6, 8}, {11, 20}},
+			&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{1, 4}, interval{6, 8}, interval{11, 20}})},
+		},
+		{
+			"ThreeRangesWithOverlap",
+			[]interval{{1, 4}, {3, 8}, {11, 20}},
+			&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{1, 8}, interval{11, 20}})},
+		},
+		{
+			"FourOverlappingRanges",
+			[]interval{{1, 4}, {6, 8}, {11, 20}, {3, 30}},
+			&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{1, 30}})},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := newIDSet(tt.intervals); !idSetsEqual(got, tt.want) {
+				t.Errorf("newIDSet() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestGetHostAndContainerIDs(t *testing.T) {
+	tests := []struct {
+		name             string
+		idMaps           []idtools.IDMap
+		wantContainerIDs *idSet
+		wantHostIDs      *idSet
+	}{
+		{
+			"Nil",
+			nil,
+			&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{})},
+			&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{})},
+		},
+		{
+			"Empty",
+			[]idtools.IDMap{},
+			&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{})},
+			&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{})},
+		},
+		{
+			"OneInvalidInterval",
+			[]idtools.IDMap{
+				{ContainerID: 10, HostID: 20, Size: -1},
+			},
+			&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{})},
+			&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{})},
+		},
+		{
+			"OneEmptyInterval",
+			[]idtools.IDMap{
+				{ContainerID: 10, HostID: 20, Size: -1},
+			},
+			&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{})},
+			&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{})},
+		},
+		{
+			"OneValidInterval",
+			[]idtools.IDMap{
+				{ContainerID: 10, HostID: 20, Size: 5},
+			},
+			&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{10, 15}})},
+			&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{20, 25}})},
+		},
+		{
+			"TwoValidIntervals",
+			[]idtools.IDMap{
+				{ContainerID: 10, HostID: 20, Size: 5},
+				{ContainerID: 30, HostID: 25, Size: 10},
+			},
+			&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{10, 15}, interval{30, 40}})},
+			&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{20, 35}})},
+		},
+		{
+			"MultipleIntervals",
+			[]idtools.IDMap{
+				{ContainerID: 10, HostID: 20, Size: 10},
+				{ContainerID: 30, HostID: 28, Size: 20},
+				{ContainerID: 40, HostID: 30, Size: -1},
+				{ContainerID: 45, HostID: 50, Size: 0},
+				{ContainerID: 48, HostID: 60, Size: 20},
+			},
+			&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{10, 20}, interval{30, 68}})},
+			&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{20, 48}, interval{60, 80}})},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := getHostIDs(tt.idMaps); !idSetsEqual(got, tt.wantHostIDs) {
+				t.Errorf("getHostIDs() = %v, want %v", got, tt.wantHostIDs)
+			}
+			if got := getContainerIDs(tt.idMaps); !idSetsEqual(got, tt.wantContainerIDs) {
+				t.Errorf("getContainerIDs() = %v, want %v", got, tt.wantContainerIDs)
+			}
+		})
+	}
+}
+
+var idSetOperatorsTestCases = []struct {
+	name         string
+	x            *idSet
+	y            *idSet
+	subtractWant *idSet
+	unionWant    *idSet
+	zipWant      []idtools.IDMap
+}{
+	{
+		"NilAndNil",
+		nil,
+		nil,
+		nil,
+		nil,
+		([]idtools.IDMap)(nil),
+	},
+	{
+		"NilAndNotNil",
+		nil,
+		newIDSet([]interval{{1, 5}}),
+		nil,
+		&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{1, 5}})},
+		([]idtools.IDMap)(nil),
+	},
+	{
+		"NotNilAndNil",
+		newIDSet([]interval{{1, 5}}),
+		nil,
+		&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{1, 5}})},
+		&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{1, 5}})},
+		([]idtools.IDMap)(nil),
+	},
+	{
+		"EmptyAndEmpty",
+		newIDSet([]interval{}),
+		newIDSet([]interval{}),
+		&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{})},
+		&idSet{set: intervalset.NewImmutableSet(nil)},
+		([]idtools.IDMap)(nil),
+	},
+	{
+		"EmptyAndNotEmpty",
+		newIDSet([]interval{}),
+		newIDSet([]interval{{1, 5}}),
+		&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{})},
+		&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{1, 5}})},
+		([]idtools.IDMap)(nil),
+	},
+	{
+		"NotEmptyAndEmpty",
+		newIDSet([]interval{{1, 5}}),
+		newIDSet([]interval{}),
+		&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{1, 5}})},
+		&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{1, 5}})},
+		([]idtools.IDMap)(nil),
+	},
+	{
+		"OneIntervalAndSameInterval",
+		newIDSet([]interval{{1, 5}}),
+		newIDSet([]interval{{1, 5}}),
+		&idSet{set: intervalset.NewImmutableSet(nil)},
+		&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{1, 5}})},
+		[]idtools.IDMap{{ContainerID: 1, HostID: 1, Size: 4}},
+	},
+	{
+		"OneIntervalAndSingleSmallerInterval",
+		newIDSet([]interval{{1, 5}}),
+		newIDSet([]interval{{3, 4}}),
+		&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{1, 3}, interval{4, 5}})},
+		&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{1, 5}})},
+		[]idtools.IDMap{{ContainerID: 3, HostID: 1, Size: 1}},
+	},
+	{
+		"OneIntervalAndSingleBiggerInterval",
+		newIDSet([]interval{{1, 5}}),
+		newIDSet([]interval{{0, 8}}),
+		&idSet{set: intervalset.NewImmutableSet(nil)},
+		&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{0, 8}})},
+		[]idtools.IDMap{{ContainerID: 0, HostID: 1, Size: 4}},
+	},
+	{
+		"OneIntervalAndSingleIntervalLeft",
+		newIDSet([]interval{{1, 5}}),
+		newIDSet([]interval{{1, 3}}),
+		&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{3, 5}})},
+		&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{1, 5}})},
+		[]idtools.IDMap{{ContainerID: 1, HostID: 1, Size: 2}},
+	},
+	{
+		"OneIntervalAndSingleIntervalRight",
+		newIDSet([]interval{{1, 5}}),
+		newIDSet([]interval{{2, 5}}),
+		&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{1, 2}})},
+		&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{1, 5}})},
+		[]idtools.IDMap{{ContainerID: 2, HostID: 1, Size: 3}},
+	},
+	{
+		"OneIntervalAndSingleIntervalLeftAndBeyond",
+		newIDSet([]interval{{1, 5}}),
+		newIDSet([]interval{{-2, 3}}),
+		&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{3, 5}})},
+		&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{-2, 5}})},
+		[]idtools.IDMap{{ContainerID: -2, HostID: 1, Size: 4}},
+	},
+	{
+		"OneIntervalAndSingleIntervalRightAndBeyond",
+		newIDSet([]interval{{1, 5}}),
+		newIDSet([]interval{{2, 8}}),
+		&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{1, 2}})},
+		&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{1, 8}})},
+		[]idtools.IDMap{{ContainerID: 2, HostID: 1, Size: 4}},
+	},
+	{
+		"OneIntervalAndSingleIntervalAdjacentLeft",
+		newIDSet([]interval{{10, 20}}),
+		newIDSet([]interval{{2, 10}}),
+		&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{10, 20}})},
+		&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{2, 20}})},
+		[]idtools.IDMap{{ContainerID: 2, HostID: 10, Size: 8}},
+	},
+	{
+		"OneIntervalAndSingleIntervalAdjacentRight",
+		newIDSet([]interval{{10, 20}}),
+		newIDSet([]interval{{20, 30}}),
+		&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{10, 20}})},
+		&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{10, 30}})},
+		[]idtools.IDMap{{ContainerID: 20, HostID: 10, Size: 10}},
+	},
+	{
+		"OneIntervalAndSingleIntervalNonOverlapLeft",
+		newIDSet([]interval{{10, 20}}),
+		newIDSet([]interval{{2, 5}}),
+		&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{10, 20}})},
+		&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{2, 5}, interval{10, 20}})},
+		[]idtools.IDMap{{ContainerID: 2, HostID: 10, Size: 3}},
+	},
+	{
+		"OneIntervalAndSingleIntervalNonOverlapRight",
+		newIDSet([]interval{{10, 20}}),
+		newIDSet([]interval{{25, 30}}),
+		&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{10, 20}})},
+		&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{10, 20}, interval{25, 30}})},
+		[]idtools.IDMap{{ContainerID: 25, HostID: 10, Size: 5}},
+	},
+	{
+		"OneIntervalAndMultipleIntervals",
+		newIDSet([]interval{{10, 100}}),
+		newIDSet([]interval{
+			{2, 5},
+			{8, 10},
+			{20, 30},
+			{40, 50},
+			{80, 120},
+		}),
+		&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{10, 20}, interval{30, 40}, interval{50, 80}})},
+		&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{2, 5}, interval{8, 120}})},
+		[]idtools.IDMap{
+			{ContainerID: 2, HostID: 10, Size: 3},
+			{ContainerID: 8, HostID: 13, Size: 2},
+			{ContainerID: 20, HostID: 15, Size: 10},
+			{ContainerID: 40, HostID: 25, Size: 10},
+			{ContainerID: 80, HostID: 35, Size: 40},
+		},
+	},
+	{
+		"MultipleIntervalsAndSingle",
+		newIDSet([]interval{
+			{2, 5},
+			{8, 10},
+			{20, 30},
+			{40, 50},
+			{80, 120},
+		}),
+		newIDSet([]interval{{10, 45}}),
+		&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{
+			interval{2, 5},
+			interval{8, 10},
+			interval{45, 50},
+			interval{80, 120},
+		})},
+		&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{2, 5}, interval{8, 50}, interval{80, 120}})},
+		[]idtools.IDMap{
+			{ContainerID: 10, HostID: 2, Size: 3},
+			{ContainerID: 13, HostID: 8, Size: 2},
+			{ContainerID: 15, HostID: 20, Size: 10},
+			{ContainerID: 25, HostID: 40, Size: 10},
+			{ContainerID: 35, HostID: 80, Size: 10},
+		},
+	},
+	{
+		"MultipleIntervalsAndMultipleIntervals",
+		newIDSet([]interval{
+			{2, 5},
+			{8, 10},
+			{20, 30},
+			{40, 50},
+			{80, 120},
+		}),
+		newIDSet([]interval{{10, 45}, {90, 100}, {130, 150}}),
+		&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{
+			interval{2, 5},
+			interval{8, 10},
+			interval{45, 50},
+			interval{80, 90},
+			interval{100, 120},
+		})},
+		&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{
+			interval{2, 5},
+			interval{8, 50},
+			interval{80, 120},
+			interval{130, 150},
+		})},
+		[]idtools.IDMap{
+			{ContainerID: 10, HostID: 2, Size: 3},
+			{ContainerID: 13, HostID: 8, Size: 2},
+			{ContainerID: 15, HostID: 20, Size: 10},
+			{ContainerID: 25, HostID: 40, Size: 10},
+			{ContainerID: 35, HostID: 80, Size: 10},
+			{ContainerID: 90, HostID: 90, Size: 10},
+			{ContainerID: 130, HostID: 100, Size: 20},
+		},
+	},
+}
+
+func TestIDSetSubtract(t *testing.T) {
+	for _, tt := range idSetOperatorsTestCases {
+		t.Run(tt.name, func(t *testing.T) {
+			var ix, iy []interval
+			if tt.x != nil {
+				ix = allIntervals(tt.x)
+			}
+			if tt.y != nil {
+				iy = allIntervals(tt.y)
+			}
+			if got := tt.x.subtract(tt.y); !idSetsEqual(got, tt.subtractWant) {
+				t.Errorf("idSet.subtract() = %v, want %v", got, tt.subtractWant)
+			}
+			// Make sure x and y are unchanged.
+			if tt.x != nil {
+				if jx := allIntervals(tt.x); !reflect.DeepEqual(ix, jx) {
+					t.Errorf("x changed from %v to %v", ix, jx)
+				}
+			}
+			if tt.y != nil {
+				if jy := allIntervals(tt.y); !reflect.DeepEqual(iy, jy) {
+					t.Errorf("y changed from %v to %v", iy, jy)
+				}
+			}
+		})
+	}
+}
+
+func TestIDSetUnion(t *testing.T) {
+	for _, tt := range idSetOperatorsTestCases {
+		t.Run(tt.name, func(t *testing.T) {
+			var ix, iy []interval
+			if tt.x != nil {
+				ix = allIntervals(tt.x)
+			}
+			if tt.y != nil {
+				iy = allIntervals(tt.y)
+			}
+			if got := tt.x.union(tt.y); !idSetsEqual(got, tt.unionWant) {
+				t.Errorf("idSet.union() = %v, want %v", got, tt.unionWant)
+			}
+			// Make sure x and y are unchanged.
+			if tt.x != nil {
+				if jx := allIntervals(tt.x); !reflect.DeepEqual(ix, jx) {
+					t.Errorf("x changed from %v to %v", ix, jx)
+				}
+			}
+			if tt.y != nil {
+				if jy := allIntervals(tt.y); !reflect.DeepEqual(iy, jy) {
+					t.Errorf("y changed from %v to %v", iy, jy)
+				}
+			}
+		})
+	}
+}
+
+func TestIDSetSize(t *testing.T) {
+	tests := []struct {
+		name string
+		set  *idSet
+		want int
+	}{
+		{"Nil", nil, 0},
+		{"Empty", newIDSet([]interval{}), 0},
+		{"EmptyInterval", newIDSet([]interval{{3, 3}}), 0},
+		{"InvalidInterval", newIDSet([]interval{{5, 3}}), 0},
+		{"OneInterval", newIDSet([]interval{{3, 9}}), 6},
+		{"TwoIntervals", newIDSet([]interval{{3, 9}, {20, 25}}), 11},
+		{"TwoAdjacentIntervals", newIDSet([]interval{{3, 9}, {9, 20}}), 17},
+		{"TwoOverlappingIntervals", newIDSet([]interval{{3, 9}, {6, 20}}), 17},
+		{"TwoContainingIntervals", newIDSet([]interval{{3, 9}, {0, 20}}), 20},
+		{"ThreeIntervals", newIDSet([]interval{{3, 9}, {15, 20}, {30, 40}}), 21},
+		{"MultipleIntervals", newIDSet([]interval{{3, 9}, {15, 20}, {3, 0}, {6, 12}, {30, 40}}), 24},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := tt.set.size(); got != tt.want {
+				t.Errorf("idSet.size() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIDSetFindAvailable(t *testing.T) {
+	tests := []struct {
+		name    string
+		set     *idSet
+		n       int
+		want    *idSet
+		wantErr bool
+	}{
+		{
+			"NilIntervalFindZero",
+			nil,
+			0,
+			&idSet{set: intervalset.NewImmutableSet(nil)},
+			false,
+		},
+		{
+			"NilIntervalFindPositive",
+			nil,
+			1,
+			nil,
+			true,
+		},
+		{
+			"NilIntervalFindNegative",
+			nil,
+			-1,
+			&idSet{set: intervalset.NewImmutableSet(nil)},
+			false,
+		},
+		{
+			"EmptyIntervalFindZero",
+			newIDSet([]interval{}),
+			0,
+			&idSet{set: intervalset.NewImmutableSet(nil)},
+			false,
+		},
+		{
+			"EmptyIntervalFindPositive",
+			newIDSet([]interval{}),
+			1,
+			nil,
+			true,
+		},
+		{
+			"EmptyIntervalFindNegative",
+			newIDSet([]interval{}),
+			-1,
+			&idSet{set: intervalset.NewImmutableSet(nil)},
+			false,
+		},
+		{
+			"OneIntervalFindOK",
+			newIDSet([]interval{{1, 5}}),
+			3,
+			&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{1, 4}})},
+			false,
+		},
+		{
+			"OneIntervalFindNotEnough",
+			newIDSet([]interval{{1, 5}}),
+			5,
+			nil,
+			true,
+		},
+		{"OneIntervalFindZero",
+			newIDSet([]interval{{1, 5}}),
+			0,
+			&idSet{set: intervalset.NewImmutableSet(nil)},
+			false,
+		},
+		{
+			"OneIntervalFindNegative",
+			newIDSet([]interval{{1, 5}}),
+			-1,
+			&idSet{set: intervalset.NewImmutableSet(nil)},
+			false,
+		},
+		{
+			"MultipleIntervalsFindOK",
+			newIDSet([]interval{{1, 5}, {9, 15}, {20, 30}}),
+			15,
+			&idSet{set: intervalset.NewImmutableSet([]intervalset.Interval{interval{1, 5}, interval{9, 15}, interval{20, 25}})},
+			false,
+		},
+		{
+			"MultipleIntervalsFindNotEnough",
+			newIDSet([]interval{{1, 5}, {9, 15}, {20, 30}}),
+			25,
+			nil,
+			true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := tt.set.findAvailable(tt.n)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("idSet.findAvailable() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !tt.wantErr && !idSetsEqual(got, tt.want) {
+				t.Errorf("idSet.findAvailable() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIDSetZip(t *testing.T) {
+	for _, tt := range idSetOperatorsTestCases {
+		t.Run(tt.name, func(t *testing.T) {
+			var ix, iy []interval
+			if tt.x != nil {
+				ix = allIntervals(tt.x)
+			}
+			if tt.y != nil {
+				iy = allIntervals(tt.y)
+			}
+			if got := tt.x.zip(tt.y); !reflect.DeepEqual(got, tt.zipWant) {
+				t.Errorf("idSet.zip() = %v, want %v", got, tt.unionWant)
+			}
+			// Make sure x and y are unchanged.
+			if tt.x != nil {
+				if jx := allIntervals(tt.x); !reflect.DeepEqual(ix, jx) {
+					t.Errorf("x changed from %v to %v", ix, jx)
+				}
+			}
+			if tt.y != nil {
+				if jy := allIntervals(tt.y); !reflect.DeepEqual(iy, jy) {
+					t.Errorf("y changed from %v to %v", iy, jy)
+				}
+			}
+		})
+	}
+}
+
+func TestIntervalLength(t *testing.T) {
+	tests := []struct {
+		name  string
+		start int
+		end   int
+		want  int
+	}{
+		{"ZeroLength", 3, 3, 0},
+		{"PositiveLength", 2, 10, 8},
+		{"NegativeLength", 10, 2, 0},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := interval{
+				start: tt.start,
+				end:   tt.end,
+			}
+			if got := i.length(); got != tt.want {
+				t.Errorf("interval.length() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestIntervalIsZero(t *testing.T) {
+	tests := []struct {
+		name  string
+		start int
+		end   int
+		want  bool
+	}{
+		{"ZeroLength", 3, 3, true},
+		{"PositiveLength", 2, 10, false},
+		{"NegativeLength", 10, 2, true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			i := interval{
+				start: tt.start,
+				end:   tt.end,
+			}
+			if got := i.IsZero(); got != tt.want {
+				t.Errorf("interval.IsZero() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+// assertIntervalSame aserts `got` equals to `want` considering zero check. If the wanted interval
+// is empty, we only want to assert IsZero() == true, instead of the exact number.
+func assertIntervalSame(got intervalset.Interval, want *interval, t *testing.T, name string) {
+	if want == nil && !got.IsZero() {
+		t.Errorf("%v = %v, want nil", name, got)
+	} else if want != nil && !reflect.DeepEqual(got, *want) {
+		t.Errorf("%v = %v, want %v", name, got, *want)
+	}
+}
+
+var intervalTestCases = []struct {
+	name                             string
+	start, end                       int
+	otherStart, otherEnd             int
+	intersectWant                    *interval
+	beforeWant, reflectiveBeforeWant bool
+	bisectWant, reflectiveBisectWant [2]*interval
+	adjoinWant                       *interval
+	encompassWant                    *interval
+}{
+	{
+		"TwoZeroIntervals", 0, 0, 0, 0,
+		nil,
+		false, false,
+		[2]*interval{nil, nil},
+		[2]*interval{nil, nil},
+		nil,
+		nil,
+	},
+	{
+		"ZeroIntervalAndInvalidInterval", 0, 0, 5, 3,
+		nil,
+		false, false,
+		[2]*interval{nil, nil},
+		[2]*interval{nil, nil},
+		nil,
+		nil,
+	},
+	{
+		"ZeroIntervalAndInvalidIntervalIncludingZero", 0, 0, 5, -3,
+		nil,
+		false, false,
+		[2]*interval{nil, nil},
+		[2]*interval{nil, nil},
+		nil,
+		nil,
+	},
+	{
+		"TwoIncludingInvalidIntervals", 3, -2, 5, -3,
+		nil,
+		false, false,
+		[2]*interval{nil, nil},
+		[2]*interval{nil, nil},
+		nil,
+		nil,
+	},
+	{
+		"TwoInvalidIntervals", 8, 6, 5, -3,
+		nil,
+		false, false,
+		[2]*interval{nil, nil},
+		[2]*interval{nil, nil},
+		nil,
+		nil,
+	},
+	{
+		"ZeroIntervalAndNormalInterval", 0, 0, 3, 5,
+		nil,
+		false, false,
+		[2]*interval{nil, nil},
+		[2]*interval{{3, 5}, nil},
+		nil,
+		&interval{3, 5},
+	},
+	{
+		"ZeroIntervalAndNormalIntervalIncludingZero", 0, 0, -3, 5,
+		nil,
+		false, false,
+		[2]*interval{nil, nil},
+		[2]*interval{{-3, 5}, nil},
+		nil,
+		&interval{-3, 5},
+	},
+	{
+		"InvalidIntervalAndNormalInterval", 5, 3, 6, 8,
+		nil,
+		false, false,
+		[2]*interval{nil, nil},
+		[2]*interval{{6, 8}, nil},
+		nil,
+		&interval{6, 8},
+	},
+	{
+		"InvalidIntervalAndNormalIntervalEnclosing", 5, 3, 2, 6,
+		nil,
+		false, false,
+		[2]*interval{nil, nil},
+		[2]*interval{{2, 6}, nil},
+		nil,
+		&interval{2, 6},
+	},
+	{
+		"InvalidIntervalAndNormalIntervalIntersecting", 5, 3, 4, 6,
+		nil,
+		false, false,
+		[2]*interval{nil, nil},
+		[2]*interval{{4, 6}, nil},
+		nil,
+		&interval{4, 6},
+	},
+	{
+		"IntersectingIntervals", 5, 8, 6, 9,
+		&interval{6, 8},
+		false, false,
+		[2]*interval{{5, 6}, nil},
+		[2]*interval{nil, {8, 9}},
+		nil,
+		&interval{5, 9},
+	},
+	{
+		"AdjoinIntervals", 5, 8, 8, 12,
+		nil,
+		false, false,
+		[2]*interval{{5, 8}, nil},
+		[2]*interval{nil, {8, 12}},
+		&interval{5, 12},
+		&interval{5, 12},
+	},
+	{
+		"EnclosingIntervals", 5, 8, 4, 12,
+		&interval{5, 8},
+		false, false,
+		[2]*interval{nil, nil},
+		[2]*interval{{4, 5}, {8, 12}},
+		nil,
+		&interval{4, 12},
+	},
+	{
+		"EnclosingIntervalsMeetOneEnd", 5, 8, 5, 12,
+		&interval{5, 8},
+		false, false,
+		[2]*interval{nil, nil},
+		[2]*interval{nil, {8, 12}},
+		nil,
+		&interval{5, 12},
+	},
+	{
+		"EqualIntervals", 5, 8, 5, 8,
+		&interval{5, 8},
+		false, false,
+		[2]*interval{nil, nil},
+		[2]*interval{nil, nil},
+		nil,
+		&interval{5, 8},
+	},
+	{
+		"NonIntersectingIntervals", 3, 5, 8, 10,
+		nil,
+		true, false,
+		[2]*interval{{3, 5}, nil},
+		[2]*interval{nil, {8, 10}},
+		nil,
+		&interval{3, 10},
+	},
+}
+
+func TestIntervalIntersect(t *testing.T) {
+	for _, tt := range intervalTestCases {
+		i := interval{tt.start, tt.end}
+		j := interval{tt.otherStart, tt.otherEnd}
+		t.Run(tt.name, func(t *testing.T) {
+			assertIntervalSame(i.Intersect(j), tt.intersectWant, t, "interval.Intersect()")
+		})
+		t.Run("Reflective_"+tt.name, func(t *testing.T) {
+			assertIntervalSame(j.Intersect(i), tt.intersectWant, t, "interval.Intersect()")
+		})
+	}
+}
+
+func TestIntervalBefore(t *testing.T) {
+	for _, tt := range intervalTestCases {
+		i := interval{tt.start, tt.end}
+		j := interval{tt.otherStart, tt.otherEnd}
+		t.Run(tt.name, func(t *testing.T) {
+			if got := i.Before(j); got != tt.beforeWant {
+				t.Errorf("interval.Before() = %v, want %v", got, tt.beforeWant)
+			}
+		})
+		t.Run("Reflective_"+tt.name, func(t *testing.T) {
+			if got := j.Before(i); got != tt.reflectiveBeforeWant {
+				t.Errorf("interval.Before() = %v, want %v", got, tt.reflectiveBeforeWant)
+			}
+		})
+	}
+}
+
+func TestIntervalBisect(t *testing.T) {
+	for _, tt := range intervalTestCases {
+		i := interval{tt.start, tt.end}
+		j := interval{tt.otherStart, tt.otherEnd}
+		t.Run(tt.name, func(t *testing.T) {
+			x, y := i.Bisect(j)
+			assertIntervalSame(x, tt.bisectWant[0], t, "interval.Bisect()[0]")
+			assertIntervalSame(y, tt.bisectWant[1], t, "interval.Bisect()[1]")
+		})
+		t.Run("Reflective_"+tt.name, func(t *testing.T) {
+			x, y := j.Bisect(i)
+			assertIntervalSame(x, tt.reflectiveBisectWant[0], t, "interval.Bisect()[0]")
+			assertIntervalSame(y, tt.reflectiveBisectWant[1], t, "interval.Bisect()[1]")
+		})
+	}
+}
+
+func TestIntervalAdjoin(t *testing.T) {
+	for _, tt := range intervalTestCases {
+		i := interval{tt.start, tt.end}
+		j := interval{tt.otherStart, tt.otherEnd}
+		t.Run(tt.name, func(t *testing.T) {
+			assertIntervalSame(i.Adjoin(j), tt.adjoinWant, t, "interval.Adjoin()")
+		})
+		t.Run("Reflective_"+tt.name, func(t *testing.T) {
+			assertIntervalSame(j.Adjoin(i), tt.adjoinWant, t, "interval.Adjoin()")
+		})
+	}
+}
+
+func TestIntervalEncompass(t *testing.T) {
+	for _, tt := range intervalTestCases {
+		i := interval{tt.start, tt.end}
+		j := interval{tt.otherStart, tt.otherEnd}
+		t.Run(tt.name, func(t *testing.T) {
+			assertIntervalSame(i.Encompass(j), tt.encompassWant, t, "interval.Encompass()")
+		})
+		t.Run("Reflective_"+tt.name, func(t *testing.T) {
+			assertIntervalSame(j.Encompass(i), tt.encompassWant, t, "interval.Encompass()")
+		})
+	}
+}

--- a/store.go
+++ b/store.go
@@ -541,8 +541,8 @@ type store struct {
 	uidMap          []idtools.IDMap
 	gidMap          []idtools.IDMap
 	autoUsernsUser  string
-	autoUIDMap      []idtools.IDMap // Set by getAvailableMappings()
-	autoGIDMap      []idtools.IDMap // Set by getAvailableMappings()
+	additionalUIDs  *idSet // Set by getAvailableIDs()
+	additionalGIDs  *idSet // Set by getAvailableIDs()
 	autoNsMinSize   uint32
 	autoNsMaxSize   uint32
 	graphDriver     drivers.Driver
@@ -648,8 +648,8 @@ func GetStore(options types.StoreOptions) (Store, error) {
 		autoUsernsUser:  options.RootAutoNsUser,
 		autoNsMinSize:   autoNsMinSize,
 		autoNsMaxSize:   autoNsMaxSize,
-		autoUIDMap:      nil,
-		autoGIDMap:      nil,
+		additionalUIDs:  nil,
+		additionalGIDs:  nil,
 		usernsLock:      usernsLock,
 	}
 	if err := s.load(); err != nil {

--- a/userns_test.go
+++ b/userns_test.go
@@ -1,272 +1,172 @@
 package storage
 
 import (
+	"reflect"
 	"testing"
 
 	"github.com/containers/storage/pkg/idtools"
-	"github.com/stretchr/testify/assert"
 )
 
-func TestSubtractHostID(t *testing.T) {
-	avail := idtools.IDMap{
-		ContainerID: 0,
-		HostID:      100000,
-		Size:        65536,
+func TestGetAutoUserNSMapping(t *testing.T) {
+	type args struct {
+		size                  int
+		availableUIDs         *idSet
+		availableGIDs         *idSet
+		usedUIDMappings       []idtools.IDMap
+		usedGIDMappings       []idtools.IDMap
+		additionalUIDMappings []idtools.IDMap
+		additionalGIDMappings []idtools.IDMap
 	}
-	used := idtools.IDMap{
-		ContainerID: 0,
-		HostID:      200000,
-		Size:        65536,
-	}
-	ret := subtractHostIDs(avail, used)
-	assert.Equal(t, len(ret), 1)
-	assert.Equal(t, avail.HostID, ret[0].HostID)
-	assert.Equal(t, avail.Size, ret[0].Size)
-
-	used = idtools.IDMap{
-		ContainerID: 0,
-		HostID:      0,
-		Size:        65536,
-	}
-	ret = subtractHostIDs(avail, used)
-	assert.Equal(t, len(ret), 1)
-	assert.Equal(t, avail.HostID, ret[0].HostID)
-	assert.Equal(t, avail.Size, ret[0].Size)
-
-	used = idtools.IDMap{
-		ContainerID: 0,
-		HostID:      0,
-		Size:        65536,
-	}
-	ret = subtractHostIDs(avail, used)
-	assert.Equal(t, len(ret), 1)
-	assert.Equal(t, avail.HostID, ret[0].HostID)
-	assert.Equal(t, avail.Size, ret[0].Size)
-
-	used = idtools.IDMap{
-		ContainerID: 0,
-		HostID:      100000,
-		Size:        4096,
-	}
-	ret = subtractHostIDs(avail, used)
-	assert.Equal(t, len(ret), 1)
-	assert.Equal(t, ret[0].HostID, avail.HostID+4096)
-	assert.Equal(t, ret[0].Size, avail.Size-4096)
-
-	used = idtools.IDMap{
-		ContainerID: 0,
-		HostID:      165536 - 4096,
-		Size:        4096,
-	}
-	ret = subtractHostIDs(avail, used)
-	assert.Equal(t, len(ret), 1)
-	assert.Equal(t, ret[0].HostID, avail.HostID)
-	assert.Equal(t, ret[0].Size, avail.Size-4096)
-
-	used = idtools.IDMap{
-		ContainerID: 0,
-		HostID:      132768,
-		Size:        4096,
-	}
-	ret = subtractHostIDs(avail, used)
-	assert.Equal(t, len(ret), 2)
-	assert.Equal(t, ret[0].HostID, avail.HostID)
-	assert.Equal(t, ret[0].Size, 32768)
-	assert.Equal(t, ret[1].HostID, avail.HostID+32768+4096)
-	assert.Equal(t, ret[1].Size, 32768-4096)
-
-	used = idtools.IDMap{
-		ContainerID: 0,
-		HostID:      132768,
-		Size:        65536,
-	}
-	ret = subtractHostIDs(avail, used)
-	assert.NotNil(t, ret)
-
-	used = idtools.IDMap{
-		ContainerID: 0,
-		HostID:      100000,
-		Size:        65536,
-	}
-	ret = subtractHostIDs(avail, used)
-	assert.Equal(t, len(ret), 0)
-
-	used = idtools.IDMap{
-		ContainerID: 0,
-		HostID:      100000,
-		Size:        1000000,
-	}
-	ret = subtractHostIDs(avail, used)
-	assert.Equal(t, len(ret), 0)
-}
-
-func TestSubtractContainerID(t *testing.T) {
-	avail := idtools.IDMap{
-		ContainerID: 100000,
-		HostID:      0,
-		Size:        65536,
-	}
-	used := idtools.IDMap{
-		ContainerID: 200000,
-		HostID:      0,
-		Size:        65536,
-	}
-	ret := subtractContainerIDs(avail, used)
-	assert.Equal(t, len(ret), 1)
-	assert.Equal(t, avail.ContainerID, ret[0].ContainerID)
-	assert.Equal(t, 0, ret[0].HostID)
-	assert.Equal(t, avail.Size, ret[0].Size)
-
-	used = idtools.IDMap{
-		ContainerID: 0,
-		HostID:      0,
-		Size:        65536,
-	}
-	ret = subtractContainerIDs(avail, used)
-	assert.Equal(t, len(ret), 1)
-	assert.Equal(t, avail.ContainerID, ret[0].ContainerID)
-	assert.Equal(t, avail.Size, ret[0].Size)
-
-	used = idtools.IDMap{
-		ContainerID: 0,
-		HostID:      1,
-		Size:        65536,
-	}
-	ret = subtractContainerIDs(avail, used)
-	assert.Equal(t, len(ret), 1)
-	assert.Equal(t, avail.ContainerID, ret[0].ContainerID)
-	assert.Equal(t, 0, ret[0].HostID)
-	assert.Equal(t, avail.Size, ret[0].Size)
-
-	used = idtools.IDMap{
-		ContainerID: 100000,
-		HostID:      0,
-		Size:        4096,
-	}
-	ret = subtractContainerIDs(avail, used)
-	assert.Equal(t, len(ret), 1)
-	assert.Equal(t, ret[0].ContainerID, avail.ContainerID+4096)
-	assert.Equal(t, 4096, ret[0].HostID)
-	assert.Equal(t, ret[0].Size, avail.Size-4096)
-
-	used = idtools.IDMap{
-		ContainerID: 165536 - 4096,
-		HostID:      0,
-		Size:        4096,
-	}
-	ret = subtractContainerIDs(avail, used)
-	assert.Equal(t, len(ret), 1)
-	assert.Equal(t, ret[0].ContainerID, avail.ContainerID)
-	assert.Equal(t, ret[0].Size, avail.Size-4096)
-
-	used = idtools.IDMap{
-		ContainerID: 132768,
-		HostID:      0,
-		Size:        4096,
-	}
-	ret = subtractContainerIDs(avail, used)
-	assert.Equal(t, len(ret), 2)
-	assert.Equal(t, ret[0].ContainerID, avail.ContainerID)
-	assert.Equal(t, ret[0].Size, 32768)
-	assert.Equal(t, ret[1].ContainerID, 132768+4096)
-	assert.Equal(t, ret[1].Size, 32768-4096)
-
-	used = idtools.IDMap{
-		ContainerID: 0,
-		HostID:      132768,
-		Size:        65536,
-	}
-	ret = subtractContainerIDs(avail, used)
-	assert.NotNil(t, ret)
-
-	used = idtools.IDMap{
-		ContainerID: 100000,
-		HostID:      0,
-		Size:        65536,
-	}
-	ret = subtractContainerIDs(avail, used)
-	assert.Equal(t, len(ret), 0)
-
-	used = idtools.IDMap{
-		ContainerID: 100000,
-		HostID:      0,
-		Size:        1000000,
-	}
-	ret = subtractContainerIDs(avail, used)
-	assert.Equal(t, len(ret), 0)
-
-	avail = idtools.IDMap{
-		ContainerID: 0,
-		HostID:      1000,
-		Size:        65536,
-	}
-	used = idtools.IDMap{
-		ContainerID: 10,
-		HostID:      10,
-		Size:        1,
-	}
-	ret = subtractContainerIDs(avail, used)
-	assert.Equal(t, len(ret), 2)
-	assert.Equal(t, ret[0].ContainerID, 0)
-	assert.Equal(t, ret[0].HostID, 1000)
-	assert.Equal(t, ret[0].Size, 10)
-	assert.Equal(t, ret[1].ContainerID, 11)
-	assert.Equal(t, ret[1].HostID, 1011)
-	assert.Equal(t, ret[1].Size, 65525)
-}
-
-func TestFindAvailableIDRange(t *testing.T) {
-	avail := []idtools.IDMap{
+	tests := []struct {
+		name            string
+		args            args
+		wantUIDMappings []idtools.IDMap
+		wantGIDMappings []idtools.IDMap
+		wantErr         bool
+	}{
 		{
-			ContainerID: 0,
-			HostID:      100000,
-			Size:        65536,
+			name: "Normal",
+			args: args{
+				size:          65536,
+				availableUIDs: newIDSet([]interval{{1000, 100000}}),
+				availableGIDs: newIDSet([]interval{{1000, 100000}}),
+			},
+			wantUIDMappings: []idtools.IDMap{{ContainerID: 0, HostID: 1000, Size: 65536}},
+			wantGIDMappings: []idtools.IDMap{{ContainerID: 0, HostID: 1000, Size: 65536}},
+		},
+		{
+			name: "NotEnoughAvailableUIDs",
+			args: args{
+				size:          65536,
+				availableUIDs: newIDSet([]interval{{1000, 10000}}),
+				availableGIDs: newIDSet([]interval{{1000, 100000}}),
+			},
+			wantErr: true,
+		},
+		{
+			name: "NotEnoughAvailableGIDs",
+			args: args{
+				size:          65536,
+				availableUIDs: newIDSet([]interval{{1000, 100000}}),
+				availableGIDs: newIDSet([]interval{{1000, 10000}}),
+			},
+			wantErr: true,
+		},
+		{
+			name: "WithUsedIDs",
+			args: args{
+				size:            65536,
+				availableUIDs:   newIDSet([]interval{{1000, 100000}}),
+				availableGIDs:   newIDSet([]interval{{1000, 100000}}),
+				usedUIDMappings: []idtools.IDMap{{ContainerID: 0, HostID: 2000, Size: 10000}},
+				usedGIDMappings: []idtools.IDMap{
+					{ContainerID: 0, HostID: 1000, Size: 10000},
+					{ContainerID: 10000, HostID: 20000, Size: 5000},
+					{ContainerID: 15000, HostID: 30000, Size: 5000},
+				},
+			},
+			wantUIDMappings: []idtools.IDMap{
+				{ContainerID: 0, HostID: 1000, Size: 1000},
+				{ContainerID: 1000, HostID: 12000, Size: 65536 - 1000},
+			},
+			wantGIDMappings: []idtools.IDMap{
+				{ContainerID: 0, HostID: 11000, Size: 9000},
+				{ContainerID: 9000, HostID: 25000, Size: 5000},
+				{ContainerID: 14000, HostID: 35000, Size: 65536 - 9000 - 5000},
+			},
+		},
+		{
+			name: "WithUsedAndAdditionalIDs",
+			args: args{
+				size:            65536,
+				availableUIDs:   newIDSet([]interval{{1000, 100000}}),
+				availableGIDs:   newIDSet([]interval{{1000, 100000}}),
+				usedUIDMappings: []idtools.IDMap{{ContainerID: 0, HostID: 2000, Size: 10000}},
+				usedGIDMappings: []idtools.IDMap{
+					{ContainerID: 0, HostID: 1000, Size: 10000},
+					{ContainerID: 10000, HostID: 20000, Size: 5000},
+					{ContainerID: 15000, HostID: 30000, Size: 5000},
+				},
+				additionalUIDMappings: []idtools.IDMap{{ContainerID: 0, HostID: 1000, Size: 1}},
+				additionalGIDMappings: []idtools.IDMap{{ContainerID: 1, HostID: 1001, Size: 1}},
+			},
+			wantUIDMappings: []idtools.IDMap{
+				{ContainerID: 1, HostID: 1001, Size: 999},
+				{ContainerID: 1000, HostID: 12000, Size: 65535 - 999},
+				{ContainerID: 0, HostID: 1000, Size: 1},
+			},
+			wantGIDMappings: []idtools.IDMap{
+				{ContainerID: 0, HostID: 11000, Size: 1},
+				{ContainerID: 2, HostID: 11001, Size: 8999},
+				{ContainerID: 9001, HostID: 25000, Size: 5000},
+				{ContainerID: 14001, HostID: 35000, Size: 65535 - 1 - 8999 - 5000},
+				{ContainerID: 1, HostID: 1001, Size: 1},
+			},
+		},
+		{
+			name: "DiscontinuedAvailableIntervals",
+			args: args{
+				size:          65536,
+				availableUIDs: newIDSet([]interval{{1000, 50000}, {80000, 130000}}),
+				availableGIDs: newIDSet([]interval{{1000, 30000}, {70000, 90000}, {110000, 160000}}),
+				usedUIDMappings: []idtools.IDMap{
+					{ContainerID: 0, HostID: 2000, Size: 10000},
+					{ContainerID: 0, HostID: 10000, Size: 10000},
+					{ContainerID: 0, HostID: 40000, Size: 10000},
+				},
+				usedGIDMappings: []idtools.IDMap{
+					{ContainerID: 0, HostID: 1000, Size: 10000},
+					{ContainerID: 100, HostID: 20000, Size: 5000},
+					{ContainerID: 150, HostID: 30000, Size: 5000},
+				},
+				additionalUIDMappings: []idtools.IDMap{
+					{ContainerID: 0, HostID: 1002, Size: 1},
+				},
+				additionalGIDMappings: []idtools.IDMap{
+					{ContainerID: 0, HostID: 1003, Size: 1},
+					{ContainerID: 1, HostID: 1001, Size: 1},
+					{ContainerID: 2, HostID: 1006, Size: 1},
+					{ContainerID: 100, HostID: 1100, Size: 10},
+				},
+			},
+			wantUIDMappings: []idtools.IDMap{
+				{ContainerID: 1, HostID: 1000, Size: 2},
+				{ContainerID: 3, HostID: 1003, Size: 997},
+				{ContainerID: 1000, HostID: 20000, Size: 20000},
+				{ContainerID: 21000, HostID: 80000, Size: 65535 - 2 - 997 - 20000},
+				{ContainerID: 0, HostID: 1002, Size: 1},
+			},
+			wantGIDMappings: []idtools.IDMap{
+				{ContainerID: 3, HostID: 11000, Size: 97},
+				{ContainerID: 110, HostID: 11000 + 97, Size: /*9000-97=*/ 8903},
+				{ContainerID: /*110+8903=*/ 9013, HostID: 25000, Size: 5000},
+				{ContainerID: /*9013+5000=*/ 14013, HostID: 70000, Size: 20000},
+				{ContainerID: /*14013+20000*/ 34013, HostID: 110000, Size: 65536 - 13 - 97 - 8903 - 5000 - 20000},
+				{ContainerID: 0, HostID: 1003, Size: 1},
+				{ContainerID: 1, HostID: 1001, Size: 1},
+				{ContainerID: 2, HostID: 1006, Size: 1},
+				{ContainerID: 100, HostID: 1100, Size: 10},
+			},
 		},
 	}
-	used := []idtools.IDMap{
-		{
-			ContainerID: 0,
-			HostID:      100000,
-			Size:        65536,
-		},
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			gotUIDMappings, gotGIDMappings, err := getAutoUserNSIDMappings(
+				tt.args.size,
+				tt.args.availableUIDs, tt.args.availableGIDs,
+				tt.args.usedUIDMappings, tt.args.usedGIDMappings,
+				tt.args.additionalUIDMappings, tt.args.additionalGIDMappings,
+			)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("getAutoUserNSMapping() error = %v, wantErr %v", err, tt.wantErr)
+				return
+			}
+			if !reflect.DeepEqual(gotUIDMappings, tt.wantUIDMappings) {
+				t.Errorf("getAutoUserNSMapping() gotUIDMappings = %v, want %v", gotUIDMappings, tt.wantUIDMappings)
+			}
+			if !reflect.DeepEqual(gotGIDMappings, tt.wantGIDMappings) {
+				t.Errorf("getAutoUserNSMapping() gotGIDMappings = %v, want %v", gotGIDMappings, tt.wantGIDMappings)
+			}
+		})
 	}
-	_, err := findAvailableIDRange(4096, avail, used)
-	assert.Error(t, err, "could not find enough available IDs")
-
-	used = []idtools.IDMap{
-		{
-			ContainerID: 0,
-			HostID:      100000,
-			Size:        4096,
-		},
-	}
-	_, err = findAvailableIDRange(100000, avail, used)
-	assert.Error(t, err, "could not find enough available IDs")
-
-	used = []idtools.IDMap{
-		{
-			ContainerID: 0,
-			HostID:      100000,
-			Size:        32768,
-		},
-	}
-
-	ret, err := findAvailableIDRange(4096, avail, used)
-	assert.Nil(t, err)
-	assert.Equal(t, len(ret), 1)
-	assert.Equal(t, ret[0].HostID, 100000+32768)
-	assert.Equal(t, ret[0].Size, 4096)
-
-	used = []idtools.IDMap{
-		{
-			ContainerID: 0,
-			HostID:      100010,
-			Size:        10,
-		},
-	}
-	ret, err = findAvailableIDRange(4096, avail, used)
-	assert.Nil(t, err)
-	assert.Equal(t, len(ret), 2)
-	assert.Equal(t, ret[0].HostID, 100000)
-	assert.Equal(t, ret[1].HostID, 100020)
 }

--- a/vendor/github.com/google/go-intervals/LICENSE
+++ b/vendor/github.com/google/go-intervals/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/vendor/github.com/google/go-intervals/intervalset/intervalset.go
+++ b/vendor/github.com/google/go-intervals/intervalset/intervalset.go
@@ -1,0 +1,545 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package intervalset provides an abtraction for dealing with sets of
+// 1-dimensional spans, such as sets of time ranges. The Set type provides set
+// arithmetic and enumeration methods based on an Interval interface.
+//
+// DISCLAIMER: This library is not yet stable, so expect breaking changes.
+package intervalset
+
+import (
+	"fmt"
+	"sort"
+	"strings"
+)
+
+// Interval is the interface for a continuous or discrete span. The interval is
+// assumed to be inclusive of the starting point and exclusive of the ending
+// point.
+//
+// All methods in the interface are non-destructive: Calls to the methods should
+// not modify the interval. Furthermore, the implementation assumes an interval
+// will not be mutated by user code, either.
+type Interval interface {
+	// Intersect returns the intersection of an interval with another
+	// interval. The function may panic if the other interval is incompatible.
+	Intersect(Interval) Interval
+
+	// Before returns true if the interval is completely before another interval.
+	Before(Interval) bool
+
+	// IsZero returns true for the zero value of an interval.
+	IsZero() bool
+
+	// Bisect returns two intervals, one on the lower side of x and one on the
+	// upper side of x, corresponding to the subtraction of x from the original
+	// interval. The returned intervals are always within the range of the
+	// original interval.
+	Bisect(x Interval) (Interval, Interval)
+
+	// Adjoin returns the union of two intervals, if the intervals are exactly
+	// adjacent, or the zero interval if they are not.
+	Adjoin(Interval) Interval
+
+	// Encompass returns an interval that covers the exact extents of two
+	// intervals.
+	Encompass(Interval) Interval
+}
+
+// Set is a set of interval objects used for
+type Set struct {
+	//non-overlapping intervals
+	intervals []Interval
+	// factory is needed when the extents of the empty set are needed.
+	factory intervalFactory
+}
+
+// SetInput is an interface implemented by Set and ImmutableSet. It is used when
+// one of these types type must take a set as an argument.
+type SetInput interface {
+	// Extent returns the Interval defined by the minimum and maximum values of
+	// the set.
+	Extent() Interval
+
+	// IntervalsBetween iterates over the intervals within extents set and calls f
+	// with each. If f returns false, iteration ceases.
+	//
+	// Any interval within the set that overlaps partially with extents is truncated
+	// before being passed to f.
+	IntervalsBetween(extents Interval, f IntervalReceiver)
+}
+
+// NewSet returns a new set given a sorted slice of intervals. This function
+// panics if the intervals are not sorted.
+func NewSet(intervals []Interval) *Set {
+	return NewSetV1(intervals, oldBehaviorFactory.makeZero)
+}
+
+// NewSetV1 returns a new set given a sorted slice of intervals. This function
+// panics if the intervals are not sorted.
+//
+// NewSetV1 will be renamed and will replace NewSet in the v1 release.
+func NewSetV1(intervals []Interval, makeZero func() Interval) *Set {
+	if err := CheckSorted(intervals); err != nil {
+		panic(err)
+	}
+	return &Set{intervals, makeIntervalFactor(makeZero)}
+}
+
+// CheckSorted checks that interval[i+1] is not before interval[i] for all
+// relevant elements of the input slice. Nil is returned when len(intervals) is
+// 0 or 1.
+func CheckSorted(intervals []Interval) error {
+	for i := 0; i < len(intervals)-1; i++ {
+		if !intervals[i].Before(intervals[i+1]) {
+			return fmt.Errorf("!intervals[%d].Before(intervals[%d]) for %s, %s", i, i+1, intervals[i], intervals[i+1])
+		}
+	}
+	return nil
+}
+
+// Empty returns a new, empty set of intervals.
+func Empty() *Set {
+	return EmptyV1(oldBehaviorFactory.makeZero)
+}
+
+// EmptyV1 returns a new, empty set of intervals using the semantics of the V1
+// API, which will require a factory method for construction of an empty interval.
+func EmptyV1(makeZero func() Interval) *Set {
+	return &Set{nil, makeIntervalFactor(makeZero)}
+}
+
+// Copy returns a copy of a set that may be mutated without affecting the original.
+func (s *Set) Copy() *Set {
+	return &Set{append([]Interval(nil), s.intervals...), s.factory}
+}
+
+// String returns a human-friendly representation of the set.
+func (s *Set) String() string {
+	var strs []string
+	for _, x := range s.intervals {
+		strs = append(strs, fmt.Sprintf("%s", x))
+	}
+	return fmt.Sprintf("{%s}", strings.Join(strs, ", "))
+}
+
+// Extent returns the Interval defined by the minimum and maximum values of the
+// set.
+func (s *Set) Extent() Interval {
+	if len(s.intervals) == 0 {
+		return s.factory.makeZero()
+	}
+	return s.intervals[0].Encompass(s.intervals[len(s.intervals)-1])
+}
+
+// Add adds all the elements of another set to this set.
+func (s *Set) Add(b SetInput) {
+	// Deal with nil extent. See https://github.com/google/go-intervals/issues/6.
+	bExtent := b.Extent()
+	if bExtent == nil {
+		return // no changes needed
+	}
+
+	// Loop through the intervals of x
+	b.IntervalsBetween(bExtent, func(x Interval) bool {
+		s.insert(x)
+		return true
+	})
+}
+
+// Contains reports whether an interval is entirely contained by the set.
+func (s *Set) Contains(ival Interval) bool {
+	// Loop through the intervals of x
+	next := s.iterator(ival, true)
+	for setInterval := next(); setInterval != nil; setInterval = next() {
+		left, right := ival.Bisect(setInterval)
+		if !left.IsZero() {
+			return false
+		}
+		ival = right
+	}
+	return ival.IsZero()
+}
+
+// adjoinOrAppend adds an interval to the end of intervals unless that value
+// directly adjoins the last element of intervals, in which case the last
+// element will be replaced by the adjoined interval.
+func adjoinOrAppend(intervals []Interval, x Interval) []Interval {
+	lastIndex := len(intervals) - 1
+	if lastIndex == -1 {
+		return append(intervals, x)
+	}
+	adjoined := intervals[lastIndex].Adjoin(x)
+	if adjoined.IsZero() {
+		return append(intervals, x)
+	}
+	intervals[lastIndex] = adjoined
+	return intervals
+}
+
+func (s *Set) insert(insertion Interval) {
+	if s.Contains(insertion) {
+		return
+	}
+	// TODO(reddaly): Something like Java's ArrayList would allow both O(log(n))
+	// insertion and O(log(n)) lookup. For now, we have O(log(n)) lookup and O(n)
+	// insertion.
+	var newIntervals []Interval
+	push := func(x Interval) {
+		newIntervals = adjoinOrAppend(newIntervals, x)
+	}
+	inserted := false
+	for _, x := range s.intervals {
+		if inserted {
+			push(x)
+			continue
+		}
+		if insertion.Before(x) {
+			push(insertion)
+			push(x)
+			inserted = true
+			continue
+		}
+		// [===left===)[==x===)[===right===)
+		left, right := insertion.Bisect(x)
+		if !left.IsZero() {
+			push(left)
+		}
+		push(x)
+		// Replace the interval being inserted with the remaining portion of the
+		// interval to be inserted.
+		if right.IsZero() {
+			inserted = true
+		} else {
+			insertion = right
+		}
+	}
+	if !inserted {
+		push(insertion)
+	}
+	s.intervals = newIntervals
+}
+
+// Sub destructively modifies the set by subtracting b.
+func (s *Set) Sub(b SetInput) {
+	extent := s.Extent()
+	// Deal with nil extent. See https://github.com/google/go-intervals/issues/6.
+	if extent == nil {
+		// Set is already empty, no changes necessary.
+		return
+	}
+	var newIntervals []Interval
+	push := func(x Interval) {
+		newIntervals = adjoinOrAppend(newIntervals, x)
+	}
+	nextX := s.iterator(extent, true)
+	nextY, cancel := setIntervalIterator(b, extent)
+	defer cancel()
+
+	x := nextX()
+	y := nextY()
+	for x != nil {
+		// If y == nil, all of the remaining intervals in A are to the right of B,
+		// so just yield them.
+		if y == nil {
+			push(x)
+			x = nextX()
+			continue
+		}
+		// Split x into parts left and right of y.
+		// The diagrams below show the bisection results for various situations.
+		// if left.IsZero() && !right.IsZero()
+		//             xxx
+		// y1y1 y2y2 y3  y4y4
+		//             xxx
+		// or
+		//   xxxxxxxxxxxx
+		// y1y1 y2y2 y3  y4y4
+		//
+		// if !left.IsZero() && !right.IsZero()
+		//       x1x1x1x1x1
+		//         y1  y2
+		//
+		// if left.IsZero() && right.IsZero()
+		//    x1x1x1x1  x2x2x2
+		//  y1y1y1y1y1y1y1
+		//
+		// if !left.IsZero() && right.IsZero()
+		//   x1x1  x2
+		//     y1y1y1y1
+		left, right := x.Bisect(y)
+
+		// If the left side of x is non-zero, it can definitely be pushed to the
+		// resulting interval set since no subsequent y value will intersect it.
+		// The sequences look something like
+		//         x1x1x1x1x1       OR   x1x1x1 x2
+		//             y1 y2                       y1y1y1
+		// left  = x1x1                  x1x1x1
+		// right =       x1x1                            {zero}
+		if !left.IsZero() {
+			push(left)
+		}
+
+		if !right.IsZero() {
+			// If the right side of x is non-zero:
+			// 1) Right is the remaining portion of x that needs to be pushed.
+			x = right
+			// 2) It's not possible for current y to intersect it, so advance y. It's
+			//    possible nextY() will intersect it, so don't push yet.
+			y = nextY()
+		} else {
+			// There's nothing left of x to push, so advance x.
+			x = nextX()
+		}
+	}
+
+	// Setting s.intervals is the only side effect in this function.
+	s.intervals = newIntervals
+}
+
+// intersectionIterator returns a function that yields intervals that are
+// members of the intersection of s and b, in increasing order.
+func (s *Set) intersectionIterator(b SetInput) (iter func() Interval, cancel func()) {
+	return intervalMapperToIterator(func(f IntervalReceiver) {
+		sExtent, bExtent := s.Extent(), b.Extent()
+		// Deal with nil extent. See https://github.com/google/go-intervals/issues/6.
+		if sExtent == nil || bExtent == nil {
+			// IF either set is already empty, the intersection is empty. This
+			// voids a panic below where a valid Interval is needed for each
+			// extent.
+			return
+		}
+		nextX := s.iterator(bExtent, true)
+		nextY, cancel := setIntervalIterator(b, sExtent)
+		defer cancel()
+
+		x := nextX()
+		y := nextY()
+		// Loop through corresponding intervals of S and B.
+		// If y == nil, all of the remaining intervals in S are to the right of B.
+		// If x == nil, all of the remaining intervals in B are to the right of S.
+		for x != nil && y != nil {
+			if x.Before(y) {
+				x = nextX()
+				continue
+			}
+			if y.Before(x) {
+				y = nextY()
+				continue
+			}
+			xyIntersect := x.Intersect(y)
+			if !xyIntersect.IsZero() {
+				if !f(xyIntersect) {
+					return
+				}
+				_, right := x.Bisect(y)
+				if !right.IsZero() {
+					x = right
+				} else {
+					x = nextX()
+				}
+			}
+		}
+	})
+}
+
+// Intersect destructively modifies the set by intersectin it with b.
+func (s *Set) Intersect(b SetInput) {
+	iter, cancel := s.intersectionIterator(b)
+	defer cancel()
+	var newIntervals []Interval
+	for x := iter(); x != nil; x = iter() {
+		newIntervals = append(newIntervals, x)
+	}
+	s.intervals = newIntervals
+}
+
+// searchLow returns the first index in s.intervals that is not before x.
+func (s *Set) searchLow(x Interval) int {
+	return sort.Search(len(s.intervals), func(i int) bool {
+		return !s.intervals[i].Before(x)
+	})
+}
+
+// searchLow returns the index of the first interval in s.intervals that is
+// entirely after x.
+func (s *Set) searchHigh(x Interval) int {
+	return sort.Search(len(s.intervals), func(i int) bool {
+		return x.Before(s.intervals[i])
+	})
+}
+
+// iterator returns a function that yields elements of the set in order.
+//
+// The function returned will return nil when finished iterating.
+func (s *Set) iterator(extents Interval, forward bool) func() Interval {
+	low, high := s.searchLow(extents), s.searchHigh(extents)
+
+	i, stride := low, 1
+	if !forward {
+		i, stride = high-1, -1
+	}
+
+	return func() Interval {
+		if i < 0 || i >= len(s.intervals) {
+			return nil
+		}
+		x := s.intervals[i]
+		i += stride
+		return x
+	}
+}
+
+// IntervalReceiver is a function used for iterating over a set of intervals. It
+// takes the start and end times and returns true if the iteration should
+// continue.
+type IntervalReceiver func(Interval) bool
+
+// IntervalsBetween iterates over the intervals within extents set and calls f
+// with each. If f returns false, iteration ceases.
+//
+// Any interval within the set that overlaps partially with extents is truncated
+// before being passed to f.
+func (s *Set) IntervalsBetween(extents Interval, f IntervalReceiver) {
+	// Begin = first index in s.intervals that is not before extents.
+	begin := sort.Search(len(s.intervals), func(i int) bool {
+		return !s.intervals[i].Before(extents)
+	})
+
+	// TODO(reddaly): Optimize this by performing a binary search for the ending
+	// point.
+	for _, interval := range s.intervals[begin:] {
+		// If the interval is after the extents, there will be no more overlap, so
+		// break out of the loop.
+		if extents.Before(interval) {
+			break
+		}
+		portionOfInterval := extents.Intersect(interval)
+		if portionOfInterval.IsZero() {
+			continue
+		}
+
+		if !f(portionOfInterval) {
+			return
+		}
+	}
+}
+
+// Intervals iterates over all the intervals within the set and calls f with
+// each one. If f returns false, iteration ceases.
+func (s *Set) Intervals(f IntervalReceiver) {
+	for _, interval := range s.intervals {
+		if !f(interval) {
+			return
+		}
+	}
+}
+
+// AllIntervals returns an ordered slice of all the intervals in the set.
+func (s *Set) AllIntervals() []Interval {
+	return append(make([]Interval, 0, len(s.intervals)), s.intervals...)
+}
+
+// ImmutableSet returns an immutable copy of this set.
+func (s *Set) ImmutableSet() *ImmutableSet {
+	return NewImmutableSet(s.AllIntervals())
+}
+
+// mapFn reports true if an iteration should continue. It is called on values of
+// a collection.
+type mapFn func(interface{}) bool
+
+// mapFn calls mapFn for each member of a collection.
+type mapperFn func(mapFn)
+
+// iteratorFn returns the next item in an iteration or the zero value. The
+// second return value indicates whether the first return value is a member of
+// the collection.
+type iteratorFn func() (interface{}, bool)
+
+// generatorFn returns an iterator.
+type generatorFn func() iteratorFn
+
+// cancelFn should be called to clean up the goroutine that would otherwise leak.
+type cancelFn func()
+
+// mapperToIterator returns an iteratorFn version of a mappingFn. The second
+// return value must be called at the end of iteration, or the underlying
+// goroutine will leak.
+func mapperToIterator(m mapperFn) (iteratorFn, cancelFn) {
+	generatedValues := make(chan interface{}, 1)
+	stopCh := make(chan interface{}, 1)
+	go func() {
+		m(func(obj interface{}) bool {
+			select {
+			case <-stopCh:
+				return false
+			case generatedValues <- obj:
+				return true
+			}
+		})
+		close(generatedValues)
+	}()
+	iter := func() (interface{}, bool) {
+		value, ok := <-generatedValues
+		return value, ok
+	}
+	return iter, func() {
+		stopCh <- nil
+	}
+}
+
+func intervalMapperToIterator(mapper func(IntervalReceiver)) (iter func() Interval, cancel func()) {
+	genericMapper := func(m mapFn) {
+		mapper(func(ival Interval) bool {
+			return m(ival)
+		})
+	}
+
+	genericIter, cancel := mapperToIterator(genericMapper)
+	return func() Interval {
+		genericVal, iterationEnded := genericIter()
+		if !iterationEnded {
+			return nil
+		}
+		ival, ok := genericVal.(Interval)
+		if !ok {
+			panic("unexpected value type, internal error")
+		}
+		return ival
+	}, cancel
+}
+
+func setIntervalIterator(s SetInput, extent Interval) (iter func() Interval, cancel func()) {
+	return intervalMapperToIterator(func(f IntervalReceiver) {
+		s.IntervalsBetween(extent, f)
+	})
+}
+
+// oldBehaviorFactory returns a nil interval. This was used before
+// construction of a Set/ImmutableSet required passing in a factory method for
+// creating a zero interval object.
+var oldBehaviorFactory = makeIntervalFactor(func() Interval { return nil })
+
+// intervalFactory is used to construct a zero-value interval. The zero value
+// interval may be different for different types of intervals, so a factory is
+// sometimes needed to write generic algorithms about intervals.
+type intervalFactory struct {
+	makeZero func() Interval
+}
+
+func makeIntervalFactor(makeZero func() Interval) intervalFactory {
+	return intervalFactory{makeZero}
+}

--- a/vendor/github.com/google/go-intervals/intervalset/intervalset_immutable.go
+++ b/vendor/github.com/google/go-intervals/intervalset/intervalset_immutable.go
@@ -1,0 +1,85 @@
+// Copyright 2017 Google Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     https://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package intervalset
+
+// ImmutableSet is a set of interval objects. It provides various set theory
+// operations.
+type ImmutableSet struct {
+	set *Set
+}
+
+// NewImmutableSet returns a new set given a sorted slice of intervals. This
+// function panics if the intervals are not sorted.
+func NewImmutableSet(intervals []Interval) *ImmutableSet {
+	return NewImmutableSetV1(intervals, oldBehaviorFactory.makeZero)
+}
+
+// NewImmutableSetV1 returns a new set given a sorted slice of intervals. This
+// function panics if the intervals are not sorted.
+func NewImmutableSetV1(intervals []Interval, makeZero func() Interval) *ImmutableSet {
+	return &ImmutableSet{NewSetV1(intervals, makeZero)}
+}
+
+// String returns a human-friendly representation of the set.
+func (s *ImmutableSet) String() string {
+	return s.set.String()
+}
+
+// Extent returns the Interval defined by the minimum and maximum values of the
+// set.
+func (s *ImmutableSet) Extent() Interval {
+	return s.set.Extent()
+}
+
+// Contains reports whether an interval is entirely contained by the set.
+func (s *ImmutableSet) Contains(ival Interval) bool {
+	return s.set.Contains(ival)
+}
+
+// Union returns a set with the contents of this set and another set.
+func (s *ImmutableSet) Union(b SetInput) *ImmutableSet {
+	union := s.set.Copy()
+	union.Add(b)
+	return &ImmutableSet{union}
+}
+
+// Sub returns a set without the intervals of another set.
+func (s *ImmutableSet) Sub(b SetInput) *ImmutableSet {
+	x := s.set.Copy()
+	x.Sub(b)
+	return &ImmutableSet{x}
+}
+
+// Intersect returns the intersection of two sets.
+func (s *ImmutableSet) Intersect(b SetInput) *ImmutableSet {
+	x := s.set.Copy()
+	x.Intersect(b)
+	return &ImmutableSet{x}
+}
+
+// IntervalsBetween iterates over the intervals within extents set and calls f
+// with each. If f returns false, iteration ceases.
+//
+// Any interval within the set that overlaps partially with extents is truncated
+// before being passed to f.
+func (s *ImmutableSet) IntervalsBetween(extents Interval, f IntervalReceiver) {
+	s.set.IntervalsBetween(extents, f)
+}
+
+// Intervals iterates over all the intervals within the set and calls f with
+// each one. If f returns false, iteration ceases.
+func (s *ImmutableSet) Intervals(f IntervalReceiver) {
+	s.set.Intervals(f)
+}

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -49,6 +49,9 @@ github.com/google/go-cmp/cmp/internal/diff
 github.com/google/go-cmp/cmp/internal/flags
 github.com/google/go-cmp/cmp/internal/function
 github.com/google/go-cmp/cmp/internal/value
+# github.com/google/go-intervals v0.0.2
+## explicit
+github.com/google/go-intervals/intervalset
 # github.com/google/uuid v1.1.2
 github.com/google/uuid
 # github.com/hashicorp/errwrap v1.0.0


### PR DESCRIPTION
This implements the algorithm proposed in
https://github.com/containers/storage/issues/852#issuecomment-798954173,
which is:
1. find available IDs from subuid/subgid file; by subtracting the used
   IDs (from other containers) as well as additional IDs, we get the IDs
   available to allocate;
2. target ID range is [0, requestedSize), subtract the additional IDs;
3. allocate IDs from range in step 1; the number to allocate is the
   number of IDs in step 2;
4. generate a mapping from IDs in step 3 to the ones in step 2.

Closes: https://github.com/containers/storage/issues/852

Signed-off-by: Kan Li <likan@google.com>