### PR TITLE
    ReloadConfigurationFile should Reset storage options

### DIFF
--- a/types/options.go
+++ b/types/options.go
@@ -278,6 +278,9 @@ func ReloadConfigurationFile(configFile string, storeOptions *StoreOptions) {
 		fmt.Printf("Failed to parse %s %v\n", configFile, err.Error())
 		return
 	}
+
+	// Clear storeOptions of previos settings
+	*storeOptions = StoreOptions{}
 	if config.Storage.Driver != "" {
 		storeOptions.GraphDriverName = config.Storage.Driver
 	}
@@ -341,13 +344,13 @@ func ReloadConfigurationFile(configFile string, storeOptions *StoreOptions) {
 	if err != nil {
 		fmt.Print(err)
 	} else {
-		storeOptions.UIDMap = append(storeOptions.UIDMap, uidmap...)
+		storeOptions.UIDMap = uidmap
 	}
 	gidmap, err := idtools.ParseIDMap([]string{config.Storage.Options.RemapGIDs}, "remap-gids")
 	if err != nil {
 		fmt.Print(err)
 	} else {
-		storeOptions.GIDMap = append(storeOptions.GIDMap, gidmap...)
+		storeOptions.GIDMap = gidmap
 	}
 	storeOptions.RootAutoNsUser = config.Storage.Options.RootAutoUsernsUser
 	if config.Storage.Options.AutoUsernsMinSize > 0 {
@@ -359,8 +362,8 @@ func ReloadConfigurationFile(configFile string, storeOptions *StoreOptions) {
 
 	storeOptions.GraphDriverOptions = append(storeOptions.GraphDriverOptions, cfg.GetGraphDriverOptions(storeOptions.GraphDriverName, config.Storage.Options)...)
 
-	if os.Getenv("STORAGE_OPTS") != "" {
-		storeOptions.GraphDriverOptions = append(storeOptions.GraphDriverOptions, strings.Split(os.Getenv("STORAGE_OPTS"), ",")...)
+	if opts, ok := os.LookupEnv("STORAGE_OPTS"); ok {
+		storeOptions.GraphDriverOptions = strings.Split(opts, ",")
 	}
 	if len(storeOptions.GraphDriverOptions) == 1 && storeOptions.GraphDriverOptions[0] == "" {
 		storeOptions.GraphDriverOptions = nil


### PR DESCRIPTION
Currently in Podman if we reset the CONTAINERS_STORAGE_CONF path, we get
the graph driver options from the original config file as well as the
options from the override path. This PR resets the storageconf to the
initial state when called multiple times.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>