### PR TITLE
Set default to overlay from storage.conf

### DIFF
--- a/storage.conf
+++ b/storage.conf
@@ -5,7 +5,7 @@
 [storage]
 
 # Default Storage Driver, Must be set for proper operation.
-driver = ""
+driver = "overlay"
 
 # Temporary storage location
 runroot = "/run/containers/storage"


### PR DESCRIPTION
If users do not set the storage driver in their storage.conf, tools that
use containers/storage will print a warning. Since we recommend that
users should use "overlay" driver by default, we should set the settings
in our default storage.conf. This ways distros that just grab the
storage.conf in the storage library will work without the warning.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>