### PR TITLE
btrfs: Do not disable quota on cleanup

### DIFF
--- a/drivers/btrfs/btrfs.go
+++ b/drivers/btrfs/btrfs.go
@@ -88,7 +88,7 @@ func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) 
 	}
 
 	if userDiskQuota {
-		if err := driver.subvolEnableQuota(); err != nil {
+		if err := driver.enableQuota(); err != nil {
 			return nil, err
 		}
 	}
@@ -159,10 +159,6 @@ func (d *Driver) Metadata(id string) (map[string]string, error) {
 
 // Cleanup unmounts the home directory.
 func (d *Driver) Cleanup() error {
-	if err := d.subvolDisableQuota(); err != nil {
-		return err
-	}
-
 	return mount.Unmount(d.home)
 }
 
@@ -320,7 +316,7 @@ func (d *Driver) updateQuotaStatus() {
 	d.once.Do(func() {
 		if !d.quotaEnabled {
 			// In case quotaEnabled is not set, check qgroup and update quotaEnabled as needed
-			if err := subvolQgroupStatus(d.home); err != nil {
+			if err := qgroupStatus(d.home); err != nil {
 				// quota is still not enabled
 				return
 			}
@@ -329,7 +325,7 @@ func (d *Driver) updateQuotaStatus() {
 	})
 }
 
-func (d *Driver) subvolEnableQuota() error {
+func (d *Driver) enableQuota() error {
 	d.updateQuotaStatus()
 
 	if d.quotaEnabled {
@@ -351,32 +347,6 @@ func (d *Driver) subvolEnableQuota() error {
 	}
 
 	d.quotaEnabled = true
-
-	return nil
-}
-
-func (d *Driver) subvolDisableQuota() error {
-	d.updateQuotaStatus()
-
-	if !d.quotaEnabled {
-		return nil
-	}
-
-	dir, err := openDir(d.home)
-	if err != nil {
-		return err
-	}
-	defer closeDir(dir)
-
-	var args C.struct_btrfs_ioctl_quota_ctl_args
-	args.cmd = C.BTRFS_QUOTA_CTL_DISABLE
-	_, _, errno := unix.Syscall(unix.SYS_IOCTL, getDirFd(dir), C.BTRFS_IOC_QUOTA_CTL,
-		uintptr(unsafe.Pointer(&args)))
-	if errno != 0 {
-		return fmt.Errorf("Failed to disable btrfs quota for %s: %v", dir, errno.Error())
-	}
-
-	d.quotaEnabled = false
 
 	return nil
 }
@@ -423,11 +393,11 @@ func subvolLimitQgroup(path string, size uint64) error {
 	return nil
 }
 
-// subvolQgroupStatus performs a BTRFS_IOC_TREE_SEARCH on the root path
+// qgroupStatus performs a BTRFS_IOC_TREE_SEARCH on the root path
 // with search key of BTRFS_QGROUP_STATUS_KEY.
 // In case qgroup is enabled, the returned key type will match BTRFS_QGROUP_STATUS_KEY.
 // For more details please see https://github.com/kdave/btrfs-progs/blob/v4.9/qgroup.c#L1035
-func subvolQgroupStatus(path string) error {
+func qgroupStatus(path string) error {
 	dir, err := openDir(path)
 	if err != nil {
 		return err
@@ -603,7 +573,7 @@ func (d *Driver) setStorageSize(dir string, driver *Driver) error {
 		return fmt.Errorf("btrfs: storage size cannot be less than %s", units.HumanSize(float64(d.options.minSpace)))
 	}
 
-	if err := d.subvolEnableQuota(); err != nil {
+	if err := d.enableQuota(); err != nil {
 		return err
 	}
 
@@ -674,7 +644,7 @@ func (d *Driver) Get(id string, options graphdriver.MountOpts) (string, error) {
 
 	if quota, err := ioutil.ReadFile(d.quotasDirID(id)); err == nil {
 		if size, err := strconv.ParseUint(string(quota), 10, 64); err == nil && size >= d.options.minSpace {
-			if err := d.subvolEnableQuota(); err != nil {
+			if err := d.enableQuota(); err != nil {
 				return "", err
 			}
 			if err := subvolLimitQgroup(dir, size); err != nil {


### PR DESCRIPTION
Before this change, cleanup of the btrfs driver (occuring on each driver
shutdown) resulted in disabling quotas. It was done with an assumption
that quotas can be enabled or disabled on a subvolume level, which is
not true - enabling or disabling quota is always done on a filesystem
level.

That was leading to disabling quota on btrfs filesystems on btrfs driver
shutdown.

This change fixes that behavior and removes misleading `subvol` prefix
from functions and methods which set up quota (on a filesystem level).

Ref: moby/moby#34593
Signed-off-by: Michal Rostecki <mrostecki@opensuse.org>