### PR TITLE
unshare: new function HasCapSysAdmin

### DIFF
--- a/pkg/unshare/unshare.go
+++ b/pkg/unshare/unshare.go
@@ -7,12 +7,17 @@ import (
 	"sync"
 
 	"github.com/pkg/errors"
+	"github.com/syndtr/gocapability/capability"
 )
 
 var (
 	homeDirOnce sync.Once
 	homeDirErr  error
 	homeDir     string
+
+	hasCapSysAdminOnce sync.Once
+	hasCapSysAdminRet  bool
+	hasCapSysAdminErr  error
 )
 
 // HomeDir returns the home directory for the current user.
@@ -31,4 +36,21 @@ func HomeDir() (string, error) {
 		homeDir, homeDirErr = home, nil
 	})
 	return homeDir, homeDirErr
+}
+
+// HasCapSysAdmin returns whether the current process has CAP_SYS_ADMIN.
+func HasCapSysAdmin() (bool, error) {
+	hasCapSysAdminOnce.Do(func() {
+		currentCaps, err := capability.NewPid2(0)
+		if err != nil {
+			hasCapSysAdminErr = err
+			return
+		}
+		if err = currentCaps.Load(); err != nil {
+			hasCapSysAdminErr = err
+			return
+		}
+		hasCapSysAdminRet = currentCaps.Get(capability.EFFECTIVE, capability.CAP_SYS_ADMIN)
+	})
+	return hasCapSysAdminRet, hasCapSysAdminErr
 }


### PR DESCRIPTION
add a function to check whether the current process has the
CAP_SYS_ADMIN capability in its effective capabilities set.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>