### PR TITLE
Log expected rootless overlay mount failures as debug level

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -620,7 +620,7 @@ func supportsOverlay(home string, homeMagic graphdriver.FsMagic, rootUID, rootGI
 		if len(flags) < unix.Getpagesize() {
 			err := unix.Mount("overlay", mergedDir, "overlay", 0, flags)
 			if err == nil {
-				logrus.Errorf("overlay test mount with multiple lowers failed, but succeeded with a single lower")
+				logrus.StandardLogger().Logf(logLevel, "overlay test mount with multiple lowers failed, but succeeded with a single lower")
 				return supportsDType, errors.Wrap(graphdriver.ErrNotSupported, "kernel too old to provide multiple lowers feature for overlay")
 			}
 			logrus.Debugf("overlay test mount with a single lower failed %v", err)


### PR DESCRIPTION
Most linux kernels do not support overlay mounts in rootless mode,
we should not be reporting this as an error, but drop it to debug
level.

Fixes: https://github.com/containers/podman/issues/10153

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>