### PR TITLE
Expand Variables on rootlessStoragePath

### DIFF
--- a/types/options.go
+++ b/types/options.go
@@ -172,7 +172,10 @@ func getRootlessStorageOpts(rootlessUID int, systemOpts StoreOptions) (StoreOpti
 	}
 	opts.RunRoot = rootlessRuntime
 	if systemOpts.RootlessStoragePath != "" {
-		opts.GraphRoot = systemOpts.RootlessStoragePath
+		opts.GraphRoot, err = expandEnvPath(systemOpts.RootlessStoragePath, rootlessUID)
+		if err != nil {
+			return opts, err
+		}
 	} else {
 		opts.GraphRoot = filepath.Join(dataDir, "containers", "storage")
 	}

--- a/types/options_test.go
+++ b/types/options_test.go
@@ -3,6 +3,7 @@ package types
 import (
 	"fmt"
 	"os"
+	"path/filepath"
 	"testing"
 
 	"gotest.tools/assert"
@@ -96,4 +97,16 @@ func TestGetRootlessStorageOpts(t *testing.T) {
 	} else {
 		os.Unsetenv("STORAGE_DRIVER")
 	}
+}
+
+func TestGetRootlessStorageOpts2(t *testing.T) {
+	opts := StoreOptions{
+		RootlessStoragePath: "/$HOME/$UID/containers/storage",
+	}
+	storageOpts, err := getRootlessStorageOpts(2000, opts)
+
+	expectedPath := filepath.Join(os.Getenv("HOME"), "2000", "containers/storage")
+
+	assert.NilError(t, err)
+	assert.Equal(t, storageOpts.GraphRoot, expectedPath)
 }

--- a/types/utils.go
+++ b/types/utils.go
@@ -156,8 +156,7 @@ func getRootlessUID() int {
 
 func expandEnvPath(path string, rootlessUID int) (string, error) {
 	path = strings.Replace(path, "$UID", strconv.Itoa(rootlessUID), -1)
-	path = os.ExpandEnv(path)
-	return path, nil
+	return filepath.Clean(os.ExpandEnv(path)), nil
 }
 
 func DefaultConfigFile(rootless bool) (string, error) {


### PR DESCRIPTION
The current code was hanging for me, this makes sure the path is
expanded properly when it is read.

Fixes: https://github.com/containers/podman/issues/10181

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>