### PR TITLE
options: expand GraphRoot

### DIFF
--- a/types/options.go
+++ b/types/options.go
@@ -176,6 +176,10 @@ func getRootlessStorageOpts(rootlessUID int, systemOpts StoreOptions) (StoreOpti
 	} else {
 		opts.GraphRoot = filepath.Join(dataDir, "containers", "storage")
 	}
+	opts.GraphRoot, err = expandEnvPath(opts.GraphRoot, rootlessUID)
+	if err != nil {
+		return opts, err
+	}
 
 	if driver := systemOpts.GraphDriverName; isRootlessDriver(driver) {
 		opts.GraphDriverName = driver


### PR DESCRIPTION
make sure it is done before calling overlay.SupportsNativeOverlay() as
GraphRoot could contain environment variables that must be expanded
first.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>