### PR TITLE
Added support for CONTAINERS_STORAGE_CONF override

### DIFF
--- a/docs/containers-storage.md
+++ b/docs/containers-storage.md
@@ -155,6 +155,10 @@ Set options which will be passed to the storage driver.  If not set, but
 comma-separated list and used instead.  If the storage tree has previously been
 initialized, these need not be provided.
 
+## ENVIRONMENT OVERRIDES
+**CONTAINERS_STORAGE_CONF** 
+
+If set will use the configuration file path provided in *$CONTAINERS_STORAGE_CONF* instead of the default `/etc/containers/storage.conf`.
 ## EXAMPLES
 **containers-storage layers -t**
 

--- a/types/default_override_test.conf
+++ b/types/default_override_test.conf
@@ -1,0 +1,11 @@
+[storage]
+
+# Default Storage Driver
+driver = ""
+
+# Primary Read/Write location of container storage
+graphroot = "environment_override_graphroot"
+
+# Storage path for rootless users
+#
+rootless_storage_path = "environment_override_rootless_storage_path"

--- a/types/utils.go
+++ b/types/utils.go
@@ -160,7 +160,14 @@ func expandEnvPath(path string, rootlessUID int) (string, error) {
 }
 
 func DefaultConfigFile(rootless bool) (string, error) {
-	if defaultConfigFileSet || !rootless {
+	if defaultConfigFileSet {
+		return defaultConfigFile, nil
+	}
+
+	if path, ok := os.LookupEnv("CONTAINERS_STORAGE_CONF"); ok {
+		return path, nil
+	}
+	if !rootless {
 		return defaultConfigFile, nil
 	}
 

--- a/types/utils_test.go
+++ b/types/utils_test.go
@@ -272,3 +272,25 @@ func TestDefaultStoreOpts(t *testing.T) {
 	assert.Equal(t, storageOpts.GraphRoot, expectedPath)
 	assert.Equal(t, storageOpts.RootlessStoragePath, expectedPath)
 }
+
+func TestStorageConfOverrideEnvironmentDefaultConfigFileRootless(t *testing.T) {
+	os.Setenv("CONTAINERS_STORAGE_CONF", "default_override_test.conf")
+	defer os.Unsetenv("CONTAINERS_STORAGE_CONF")
+	defaultFile, err := DefaultConfigFile(true)
+
+	expectedPath := "default_override_test.conf"
+
+	assert.NilError(t, err)
+	assert.Equal(t, defaultFile, expectedPath)
+}
+
+func TestStorageConfOverrideEnvironmentDefaultConfigFileRoot(t *testing.T) {
+	os.Setenv("CONTAINERS_STORAGE_CONF", "default_override_test.conf")
+	defer os.Unsetenv("CONTAINERS_STORAGE_CONF")
+	defaultFile, err := DefaultConfigFile(false)
+
+	expectedPath := "default_override_test.conf"
+
+	assert.NilError(t, err)
+	assert.Equal(t, defaultFile, expectedPath)
+}


### PR DESCRIPTION
Following the discussion from [here](https://github.com/containers/skopeo/issues/1272) 
The `DefaultStoreOptions` now checks if the environment variable `CONTAINERS_STORAGE_CONF` is set and uses that path 
for the configuration file. This is in line with how podman does it.

Please let me know your thoughts