### PR TITLE
Expand the scope of transaction in the process of deleting device

### DIFF
--- a/drivers/devmapper/deviceset.go
+++ b/drivers/devmapper/deviceset.go
@@ -2010,14 +2010,7 @@ func (devices *DeviceSet) markForDeferredDeletion(info *devInfo) error {
 }
 
 // Should be called with devices.Lock() held.
-func (devices *DeviceSet) deleteTransaction(info *devInfo, syncDelete bool) error {
-	if err := devices.openTransaction(info.Hash, info.DeviceID); err != nil {
-		logrus.Debugf("devmapper: Error opening transaction hash = %s deviceId = %d", "", info.DeviceID)
-		return err
-	}
-
-	defer devices.closeTransaction()
-
+func (devices *DeviceSet) deleteDeviceNoLock(info *devInfo, syncDelete bool) error {
 	err := devicemapper.DeleteDevice(devices.getPoolDevName(), info.DeviceID)
 	if err != nil {
 		// If syncDelete is true, we want to return error. If deferred
@@ -2080,6 +2073,13 @@ func (devices *DeviceSet) issueDiscard(info *devInfo) error {
 
 // Should be called with devices.Lock() held.
 func (devices *DeviceSet) deleteDevice(info *devInfo, syncDelete bool) error {
+	if err := devices.openTransaction(info.Hash, info.DeviceID); err != nil {
+		logrus.WithField("storage-driver", "devicemapper").Debugf("Error opening transaction hash = %s deviceId = %d", info.Hash, info.DeviceID)
+		return err
+	}
+
+	defer devices.closeTransaction()
+
 	if devices.doBlkDiscard {
 		devices.issueDiscard(info)
 	}
@@ -2099,7 +2099,7 @@ func (devices *DeviceSet) deleteDevice(info *devInfo, syncDelete bool) error {
 		return err
 	}
 
-	if err := devices.deleteTransaction(info, syncDelete); err != nil {
+	if err := devices.deleteDeviceNoLock(info, syncDelete); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
When "docker load $image" and "docker rmi $image" commands are repeatedly executed in the background, the dockerd daemon process is killed. As a result, the DM device where the image resides may be unavailable. The image can be queried, but the container fails to be run. After function “devices.issueDiscard(info)” is executed and before function "devices.deleteTransaction(info, syncDelete)" is executed, at this point, dockerd daemon's withdrawal would result in dm device discarded. Howerver, the dm device is not deleted at the same time.

Signed-off-by: gaohuatao <gaohuatao@huawei.com>