### PR TITLE
store: allow shifting only with contiguous mappings

### DIFF
--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -60,6 +60,9 @@ type MountOpts struct {
 	// Volatile specifies whether the container storage can be optimized
 	// at the cost of not syncing all the dirty files in memory.
 	Volatile bool
+
+	// DisableShifting forces the driver to not do any ID shifting at runtime.
+	DisableShifting bool
 }
 
 // ApplyDiffOpts contains optional arguments for ApplyDiff methods.

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -1145,6 +1145,10 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 	}
 	readWrite := true
 
+	if !d.SupportsShifting() || options.DisableShifting {
+		disableShifting = true
+	}
+
 	optsList := options.Options
 	if len(optsList) == 0 {
 		optsList = strings.Split(d.options.mountOptions, ",")

--- a/pkg/idtools/idtools_test.go
+++ b/pkg/idtools/idtools_test.go
@@ -103,3 +103,89 @@ func TestGetRootUIDGID(t *testing.T) {
 		t.Fatalf("Detected root user")
 	}
 }
+
+func TestIsContiguous(t *testing.T) {
+	mappings := []IDMap{
+		{
+			ContainerID: 0,
+			HostID:      0,
+			Size:        100,
+		},
+		{
+			ContainerID: 100,
+			HostID:      100,
+			Size:        100,
+		},
+	}
+	if !IsContiguous(mappings) {
+		t.Errorf("mappings %v expected to be contiguous", mappings)
+	}
+	mappings = []IDMap{
+		{
+			ContainerID: 0,
+			HostID:      10000,
+			Size:        100,
+		},
+		{
+			ContainerID: 100,
+			HostID:      100,
+			Size:        100,
+		},
+	}
+	if IsContiguous(mappings) {
+		t.Errorf("mappings %v expected to not be contiguous", mappings)
+	}
+
+	mappings = []IDMap{
+		{
+			ContainerID: 10000,
+			HostID:      0,
+			Size:        100,
+		},
+		{
+			ContainerID: 100,
+			HostID:      100,
+			Size:        100,
+		},
+	}
+	if IsContiguous(mappings) {
+		t.Errorf("mappings %v expected to not be contiguous", mappings)
+	}
+
+	mappings = []IDMap{
+		{
+			ContainerID: 0,
+			HostID:      10,
+			Size:        10,
+		},
+		{
+			ContainerID: 10,
+			HostID:      20,
+			Size:        10,
+		},
+		{
+			ContainerID: 20,
+			HostID:      30,
+			Size:        10,
+		},
+		{
+			ContainerID: 30,
+			HostID:      40,
+			Size:        10,
+		},
+	}
+	if !IsContiguous(mappings) {
+		t.Errorf("mappings %v expected to be contiguous", mappings)
+	}
+
+	mappings = []IDMap{
+		{
+			ContainerID: 0,
+			HostID:      10,
+			Size:        10,
+		},
+	}
+	if !IsContiguous(mappings) {
+		t.Errorf("mappings %v expected to be contiguous", mappings)
+	}
+}

--- a/store.go
+++ b/store.go
@@ -920,6 +920,19 @@ func (s *store) ContainerStore() (ContainerStore, error) {
 	return nil, ErrLoadError
 }
 
+func (s *store) canUseShifting(uidmap, gidmap []idtools.IDMap) bool {
+	if !s.graphDriver.SupportsShifting() {
+		return false
+	}
+	if uidmap != nil && !idtools.IsContiguous(uidmap) {
+		return false
+	}
+	if gidmap != nil && !idtools.IsContiguous(gidmap) {
+		return false
+	}
+	return true
+}
+
 func (s *store) PutLayer(id, parent string, names []string, mountLabel string, writeable bool, options *LayerOptions, diff io.Reader) (*Layer, int64, error) {
 	var parentLayer *Layer
 	rlstore, err := s.LayerStore()
@@ -1009,7 +1022,7 @@ func (s *store) PutLayer(id, parent string, names []string, mountLabel string, w
 		}
 	}
 	var layerOptions *LayerOptions
-	if s.graphDriver.SupportsShifting() {
+	if s.canUseShifting(uidMap, gidMap) {
 		layerOptions = &LayerOptions{IDMappingOptions: types.IDMappingOptions{HostUIDMapping: true, HostGIDMapping: true, UIDMap: nil, GIDMap: nil}}
 	} else {
 		layerOptions = &LayerOptions{
@@ -1091,7 +1104,7 @@ func (s *store) CreateImage(id string, names []string, layer, metadata string, o
 func (s *store) imageTopLayerForMapping(image *Image, ristore ROImageStore, createMappedLayer bool, rlstore LayerStore, lstores []ROLayerStore, options types.IDMappingOptions) (*Layer, error) {
 	layerMatchesMappingOptions := func(layer *Layer, options types.IDMappingOptions) bool {
 		// If the driver supports shifting and the layer has no mappings, we can use it.
-		if s.graphDriver.SupportsShifting() && len(layer.UIDMap) == 0 && len(layer.GIDMap) == 0 {
+		if s.canUseShifting(layer.UIDMap, layer.GIDMap) && len(layer.UIDMap) == 0 && len(layer.GIDMap) == 0 {
 			return true
 		}
 		// If we want host mapping, and the layer uses mappings, it's not the best match.
@@ -1167,7 +1180,7 @@ func (s *store) imageTopLayerForMapping(image *Image, ristore ROImageStore, crea
 		// ... so create a duplicate of the layer with the desired mappings, and
 		// register it as an alternate top layer in the image.
 		var layerOptions LayerOptions
-		if s.graphDriver.SupportsShifting() {
+		if s.canUseShifting(options.UIDMap, options.GIDMap) {
 			layerOptions = LayerOptions{
 				IDMappingOptions: types.IDMappingOptions{
 					HostUIDMapping: true,
@@ -1327,7 +1340,7 @@ func (s *store) CreateContainer(id string, names []string, image, layer, metadat
 		}
 	}
 	var layerOptions *LayerOptions
-	if s.graphDriver.SupportsShifting() {
+	if s.canUseShifting(uidMap, gidMap) {
 		layerOptions = &LayerOptions{
 			IDMappingOptions: types.IDMappingOptions{
 				HostUIDMapping: true,
@@ -2796,6 +2809,7 @@ func (s *store) Mount(id, mountLabel string) (string, error) {
 		if v, found := container.Flags["Volatile"]; found {
 			options.Volatile = v.(bool)
 		}
+		options.DisableShifting = true
 	}
 	return s.mount(id, options)
 }


### PR DESCRIPTION
enable fuse-overlayfs shifting only when the specified mapping is contiguous.

Closes: https://github.com/containers/podman/issues/10272

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
