### PR TITLE
store: replace Modified+Load with ReloadIfChanged

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"sync"
 	"time"
 
 	"github.com/containers/storage/pkg/idtools"
@@ -113,6 +114,7 @@ type containerStore struct {
 	byid       map[string]*Container
 	bylayer    map[string]*Container
 	byname     map[string]*Container
+	loadMut    sync.Mutex
 }
 
 func copyContainer(c *Container) *Container {
@@ -614,4 +616,15 @@ func (r *containerStore) TouchedSince(when time.Time) bool {
 
 func (r *containerStore) Locked() bool {
 	return r.lockfile.Locked()
+}
+
+func (r *containerStore) ReloadIfChanged() error {
+	r.loadMut.Lock()
+	defer r.loadMut.Unlock()
+
+	modified, err := r.Modified()
+	if err == nil && modified {
+		return r.Load()
+	}
+	return nil
 }

--- a/images.go
+++ b/images.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/containers/storage/pkg/ioutils"
@@ -152,6 +153,7 @@ type imageStore struct {
 	byid     map[string]*Image
 	byname   map[string]*Image
 	bydigest map[digest.Digest][]*Image
+	loadMut  sync.Mutex
 }
 
 func copyImage(i *Image) *Image {
@@ -798,4 +800,15 @@ func (r *imageStore) TouchedSince(when time.Time) bool {
 
 func (r *imageStore) Locked() bool {
 	return r.lockfile.Locked()
+}
+
+func (r *imageStore) ReloadIfChanged() error {
+	r.loadMut.Lock()
+	defer r.loadMut.Unlock()
+
+	modified, err := r.Modified()
+	if err == nil && modified {
+		return r.Load()
+	}
+	return nil
 }

--- a/layers.go
+++ b/layers.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"sort"
 	"strings"
+	"sync"
 	"time"
 
 	drivers "github.com/containers/storage/drivers"
@@ -271,6 +272,7 @@ type layerStore struct {
 	byuncompressedsum map[digest.Digest][]string
 	uidMap            []idtools.IDMap
 	gidMap            []idtools.IDMap
+	loadMut           sync.Mutex
 }
 
 func copyLayer(l *Layer) *Layer {
@@ -1619,4 +1621,15 @@ func (r *layerStore) TouchedSince(when time.Time) bool {
 
 func (r *layerStore) Locked() bool {
 	return r.lockfile.Locked()
+}
+
+func (r *layerStore) ReloadIfChanged() error {
+	r.loadMut.Lock()
+	defer r.loadMut.Unlock()
+
+	modified, err := r.Modified()
+	if err == nil && modified {
+		return r.Load()
+	}
+	return nil
 }

--- a/store.go
+++ b/store.go
@@ -44,6 +44,9 @@ type ROFileBasedStore interface {
 	// Load reloads the contents of the store from disk.  It should be called
 	// with the lock held.
 	Load() error
+
+	// ReloadIfChanged reloads the contents of the store from disk if it is changed.
+	ReloadIfChanged() error
 }
 
 // RWFileBasedStore wraps up the methods of various types of file-based data


### PR DESCRIPTION
simplify the pattern if store.Modified() => store.Load() with a single function call store.ReloadIfChanged().
    
In addition to the code simplification, it solves a race condition that when only a RLock() is hold and that multiple goroutines could
run the sequence store.Modified() and store.Load().  In this case only one goroutine would see store.Modified( and run store.Load().
Other goroutines could access the old data while the goroutine that saw the change modifies the store data.

Closes: https://github.com/containers/storage/issues/880

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>