### PR TITLE
Enable to export layers from Additional Layer Store

### DIFF
--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -230,6 +230,9 @@ type AdditionalLayer interface {
 	// Info returns arbitrary information stored along with this layer (i.e. `info` file)
 	Info() (io.ReadCloser, error)
 
+	// Blob returns a reader of the raw contents of this layer.
+	Blob() (io.ReadCloser, error)
+
 	// Release tells the additional layer store that we don't use this handler.
 	Release()
 }
@@ -243,6 +246,10 @@ type AdditionalLayerStoreDriver interface {
 	// LookupAdditionalLayer looks up additional layer store by the specified
 	// digest and ref and returns an object representing that layer.
 	LookupAdditionalLayer(d digest.Digest, ref string) (AdditionalLayer, error)
+
+	// LookupAdditionalLayer looks up additional layer store by the specified
+	// ID and returns an object representing that layer.
+	LookupAdditionalLayerByID(id string) (AdditionalLayer, error)
 }
 
 // DiffGetterDriver is the interface for layered file system drivers that

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -712,8 +712,28 @@ func (d *Driver) Cleanup() error {
 // LookupAdditionalLayer looks up additional layer store by the specified
 // digest and ref and returns an object representing that layer.
 // This API is experimental and can be changed without bumping the major version number.
+// TODO: to remove the comment once it's no longer experimental.
 func (d *Driver) LookupAdditionalLayer(dgst digest.Digest, ref string) (graphdriver.AdditionalLayer, error) {
 	l, err := d.getAdditionalLayerPath(dgst, ref)
+	if err != nil {
+		return nil, err
+	}
+	// Tell the additional layer store that we use this layer.
+	// This will increase reference counter on the store's side.
+	// This will be decreased on Release() method.
+	notifyUseAdditionalLayer(l)
+	return &additionalLayer{
+		path: l,
+		d:    d,
+	}, nil
+}
+
+// LookupAdditionalLayerByID looks up additional layer store by the specified
+// ID and returns an object representing that layer.
+// This API is experimental and can be changed without bumping the major version number.
+// TODO: to remove the comment once it's no longer experimental.
+func (d *Driver) LookupAdditionalLayerByID(id string) (graphdriver.AdditionalLayer, error) {
+	l, err := d.getAdditionalLayerPathByID(id)
 	if err != nil {
 		return nil, err
 	}
@@ -1818,9 +1838,7 @@ func (d *Driver) getAdditionalLayerPath(dgst digest.Digest, ref string) (string,
 		for _, p := range []string{
 			filepath.Join(target, "diff"),
 			filepath.Join(target, "info"),
-			// TODO(ktock): We should have an API to expose the stream data of this layer
-			//              to enable the client to retrieve the entire contents of this
-			//              layer when it exports this layer.
+			filepath.Join(target, "blob"),
 		} {
 			if _, err := os.Stat(p); err != nil {
 				return "", errors.Wrapf(graphdriver.ErrLayerUnknown,
@@ -1835,8 +1853,8 @@ func (d *Driver) getAdditionalLayerPath(dgst digest.Digest, ref string) (string,
 }
 
 func (d *Driver) releaseAdditionalLayerByID(id string) {
-	if al, err := ioutil.ReadFile(path.Join(d.dir(id), "additionallayer")); err == nil {
-		notifyReleaseAdditionalLayer(string(al))
+	if al, err := d.getAdditionalLayerPathByID(id); err == nil {
+		notifyReleaseAdditionalLayer(al)
 	} else if !os.IsNotExist(err) {
 		logrus.Warnf("unexpected error on reading Additional Layer Store pointer %v", err)
 	}
@@ -1851,12 +1869,19 @@ type additionalLayer struct {
 
 // Info returns arbitrary information stored along with this layer (i.e. `info` file).
 // This API is experimental and can be changed without bumping the major version number.
+// TODO: to remove the comment once it's no longer experimental.
 func (al *additionalLayer) Info() (io.ReadCloser, error) {
 	return os.Open(filepath.Join(al.path, "info"))
 }
 
+// Blob returns a reader of the raw contents of this leyer.
+func (al *additionalLayer) Blob() (io.ReadCloser, error) {
+	return os.Open(filepath.Join(al.path, "blob"))
+}
+
 // CreateAs creates a new layer from this additional layer.
 // This API is experimental and can be changed without bumping the major version number.
+// TODO: to remove the comment once it's no longer experimental.
 func (al *additionalLayer) CreateAs(id, parent string) error {
 	// TODO: support opts
 	if err := al.d.Create(id, parent, nil); err != nil {
@@ -1876,8 +1901,17 @@ func (al *additionalLayer) CreateAs(id, parent string) error {
 	return os.Symlink(filepath.Join(al.path, "diff"), diffDir)
 }
 
+func (d *Driver) getAdditionalLayerPathByID(id string) (string, error) {
+	al, err := ioutil.ReadFile(path.Join(d.dir(id), "additionallayer"))
+	if err != nil {
+		return "", err
+	}
+	return string(al), nil
+}
+
 // Release tells the additional layer store that we don't use this handler.
 // This API is experimental and can be changed without bumping the major version number.
+// TODO: to remove the comment once it's no longer experimental.
 func (al *additionalLayer) Release() {
 	// Tell the additional layer store that we don't use this layer handler.
 	// This will decrease the reference counter on the store's side, which was


### PR DESCRIPTION
Currently, layers aquired from additional layer store cannot be exported (e.g. `podman save`, `podman push`) as mentioned in https://github.com/containers/storage/pull/795#issuecomment-799057091.

```
# podman save ghcr.io/stargz-containers/postgres:13.1-esgz > /tmp/test.tar
Error: unable to save "ghcr.io/stargz-containers/postgres:13.1-esgz": error copying image to the remote destination: Error writing blob: error happened during read: Digest did not match, expected sha256:0167446b81cb115e90d668017ed409b449aee3a8fade44c7a96d36ebb0937ca5, got sha256:0a45da8cdff8388828644ad2052e91595733e558067b60b9f4bd290035964193
```

This is because the current additional layer store exposes only *extracted view* of layers. Tar is not reproducible so the runtime cannot reproduce the tar archive that has the same diff ID as the original.

This commit solves this issue by introducing a new API "`blob`" to the following location of the additional layer store. This file exposes the raw contents of that layer. When `*(c/storage).layerStore.Diff` is called, it acquires the diff contents from this `blob` file which has the same digest as the original layer. 

```
<ALS root>/[<image-reference>/]<layer-digest>/
- blob
```

## Testing

The following example shows how this patch works.

We can manually create an additional layers store using something like the following script:

```bash
#!/bin/bash

set -euo pipefail

ORG="${1}"
STORE="${2}"

if [ "${1}" == "--ref" ] ; then
    ORG="${2}"
    STORE="${3}/$(echo -n ${2} | base64)"
fi

OCI="$(mktemp -d)"
skopeo copy docker://${ORG} oci://${OCI}
cat ${OCI}/blobs/sha256/$(cat ${OCI}/index.json | jq -r '.manifests[0].digest' | sed 's/sha256://') \
    | jq -r '.layers[].digest' | while read DGST ; do
    ENCODED_DGST=$(echo -n ${DGST} | sed 's/sha256://')
    mkdir -p ${STORE}/${DGST}/diff
    tar -xf ${OCI}/blobs/sha256/${ENCODED_DGST} -C ${STORE}/${DGST}/diff
    cp ${OCI}/blobs/sha256/${ENCODED_DGST} ${STORE}/${DGST}/blob
    touch ${STORE}/${DGST}/use
    cat <<EOF > ${STORE}/${DGST}/info
{
  "compressed-diff-digest": "${DGST}",
  "compressed-size": $(stat --printf="%s" ${OCI}/blobs/sha256/${ENCODED_DGST}),
  "diff-digest": "sha256:$(cat ${OCI}/blobs/sha256/${ENCODED_DGST} | gunzip | sha256sum | sed -E 's/([^ ]*).*/\1/g')",
  "diff-size": $(cat ${OCI}/blobs/sha256/${ENCODED_DGST} | gunzip | wc -c),
  "compression": 2
}
EOF
done
```
For example, the following prepares additional layer store that contains `ghcr.io/stargz-containers/python:3.9-esgz` at `/tmp/storagedemo`.

```
create_store.sh ghcr.io/stargz-containers/python:3.9-esgz /tmp/storagedemo
```

At least the following configuration is needed to /etc/containers/storage.conf to enable addtional layer store.

```
cat <<EOF > /etc/containers/storage.conf
[storage]
driver = "overlay"
graphroot = "/var/lib/containers/storage"
runroot = "/run/containers/storage"

[storage.options]
additionallayerstores = ["/tmp/storagedemo"]
EOF
```

As shown in the following example, this image can aquired from the addtional layer store without pulling.
And this also can be exported to somewhere else because of `blob` API.

```console
# Layers are used from Additional Layer Store with skipping pulling layers

$ podman pull ghcr.io/stargz-containers/python:3.9-esgz
Copying blob 11f19ef2588b skipped: already exists  
Copying blob 1320c6c8123e skipped: already exists  
Copying blob 58c06a9c95bc skipped: already exists  
...

# Image can run

$ podman run --rm -it ghcr.io/stargz-containers/python:3.9-esgz /bin/echo 'Hello, World!'
Hello, World!

# Image can be exported in the same way as normal images

$ podman save ghcr.io/stargz-containers/python:3.9-esgz > /tmp/test.tar
$ podman tag ghcr.io/stargz-containers/python:3.9-esgz ghcr.io/ktock/python:3.9-my
$ podman push ghcr.io/ktock/python:3.9-my
```
