### PR TITLE
archive/overlay: ignore failures from nested whiteouts

### DIFF
--- a/pkg/archive/changes.go
+++ b/pkg/archive/changes.go
@@ -121,6 +121,9 @@ func isENOTDIR(err error) bool {
 	if err == nil {
 		return false
 	}
+	if err == syscall.ENOTDIR {
+		return true
+	}
 	if perror, ok := err.(*os.PathError); ok {
 		if errno, ok := perror.Err.(syscall.Errno); ok {
 			return errno == syscall.ENOTDIR


### PR DESCRIPTION
See comment for the situation that arises, we've seen this with images
generated by very old dockers (and possibly others?).

I added a test for both syscall.ENOTDIR and unix.ENOTDIR even though they
*should be* aliases to be extra defensive (syscall.Stat_t and unix.Stat_t
were aliases for a while, but now they are not), but I can drop it if
necessary.

Signed-off-by: Tycho Andersen <tycho@tycho.pizza>