### PR TITLE
reintroduce store: allow shifting only with contiguous mappings

### DIFF
--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -60,6 +60,9 @@ type MountOpts struct {
 	// Volatile specifies whether the container storage can be optimized
 	// at the cost of not syncing all the dirty files in memory.
 	Volatile bool
+
+	// DisableShifting forces the driver to not do any ID shifting at runtime.
+	DisableShifting bool
 }
 
 // ApplyDiffOpts contains optional arguments for ApplyDiff methods.

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -1155,6 +1155,10 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 	}
 	readWrite := true
 
+	if !d.SupportsShifting() || options.DisableShifting {
+		disableShifting = true
+	}
+
 	optsList := options.Options
 	if len(optsList) == 0 {
 		optsList = strings.Split(d.options.mountOptions, ",")


### PR DESCRIPTION
reintroduce `store:  allow shifting only with contiguous mappings` after it was reverted.

enable fuse-overlayfs shifting only when the specified mapping is contiguous.

Closes: https://github.com/containers/podman/issues/10272

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

The difference with the first version:

```diff
diff --git a/store.go b/store.go
index 22f932698..759407c63 100644
--- a/store.go
+++ b/store.go
@@ -1114,7 +1114,7 @@ func (s *store) CreateImage(id string, names []string, layer, metadata string, o
 func (s *store) imageTopLayerForMapping(image *Image, ristore ROImageStore, createMappedLayer bool, rlstore LayerStore, lstores []ROLayerStore, options types.IDMappingOptions) (*Layer, error) {
        layerMatchesMappingOptions := func(layer *Layer, options types.IDMappingOptions) bool {
                // If the driver supports shifting and the layer has no mappings, we can use it.
-               if s.canUseShifting(layer.UIDMap, layer.GIDMap) && len(layer.UIDMap) == 0 && len(layer.GIDMap) == 0 {
+               if s.canUseShifting(options.UIDMap, options.GIDMap) && len(layer.UIDMap) == 0 && len(layer.GIDMap) == 0 {
                        return true
                }
                // If we want host mapping, and the layer uses mappings, it's not the best match.
@@ -2706,7 +2706,7 @@ func (s *store) Mount(id, mountLabel string) (string, error) {
                                options.Volatile = v.(bool)
                        }
                }
-               options.DisableShifting = true
+               options.DisableShifting = !s.canUseShifting(container.UIDMap, container.GIDMap)
        }
        return s.mount(id, options)
 }
```

with this patch I get:

```
$ ./bin/podman run --rm --userns=keep-id  fedora  stat -c '%u:%g:%n'  /etc
0:0:/etc
```