### PR TITLE
overlay: enable native diff for fuse-overlayfs

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -1675,7 +1675,7 @@ func (d *Driver) getLowerDiffPaths(id string) ([]string, error) {
 // and its parent and returns the size in bytes of the changes
 // relative to its base filesystem directory.
 func (d *Driver) DiffSize(id string, idMappings *idtools.IDMappings, parent string, parentMappings *idtools.IDMappings, mountLabel string) (size int64, err error) {
-	if d.useNaiveDiff() || !d.isParent(id, parent) {
+	if d.options.mountProgram == "" && (d.useNaiveDiff() || !d.isParent(id, parent)) {
 		return d.naiveDiff.DiffSize(id, idMappings, parent, parentMappings, mountLabel)
 	}
 


### PR DESCRIPTION
NaiveDiff was enabled since the initial implementation to be
conservative.  There is not really any good reason for using it
instead of native diff.

Switch to native diff for better performance.

Closes: https://github.com/containers/storage/issues/917

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>