### PR TITLE
store: fix graphLock reload

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -626,5 +626,5 @@ func (r *containerStore) ReloadIfChanged() error {
 	if err == nil && modified {
 		return r.Load()
 	}
-	return nil
+	return err
 }

--- a/images.go
+++ b/images.go
@@ -810,5 +810,5 @@ func (r *imageStore) ReloadIfChanged() error {
 	if err == nil && modified {
 		return r.Load()
 	}
-	return nil
+	return err
 }

--- a/layers.go
+++ b/layers.go
@@ -1777,7 +1777,7 @@ func (r *layerStore) ReloadIfChanged() error {
 	if err == nil && modified {
 		return r.Load()
 	}
-	return nil
+	return err
 }
 
 func closeAll(closes ...func() error) (rErr error) {

--- a/store.go
+++ b/store.go
@@ -2652,8 +2652,13 @@ func (s *store) mount(id string, options drivers.MountOpts) (string, error) {
 		return "", err
 	}
 
+	modified, err := s.graphLock.Modified()
+	if err != nil {
+		return "", err
+	}
+
 	/* We need to make sure the home mount is present when the Mount is done.  */
-	if s.graphLock.TouchedSince(s.lastLoaded) {
+	if modified {
 		s.graphDriver = nil
 		s.layerStore = nil
 		s.graphDriver, err = s.getGraphDriver()

--- a/store.go
+++ b/store.go
@@ -788,6 +788,15 @@ func (s *store) load() error {
 	}
 	s.containerStore = rcs
 
+	for _, store := range driver.AdditionalImageStores() {
+		gipath := filepath.Join(store, driverPrefix+"images")
+		ris, err := newROImageStore(gipath)
+		if err != nil {
+			return err
+		}
+		s.roImageStores = append(s.roImageStores, ris)
+	}
+
 	s.digestLockRoot = filepath.Join(s.runRoot, driverPrefix+"locks")
 	if err := os.MkdirAll(s.digestLockRoot, 0700); err != nil {
 		return err
@@ -910,22 +919,10 @@ func (s *store) ImageStore() (ImageStore, error) {
 // Store.  Accessing these stores directly will bypass locking and
 // synchronization, so it is not a part of the exported Store interface.
 func (s *store) ROImageStores() ([]ROImageStore, error) {
-	if len(s.roImageStores) != 0 {
-		return s.roImageStores, nil
+	if s.imageStore == nil {
+		return nil, ErrLoadError
 	}
-	driver, err := s.getGraphDriver()
-	if err != nil {
-		return nil, err
-	}
-	driverPrefix := s.graphDriverName + "-"
-	for _, store := range driver.AdditionalImageStores() {
-		gipath := filepath.Join(store, driverPrefix+"images")
-		ris, err := newROImageStore(gipath)
-		if err != nil {
-			return nil, err
-		}
-		s.roImageStores = append(s.roImageStores, ris)
-	}
+
 	return s.roImageStores, nil
 }
 


### PR DESCRIPTION
use s.graphLock.Modified() instead of s.graphLock.TouchedSince().
    
TouchedSince() seems to fail in some cases when comparing the inode mtime with the current time.
    
Avoid such kind of problems in a critical code path as store.mount(), as we must be sure there is already a driver home mount present, otherwise it the next process may cover the container mount with the home mount.

Closes: https://github.com/containers/podman/issues/10454

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
