### PR TITLE
overlay: make userxattr,metacopy=on debug message

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -1189,7 +1189,11 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 			if d.usingMetacopy {
 				optsList = append(optsList, "metacopy=on")
 			} else {
-				logrus.Warnf("ignoring metacopy option from storage.conf, not supported with booted kernel")
+				logLevel := logrus.WarnLevel
+				if unshare.IsRootless() {
+					logLevel = logrus.DebugLevel
+				}
+				logrus.StandardLogger().Logf(logLevel, "ignoring metacopy option from storage.conf, not supported with booted kernel")
 			}
 		}
 	}


### PR DESCRIPTION
currently the kernel doesn't support both userxattr and metacopy=on
options.  When they are specified the mount fails with EINVAL.

Downgrade the warning message to debug level when running as
rootless.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>