### PR TITLE
Fix cancel deferred remove bug

### DIFF
--- a/drivers/devmapper/deviceset.go
+++ b/drivers/devmapper/deviceset.go
@@ -2229,7 +2229,7 @@ func (devices *DeviceSet) cancelDeferredRemovalIfNeeded(info *devInfo) error {
 	// Cancel deferred remove
 	if err := devices.cancelDeferredRemoval(info); err != nil {
 		// If Error is ErrEnxio. Device is probably already gone. Continue.
-		if errors.Cause(err) != devicemapper.ErrBusy {
+		if errors.Cause(err) != devicemapper.ErrEnxio {
 			return err
 		}
 	}


### PR DESCRIPTION
When cancel the deferred removal, if the device is already gone,
continue. According to the original logic, if the device does not exist,
an error is reported.

Signed-off-by: gaohuatao <gaohuatao@huawei.com>