### PR TITLE
Use /run/user/UID in rootless mode if writable

### DIFF
--- a/types/utils.go
+++ b/types/utils.go
@@ -2,7 +2,6 @@ package types
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -75,12 +74,9 @@ func getRootlessRuntimeDirIsolated(env rootlessRuntimeDirEnvironment) (string, e
 		return runtimeDir, nil
 	}
 
-	initCommand, err := ioutil.ReadFile(env.getProcCommandFile())
-	if err != nil || string(initCommand) == "systemd" {
-		runUserDir := env.getRunUserDir()
-		if isRootlessRuntimeDirOwner(runUserDir, env) {
-			return runUserDir, nil
-		}
+	runUserDir := env.getRunUserDir()
+	if isRootlessRuntimeDirOwner(runUserDir, env) {
+		return runUserDir, nil
 	}
 
 	tmpPerUserDir := env.getTmpPerUserDir()


### PR DESCRIPTION
Other parts of the code are using this directory, so we end up
with us creating an empty directory.

I don't see a reason why we would just use this directory only if
the init program is systemd?

Fixes: https://github.com/containers/podman/issues/10782

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>