### PR TITLE
chunked: fix the path used for layers dedup

### DIFF
--- a/pkg/chunked/storage_linux.go
+++ b/pkg/chunked/storage_linux.go
@@ -160,7 +160,7 @@ func findFileInOtherLayers(file zstdFileMetadata, root string, dirfd int, layers
 			continue
 		}
 
-		srcDirfd, err := unix.Open(root, unix.O_RDONLY, 0)
+		srcDirfd, err := unix.Open(source, unix.O_RDONLY, 0)
 		if err != nil {
 			continue
 		}


### PR DESCRIPTION
`source` is the path to the layer that already contains the file that
is looked up.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>