### PR TITLE
Cleanup exclude exceptions path

### DIFF
--- a/pkg/fileutils/fileutils.go
+++ b/pkg/fileutils/fileutils.go
@@ -38,7 +38,7 @@ func NewPatternMatcher(patterns []string) (*PatternMatcher, error) {
 				return nil, errors.New("illegal exclusion pattern: \"!\"")
 			}
 			newp.exclusion = true
-			p = p[1:]
+			p = strings.TrimPrefix(filepath.Clean(p[1:]), "/")
 			pm.exclusions = true
 		}
 		// Do some syntax checking on the pattern.

--- a/pkg/fileutils/fileutils_test.go
+++ b/pkg/fileutils/fileutils_test.go
@@ -633,9 +633,11 @@ func TestMatchesAmount(t *testing.T) {
 		{[]string{"1", "2", "2"}, "2", 2, 0, true},
 		{[]string{"1", "2", "2", "2"}, "2", 3, 0, true},
 		{[]string{"/prefix/path", "/prefix/other"}, "/prefix/path", 1, 0, true},
-		{[]string{"/prefix*", "/prefix/path"}, "/prefix/path", 2, 0, true},
 		{[]string{"/prefix*", "!/prefix/path"}, "/prefix/match", 1, 0, true},
-		{[]string{"/prefix*", "!/prefix/path"}, "/prefix/path", 1, 1, false},
+		{[]string{"/prefix*", "!/prefix/path"}, "/prefix/path", 1, 0, true},
+		{[]string{"/prefix*", "!/prefix/path"}, "prefix/path", 0, 1, false},
+		{[]string{"/prefix*", "!./prefix/path"}, "prefix/path", 0, 1, false},
+		{[]string{"/prefix*", "!prefix/path"}, "prefix/path", 0, 1, false},
 	}
 
 	for _, testCase := range testData {


### PR DESCRIPTION
It is legal to use !./PATH and !/PATH in a .containerignore or
.dockerignore file.

Currently we fail to match on these patterns,  Removing the leadking
"/" and cleaning the path, fixes the problem.

Fixes: https://github.com/containers/buildah/issues/3272

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>