### PR TITLE
Revert #952, we don't want to use /run/user on non systemd systems

### DIFF
--- a/types/utils.go
+++ b/types/utils.go
@@ -2,6 +2,7 @@ package types
 
 import (
 	"fmt"
+	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strconv"
@@ -74,9 +75,12 @@ func getRootlessRuntimeDirIsolated(env rootlessRuntimeDirEnvironment) (string, e
 		return runtimeDir, nil
 	}
 
-	runUserDir := env.getRunUserDir()
-	if isRootlessRuntimeDirOwner(runUserDir, env) {
-		return runUserDir, nil
+	initCommand, err := ioutil.ReadFile(env.getProcCommandFile())
+	if err != nil || string(initCommand) == "systemd" {
+		runUserDir := env.getRunUserDir()
+		if isRootlessRuntimeDirOwner(runUserDir, env) {
+			return runUserDir, nil
+		}
 	}
 
 	tmpPerUserDir := env.getTmpPerUserDir()


### PR DESCRIPTION
This feature was originally added for  #568, and I mistakenly removed
it.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>