### PR TITLE
[1.24] Fix runtime panic for opening lockfile if parent dir got removed

### DIFF
--- a/pkg/lockfile/lockfile_unix_test.go
+++ b/pkg/lockfile/lockfile_unix_test.go
@@ -1,0 +1,65 @@
+// +build linux solaris darwin freebsd
+
+package lockfile
+
+import (
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestOpenLock(t *testing.T) {
+	t.Parallel()
+
+	for _, tc := range []struct {
+		name    string
+		prepare func() (path string, readOnly bool)
+	}{
+		{
+			name: "file exists (read/write)",
+			prepare: func() (string, bool) {
+				tempFile, err := ioutil.TempFile("", "lock-")
+				require.NoError(t, err)
+				return tempFile.Name(), false
+			},
+		},
+		{
+			name: "file exists readonly (readonly)",
+			prepare: func() (string, bool) {
+				tempFile, err := ioutil.TempFile("", "lock-")
+				require.NoError(t, err)
+				return tempFile.Name(), true
+			},
+		},
+		{
+			name: "base dir exists (read/write)",
+			prepare: func() (string, bool) {
+				tempDir := os.TempDir()
+				require.DirExists(t, tempDir)
+				return filepath.Join(tempDir, "test-1.lock"), false
+			},
+		},
+		{
+			name: "base dir not exists (read/write)",
+			prepare: func() (string, bool) {
+				tempDir, err := ioutil.TempDir("", "lock-")
+				require.NoError(t, err)
+				return filepath.Join(tempDir, "subdir", "test-1.lock"), false
+			},
+		},
+	} {
+		path, readOnly := tc.prepare()
+
+		_, err := openLock(path, readOnly)
+
+		require.NoError(t, err, tc.name)
+
+		_, err = openLock(path, readOnly)
+		require.NoError(t, err)
+
+		require.Nil(t, os.RemoveAll(path))
+	}
+}


### PR DESCRIPTION
Required for CRI-O 1.20 release branch.
Cherry-picked: 16de6d32b4f82fa6c4a5456450fb95de65e794a6
Refers to https://github.com/containers/storage/pull/957

---

If the lockfile directory gets removed but the container runtime is
still running with an open storage instance, then we can trigger a
runtime panic by:

1. Starting CRI-O
2. Removing the lockfile dir, e.g.:
   `sudo rm -rf /var/lib/containers/storage/overlay-images`
3. Running `crictl images`

```
panic: error opening "/var/lib/containers/storage/overlay-images/images.lock": no such file or directory

goroutine 93 [running]:
github.com/containers/storage/pkg/lockfile.(*lockfile).lock(0xc0006b83c0, 0x2000000)
        /go/src/github.com/cri-o/cri-o/vendor/github.com/containers/storage/pkg/lockfile/lockfile_unix.go:107 +0x388
github.com/containers/storage/pkg/lockfile.(*lockfile).RLock(0xc0006b83c0)
        /go/src/github.com/cri-o/cri-o/vendor/github.com/containers/storage/pkg/lockfile/lockfile_unix.go:146 +0x37
github.com/containers/storage.(*imageStore).RLock(0xc00006e420)
        /go/src/github.com/cri-o/cri-o/vendor/github.com/containers/storage/images.go:778 +0x33
github.com/containers/storage.(*store).Images(0xc0003f3b80, 0x0, 0x0, 0x0, 0x0, 0x0)
        /go/src/github.com/cri-o/cri-o/vendor/github.com/containers/storage/store.go:3089 +0x1dc
```

We now ensure the parent lockfile directory, but only if it does not
exist to not degrade the performance of c/stroage.

Unit tests around that case have been added as well.

