### PR TITLE
overlay: check if we can mknod() kernel whiteout

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -613,6 +613,10 @@ func supportsOverlay(home string, homeMagic graphdriver.FsMagic, rootUID, rootGI
 		if unshare.IsRootless() {
 			flags = fmt.Sprintf("%s,userxattr", flags)
 		}
+		if err := syscall.Mknod(filepath.Join(upperDir, "whiteout"), syscall.S_IFCHR|0600, int(unix.Mkdev(0, 0))); err != nil {
+			logrus.Debugf("unable to create kernel-style whiteout: %v", err)
+			return supportsDType, errors.Wrapf(err, "unable to create kernel-style whiteout")
+		}
 
 		if len(flags) < unix.Getpagesize() {
 			err := unix.Mount("overlay", mergedDir, "overlay", 0, flags)


### PR DESCRIPTION
When checking if we can use the kernel's overlay filesystem, verify that we can create whiteouts in the format the kernel expects (character devices with major and minor of 0), and if we fail to do that, don't try to use the kernel's overlay filesystem.  I think this is a "we can mount kernel overlay, but not everything else works" case that pops up among the gating test errors in https://bugzilla.redhat.com/show_bug.cgi?id=1955166.