### PR TITLE
Add inode support to quota

### DIFF
--- a/docs/containers-storage.conf.5.md
+++ b/docs/containers-storage.conf.5.md
@@ -223,7 +223,7 @@ based file systems.
   Comma separated list of default options to be used to mount container images.  Suggested value "nodev". Mount options are documented in the mount(8) man page.
 
 **size**=""
-  Maximum size of a read/write layer.   This flag can be used to set quota on the size of a read/write layer of a container image. (format: <number>[<unit>], where unit = b (bytes), k (kilobytes), m (megabytes), or g (gigabytes))
+  Maximum size of a read/write layer.   This flag can be used to set quota on the size of a read/write layer of a container. (format: <number>[<unit>], where unit = b (bytes), k (kilobytes), m (megabytes), or g (gigabytes))
 
 ### STORAGE OPTIONS FOR VFS TABLE
 

--- a/docs/containers-storage.conf.5.md
+++ b/docs/containers-storage.conf.5.md
@@ -174,6 +174,9 @@ The `storage.options.overlay` table supports the following options:
 **ignore_chown_errors** = "false"
   ignore_chown_errors can be set to allow a non privileged user running with a  single UID within a user namespace to run containers. The user can pull and use any image even those with multiple uids.  Note multiple UIDs will be squashed down to the default uid in the container.  These images will have no separation between the users in the container. (default: false)
 
+**inodes**=""
+  Maximum inodes in a read/write layer.   This flag can be used to set a quota on the inodes allocated for a read/write layer of a container image.
+
 **force_mask** = "0000|shared|private"
   ForceMask specifies the permissions mask that is used for new files and
 directories.
@@ -220,7 +223,7 @@ based file systems.
   Comma separated list of default options to be used to mount container images.  Suggested value "nodev". Mount options are documented in the mount(8) man page.
 
 **size**=""
-  Maximum size of a container image.   This flag can be used to set quota on the size of container images. (format: <number>[<unit>], where unit = b (bytes), k (kilobytes), m (megabytes), or g (gigabytes))
+  Maximum size of a read/write layer.   This flag can be used to set quota on the size of a read/write layer of a container image. (format: <number>[<unit>], where unit = b (bytes), k (kilobytes), m (megabytes), or g (gigabytes))
 
 ### STORAGE OPTIONS FOR VFS TABLE
 

--- a/docs/containers-storage.conf.5.md
+++ b/docs/containers-storage.conf.5.md
@@ -175,7 +175,7 @@ The `storage.options.overlay` table supports the following options:
   ignore_chown_errors can be set to allow a non privileged user running with a  single UID within a user namespace to run containers. The user can pull and use any image even those with multiple uids.  Note multiple UIDs will be squashed down to the default uid in the container.  These images will have no separation between the users in the container. (default: false)
 
 **inodes**=""
-  Maximum inodes in a read/write layer.   This flag can be used to set a quota on the inodes allocated for a read/write layer of a container image.
+  Maximum inodes in a read/write layer.   This flag can be used to set a quota on the inodes allocated for a read/write layer of a container.
 
 **force_mask** = "0000|shared|private"
   ForceMask specifies the permissions mask that is used for new files and

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -364,12 +364,12 @@ func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) 
 		// Try to enable project quota support over xfs.
 		if d.quotaCtl, err = quota.NewControl(home); err == nil {
 			projectQuotaSupported = true
-		} else if opts.quota.Size > 0 {
-			return nil, fmt.Errorf("Storage option overlay.size not supported. Filesystem does not support Project Quota: %v", err)
+		} else if opts.quota.Size > 0 || opts.quota.Inodes > 0 {
+			return nil, fmt.Errorf("Storage options overlay.size and overlay.inodes not supported. Filesystem does not support Project Quota: %v", err)
 		}
-	} else if opts.quota.Size > 0 {
+	} else if opts.quota.Size > 0 || opts.quota.Inodes > 0 {
 		// if xfs is not the backing fs then error out if the storage-opt overlay.size is used.
-		return nil, fmt.Errorf("Storage option overlay.size only supported for backingFS XFS. Found %v", backingFs)
+		return nil, fmt.Errorf("Storage option overlay.size and overlay.inodes only supported for backingFS XFS. Found %v", backingFs)
 	}
 
 	logrus.Debugf("backingFs=%s, projectQuotaSupported=%v, useNativeDiff=%v, usingMetacopy=%v", backingFs, projectQuotaSupported, !d.useNaiveDiff(), d.usingMetacopy)
@@ -400,6 +400,13 @@ func parseOptions(options []string) (*overlayOptions, error) {
 				return nil, err
 			}
 			o.quota.Size = uint64(size)
+		case "inodes":
+			logrus.Debugf("overlay: inodes=%s", val)
+			inodes, err := strconv.ParseUint(val, 10, 64)
+			if err != nil {
+				return nil, err
+			}
+			o.quota.Inodes = uint64(inodes)
 		case "imagestore", "additionalimagestore":
 			logrus.Debugf("overlay: imagestore=%s", val)
 			// Additional read only image stores to use for lower paths
@@ -788,6 +795,13 @@ func (d *Driver) CreateReadWrite(id, parent string, opts *graphdriver.CreateOpts
 		opts.StorageOpt["size"] = strconv.FormatUint(d.options.quota.Size, 10)
 	}
 
+	if _, ok := opts.StorageOpt["inodes"]; !ok {
+		if opts.StorageOpt == nil {
+			opts.StorageOpt = map[string]string{}
+		}
+		opts.StorageOpt["inodes"] = strconv.FormatUint(d.options.quota.Inodes, 10)
+	}
+
 	return d.create(id, parent, opts)
 }
 
@@ -797,6 +811,9 @@ func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) (retErr
 	if opts != nil && len(opts.StorageOpt) != 0 {
 		if _, ok := opts.StorageOpt["size"]; ok {
 			return fmt.Errorf("--storage-opt size is only supported for ReadWrite Layers")
+		}
+		if _, ok := opts.StorageOpt["inodes"]; ok {
+			return fmt.Errorf("--storage-opt inodes is only supported for ReadWrite Layers")
 		}
 	}
 
@@ -854,7 +871,9 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts) (retErr
 			if driver.options.quota.Size > 0 {
 				quota.Size = driver.options.quota.Size
 			}
-
+			if driver.options.quota.Inodes > 0 {
+				quota.Inodes = driver.options.quota.Inodes
+			}
 		}
 		// Set container disk quota limit
 		// If it is set to 0, we will track the disk usage, but not enforce a limit
@@ -926,6 +945,12 @@ func (d *Driver) parseStorageOpt(storageOpt map[string]string, driver *Driver) e
 				return err
 			}
 			driver.options.quota.Size = uint64(size)
+		case "inodes":
+			inodes, err := strconv.ParseUint(val, 10, 64)
+			if err != nil {
+				return err
+			}
+			driver.options.quota.Inodes = uint64(inodes)
 		default:
 			return fmt.Errorf("Unknown option %s", key)
 		}

--- a/drivers/quota/projectquota_unsupported.go
+++ b/drivers/quota/projectquota_unsupported.go
@@ -8,7 +8,8 @@ import (
 
 // Quota limit params - currently we only control blocks hard limit
 type Quota struct {
-	Size uint64
+	Size   uint64
+	Inodes uint64
 }
 
 // Control - Context to be used by storage driver (e.g. overlay)

--- a/storage.conf
+++ b/storage.conf
@@ -69,6 +69,9 @@ additionalimagestores = [
 # and vfs drivers.
 #ignore_chown_errors = "false"
 
+# Inodes is used to set a maximum inodes of the container image.
+# inodes = ""
+
 # Path to an helper program to use for mounting the file system instead of mounting it
 # directly.
 #mount_program = "/usr/bin/fuse-overlayfs"


### PR DESCRIPTION
xfs quota for overlay also supports setting the maximum number of
inodes. OpenShift would like to be able to set this to control the
number of inodes added to an image or to a volume.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>