### PR TITLE
overlay: check for aufs-style whiteout at startup

### DIFF
--- a/drivers/overlay/check_115.go
+++ b/drivers/overlay/check_115.go
@@ -1,0 +1,42 @@
+// +build !go1.16
+
+package overlay
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/containers/storage/pkg/archive"
+	"github.com/containers/storage/pkg/system"
+)
+
+func scanForMountProgramIndicators(home string) (detected bool, err error) {
+	err = filepath.Walk(home, func(path string, info os.FileInfo, err error) error {
+		if detected {
+			return filepath.SkipDir
+		}
+		if err != nil {
+			return err
+		}
+		basename := filepath.Base(path)
+		if strings.HasPrefix(basename, archive.WhiteoutPrefix) {
+			detected = true
+			return filepath.SkipDir
+		}
+		if info.IsDir() {
+			xattrs, err := system.Llistxattr(path)
+			if err != nil {
+				return err
+			}
+			for _, xattr := range xattrs {
+				if strings.HasPrefix(xattr, "user.fuseoverlayfs.") || strings.HasPrefix(xattr, "user.containers.") {
+					detected = true
+					return filepath.SkipDir
+				}
+			}
+		}
+		return nil
+	})
+	return detected, err
+}

--- a/drivers/overlay/check_116.go
+++ b/drivers/overlay/check_116.go
@@ -1,0 +1,42 @@
+// +build go1.16
+
+package overlay
+
+import (
+	"io/fs"
+	"path/filepath"
+	"strings"
+
+	"github.com/containers/storage/pkg/archive"
+	"github.com/containers/storage/pkg/system"
+)
+
+func scanForMountProgramIndicators(home string) (detected bool, err error) {
+	err = filepath.WalkDir(home, func(path string, d fs.DirEntry, err error) error {
+		if detected {
+			return fs.SkipDir
+		}
+		if err != nil {
+			return err
+		}
+		basename := filepath.Base(path)
+		if strings.HasPrefix(basename, archive.WhiteoutPrefix) {
+			detected = true
+			return fs.SkipDir
+		}
+		if d.IsDir() {
+			xattrs, err := system.Llistxattr(path)
+			if err != nil {
+				return err
+			}
+			for _, xattr := range xattrs {
+				if strings.HasPrefix(xattr, "user.fuseoverlayfs.") || strings.HasPrefix(xattr, "user.containers.") {
+					detected = true
+					return fs.SkipDir
+				}
+			}
+		}
+		return nil
+	})
+	return detected, err
+}


### PR DESCRIPTION
At startup, check if we see any aufs-style whiteout in any of our layers.  This can be expensive, so if we don't find any at startup, note that and bypass the check later until the system reboots.  If we do find some, leave a note that we needed to use a mount_program so that we don't have to bother with even this in the future.