### PR TITLE
Invert libsubid tag

### DIFF
--- a/hack/libsubid_tag.sh
+++ b/hack/libsubid_tag.sh
@@ -1,6 +1,5 @@
 #!/usr/bin/env bash
 if test $(${GO:-go} env GOOS) != "linux" ; then
-	echo no_libsubid
 	exit 0
 fi
 tmpdir="$PWD/tmp.$RANDOM"
@@ -15,6 +14,6 @@ int main() {
 	return 0;
 }
 EOF
-if test $? -ne 0 ; then
-	echo no_libsubid
+if test $? -eq 0 ; then
+	echo libsubid
 fi

--- a/pkg/idtools/idtools_supported.go
+++ b/pkg/idtools/idtools_supported.go
@@ -1,4 +1,4 @@
-// +build linux,cgo,!no_libsubid
+// +build linux,cgo,libsubid
 
 package idtools
 

--- a/pkg/idtools/idtools_unsupported.go
+++ b/pkg/idtools/idtools_unsupported.go
@@ -1,4 +1,4 @@
-// +build !linux no_libsubid !cgo
+// +build !linux !libsubid !cgo
 
 package idtools
 


### PR DESCRIPTION
We now switch to a `libsubid` tag to increase the usability of the
library on systems not having the dependency in place.

Fixes https://github.com/containers/storage/issues/985