### PR TITLE
ApplyDiff: compress saved headers without concurrency

### DIFF
--- a/layers.go
+++ b/layers.go
@@ -27,6 +27,7 @@ import (
 	digest "github.com/opencontainers/go-digest"
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/vbatts/tar-split/archive/tar"
 	"github.com/vbatts/tar-split/tar/asm"
 	"github.com/vbatts/tar-split/tar/storage"
@@ -1528,6 +1529,9 @@ func (r *layerStore) ApplyDiff(to string, diff io.Reader) (size int64, err error
 	compressor, err := pgzip.NewWriterLevel(&tsdata, pgzip.BestSpeed)
 	if err != nil {
 		compressor = pgzip.NewWriter(&tsdata)
+	}
+	if err := compressor.SetConcurrency(1024*1024, 1); err != nil { // 1024*1024 is the hard-coded default; we're not changing that
+		logrus.Infof("error setting compression concurrency threads to 1: %v; ignoring", err)
 	}
 	metadata := storage.NewJSONPacker(compressor)
 	uncompressed, err := archive.DecompressStream(defragmented)


### PR DESCRIPTION
When we're applying a diff, we compress the headers and stash them elsewhere so that we can use them to correctly reconstruct the layer if we need to extract its contents later.

By default, the compression uses a 1MB block, and up to GOMAXPROCS threads, which results in allocating GOMAXPROCS megabytes of memory up front.  That can be much more than we need, especially if the system has many, many cores.  Drop it down to 1 megabyte.