### PR TITLE
chunked: add new pull options use_hard_links and enable_partial_images

### DIFF
--- a/pkg/chunked/storage_linux.go
+++ b/pkg/chunked/storage_linux.go
@@ -270,13 +270,16 @@ func findFileOnTheHost(file internal.ZstdFileMetadata, root string, dirfd int, u
 
 	// calculate the checksum again to make sure the file wasn't modified while it was copied
 	if _, err := f.Seek(0, 0); err != nil {
+		dstFile.Close()
 		return false, nil, 0, err
 	}
 	checksum, err = getFileDigest(f)
 	if err != nil {
+		dstFile.Close()
 		return false, nil, 0, err
 	}
 	if checksum != manifestChecksum {
+		dstFile.Close()
 		return false, nil, 0, nil
 	}
 	return true, dstFile, written, nil


### PR DESCRIPTION
if the option use_hard_links is set:
    
[storage.options]
pull_options = {use_hard_links = "true"}

then attempt to deduplicate files using hard links first.

the partial images feature is disabled by default, to enable it we need now:

pull_options = {enable_partial_images = "true"}

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
