### PR TITLE
chunked: allow to disable partial images feature

### DIFF
--- a/pkg/chunked/storage_linux.go
+++ b/pkg/chunked/storage_linux.go
@@ -654,8 +654,14 @@ func (d *chunkedZstdDiffer) ApplyDiff(dest string, options *archive.TarOptions) 
 		return output, err
 	}
 
+	const trueVal = "true"
+
+	if value := storeOpts.PullOptions["enable_partial_images"]; strings.ToLower(value) != trueVal {
+		return output, errors.New("enable_partial_images not configured")
+	}
+
 	enableHostDedup := false
-	if value := storeOpts.PullOptions["enable_host_deduplication"]; strings.ToLower(value) == "true" {
+	if value := storeOpts.PullOptions["enable_host_deduplication"]; strings.ToLower(value) == trueVal {
 		enableHostDedup = true
 	}
 


### PR DESCRIPTION
enable partial pulls only when it is explicitely configured in the
storage.conf file:

[storage.options]

pull_options = {enable_partial_images = "true"}

This is to prevent the experimental feature to leak into CRI-O.

The default value will change in future once the feature is stable.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>