### PR TITLE
Have NewReadCloserWrapper pass through io.WriterTo

### DIFF
--- a/pkg/ioutils/readers.go
+++ b/pkg/ioutils/readers.go
@@ -17,8 +17,25 @@ func (r *readCloserWrapper) Close() error {
 	return r.closer()
 }
 
+type readWriteToCloserWrapper struct {
+	io.Reader
+	io.WriterTo
+	closer func() error
+}
+
+func (r *readWriteToCloserWrapper) Close() error {
+	return r.closer()
+}
+
 // NewReadCloserWrapper returns a new io.ReadCloser.
 func NewReadCloserWrapper(r io.Reader, closer func() error) io.ReadCloser {
+	if wt, ok := r.(io.WriterTo); ok {
+		return &readWriteToCloserWrapper{
+			Reader:   r,
+			WriterTo: wt,
+			closer:   closer,
+		}
+	}
 	return &readCloserWrapper{
 		Reader: r,
 		closer: closer,


### PR DESCRIPTION
If the underlying `io.Reader` implements `WriteTo`, make the wrapped `ReadCloser` implement it as well.

This causes the values returned by `pkg/archive.DecompressStream` to implement `WriteTo` (for gzip and zstd, not bzip2 and xz), and that in turn eliminates a 32kB memory allocation when decompressing layers during pull.