### PR TITLE
Add Inodes to OverlayOptionsConfig

### DIFF
--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -93,6 +93,8 @@ type OverlayOptionsConfig struct {
 	MountProgram string `toml:"mount_program"`
 	// Size
 	Size string `toml:"size"`
+	// Inodes is used to set a maximum inodes of the container image.
+	Inodes string `toml:"inodes"`
 	// Do not create a bind mount on the storage home
 	SkipMountHome string `toml:"skip_mount_home"`
 	// ForceMask indicates the permissions mask (e.g. "0755") to use for new
@@ -295,6 +297,9 @@ func GetGraphDriverOptions(driverName string, options OptionsConfig) []string {
 			doptions = append(doptions, fmt.Sprintf("%s.size=%s", driverName, options.Overlay.Size))
 		} else if options.Size != "" {
 			doptions = append(doptions, fmt.Sprintf("%s.size=%s", driverName, options.Size))
+		}
+		if options.Overlay.Inodes != "" {
+			doptions = append(doptions, fmt.Sprintf("%s.inodes=%s", driverName, options.Overlay.Inodes))
 		}
 		if options.Overlay.SkipMountHome != "" {
 			doptions = append(doptions, fmt.Sprintf("%s.skip_mount_home=%s", driverName, options.Overlay.SkipMountHome))


### PR DESCRIPTION
Fix error "Failed to decode the keys inodes" when using inodes in storage.conf
as documented https://github.com/containers/storage/blob/main/storage.conf#L73
https://github.com/containers/storage/blob/c9f1d016b9e7692e70b1338045af61c89fd63a0b/types/options.go#L280

Signed-off-by: Qi Wang <qiwan@redhat.com>