### PR TITLE
(*Store)Layer(): fix race when loading layers

### DIFF
--- a/store.go
+++ b/store.go
@@ -3054,10 +3054,15 @@ func (s *store) Layers() ([]Layer, error) {
 	if err != nil {
 		return nil, err
 	}
-	if err := lstore.LoadLocked(); err != nil {
-		return nil, err
-	}
-	layers, err := lstore.Layers()
+
+	layers, err := func() ([]Layer, error) {
+		lstore.Lock()
+		defer lstore.Unlock()
+		if err := lstore.Load(); err != nil {
+			return nil, err
+		}
+		return lstore.Layers()
+	}()
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Make sure that the layer store is locked when loading the layers.

Reported-in: github.com/containers/podman/issues/11487
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>

@nalind PTAL