### PR TITLE
store: don't ignore empty mappings for top layer

### DIFF
--- a/cmd/containers-storage/container.go
+++ b/cmd/containers-storage/container.go
@@ -211,12 +211,8 @@ func containerParentOwners(flags *mflag.FlagSet, action string, m storage.Store,
 			json.NewEncoder(os.Stdout).Encode(mappings)
 		} else {
 			fmt.Printf("ID: %s\n", container.ID)
-			if len(uids) > 0 {
-				fmt.Printf("UIDs: %v\n", uids)
-			}
-			if len(gids) > 0 {
-				fmt.Printf("GIDs: %v\n", gids)
-			}
+			fmt.Printf("UIDs: %v\n", uids)
+			fmt.Printf("GIDs: %v\n", gids)
 		}
 	}
 	if len(matched) != len(args) {

--- a/store.go
+++ b/store.go
@@ -1131,10 +1131,6 @@ func (s *store) imageTopLayerForMapping(image *Image, ristore ROImageStore, crea
 		if options.HostGIDMapping && len(layer.GIDMap) != 0 {
 			return false
 		}
-		// If we don't care about the mapping, it's fine.
-		if len(options.UIDMap) == 0 && len(options.GIDMap) == 0 {
-			return true
-		}
 		// Compare the maps.
 		return reflect.DeepEqual(layer.UIDMap, options.UIDMap) && reflect.DeepEqual(layer.GIDMap, options.GIDMap)
 	}

--- a/tests/idmaps.bats
+++ b/tests/idmaps.bats
@@ -313,7 +313,7 @@ load helpers
 	for i in $(seq $n) ; do
 		run stat -c %u:%g "$defmapmount"/file$i
 		[ "$status" -eq 0 ]
-		[ "$output" = ${uidrange[$n]}:${gidrange[$n]} ]
+		[ "$output" = "0:0" ]
 	done
 }
 
@@ -372,15 +372,11 @@ load helpers
 	[ "$status" -eq 0 ]
 	# Check who owns the parent directories.
 	run storage --debug=false container-parent-owners $container
-	echo "$output"
 	[ "$status" -eq 0 ]
-	# Assume that except for root and maybe us, there are no other owners of parent directories of our container's layer.
-	if ! fgrep -q 'UIDs: [0]' <<< "$output" ; then
-		fgrep -q 'UIDs: [0, '$(id -u)']' <<< "$output"
-	fi
-	if ! fgrep -q 'GIDs: [0]' <<< "$output" ; then
-		fgrep -q 'GIDs: [0, '$(id -g)']' <<< "$output"
-	fi
+        cat <<< "$output" | tr '\n' '_'
+	# Check there are no unmapped IDs
+	fgrep -q 'UIDs: []' <<< "$output"
+	fgrep -q 'GIDs: []' <<< "$output"
 }
 
 @test "idmaps-copy" {


### PR DESCRIPTION
do not pick the first available image if it was requested to not use
any mapping.

It causes a problem where an image is already present in the local
store with a mapping, then a container that doesn't specify any
mapping would end up to reuse that:

$ podman system reset -y
$ podman run --rm --uidmap 0:10000:1000 centos ls -ld /home
drwxr-xr-x. 2 root root 6 Nov  3  2020 /home
    
$ podman run --rm centos ls -ld /home
drwxr-xr-x. 2 10000 10000 6 Nov  3  2020 /home

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>