### PR TITLE
Update VM Images + Drop prior-ubuntu references

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -20,16 +20,14 @@ env:
     FEDORA_NAME: "fedora-34"
     PRIOR_FEDORA_NAME: "fedora-33"
     UBUNTU_NAME: "ubuntu-2104"
-    PRIOR_UBUNTU_NAME: "ubuntu-2010"
 
     # GCE project where images live
     IMAGE_PROJECT: "libpod-218412"
     # VM Image built in containers/automation_images
-    _BUILT_IMAGE_SUFFIX: "c6248193773010944"
+    _BUILT_IMAGE_SUFFIX: "c6431352024203264"
     FEDORA_CACHE_IMAGE_NAME: "fedora-${_BUILT_IMAGE_SUFFIX}"
     PRIOR_FEDORA_CACHE_IMAGE_NAME: "prior-fedora-${_BUILT_IMAGE_SUFFIX}"
     UBUNTU_CACHE_IMAGE_NAME: "ubuntu-${_BUILT_IMAGE_SUFFIX}"
-    PRIOR_UBUNTU_CACHE_IMAGE_NAME: "prior-ubuntu-${_BUILT_IMAGE_SUFFIX}"
 
     ####
     #### Command variables to help avoid duplication
@@ -115,15 +113,6 @@ ubuntu_testing_task: &ubuntu_testing
             TEST_DRIVER: "overlay"
 
 
-prior_ubuntu_testing_task:
-    <<: *ubuntu_testing
-    alias: prior_ubuntu_testing
-    name: *std_test_name
-    env:
-        OS_NAME: "${PRIOR_UBUNTU_NAME}"
-        VM_IMAGE: "${PRIOR_UBUNTU_CACHE_IMAGE_NAME}"
-
-
 lint_task:
     env:
         CIRRUS_WORKING_DIR: "/go/src/github.com/containers/storage"
@@ -153,7 +142,6 @@ meta_task:
             ${FEDORA_CACHE_IMAGE_NAME}
             ${PRIOR_FEDORA_CACHE_IMAGE_NAME}
             ${UBUNTU_CACHE_IMAGE_NAME}
-            ${PRIOR_UBUNTU_CACHE_IMAGE_NAME}
         BUILDID: "${CIRRUS_BUILD_ID}"
         REPOREF: "${CIRRUS_CHANGE_IN_REPO}"
         GCPJSON: ENCRYPTED[244a93fe8b386b48b96f748342bf741350e43805eee81dd04b45093bdf737e540b993fc735df41f131835fa0f9b65826]
@@ -181,7 +169,6 @@ success_task:
         - fedora_testing
         - prior_fedora_testing
         - ubuntu_testing
-        - prior_ubuntu_testing
         - meta
         - vendor
     container:


### PR DESCRIPTION
Prior-Ubuntu support is being dropped everywhere.

Ref: https://github.com/containers/podman/issues/11070
     https://github.com/containers/automation_images/pull/88

Signed-off-by: Chris Evich <cevich@redhat.com>