### PR TITLE
overlay: support project quota with partial pulls

### DIFF
--- a/drivers/quota/projectquota.go
+++ b/drivers/quota/projectquota.go
@@ -289,6 +289,15 @@ func (q *Control) fsDiskQuotaFromPath(targetPath string) (C.fs_disk_quota_t, err
 	return d, nil
 }
 
+// CopyProjectID copies the project id from sourcePath to targetPath
+func CopyProjectID(sourcePath, targetPath string) error {
+	q, err := getProjectID(sourcePath)
+	if err != nil {
+		return err
+	}
+	return setProjectID(targetPath, q)
+}
+
 // getProjectID - get the project id of path on xfs
 func getProjectID(targetPath string) (uint32, error) {
 	dir, err := openDir(targetPath)

--- a/drivers/quota/projectquota_unsupported.go
+++ b/drivers/quota/projectquota_unsupported.go
@@ -31,3 +31,8 @@ func (q *Control) SetQuota(targetPath string, quota Quota) error {
 func (q *Control) GetQuota(targetPath string, quota *Quota) error {
 	return errors.New("filesystem does not support, or has not enabled quotas")
 }
+
+// CopyProjectID copies the project id from sourcePath to targetPath
+func CopyProjectID(sourcePath, targetPath string) error {
+	return errors.New("filesystem does not support, or has not enabled quotas")
+}


### PR DESCRIPTION
When quotas are enabled, partial pulls currently fail with an error like:

Error: committing the finished image: rename /var/lib/containers/storage/overlay/staging/012887766 /var/lib/containers/storage/overlay/b9b6a85242afa733a717aa45d7c0d80a444e224c96fb46677453aeef44caa0d6/diff: invalid cross-device link

Assign a project ID to the staging directory and copy it back to the target directory if the EXDEV error happens.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>