### PR TITLE
Create readonly locks if the lockfile does not exists

### DIFF
--- a/pkg/lockfile/lockfile_unix.go
+++ b/pkg/lockfile/lockfile_unix.go
@@ -36,7 +36,7 @@ type lockfile struct {
 // necessary.
 func openLock(path string, ro bool) (fd int, err error) {
 	if ro {
-		fd, err = unix.Open(path, os.O_RDONLY|unix.O_CLOEXEC, 0)
+		fd, err = unix.Open(path, os.O_RDONLY|unix.O_CLOEXEC|os.O_CREATE, 0)
 	} else {
 		fd, err = unix.Open(path,
 			os.O_RDWR|unix.O_CLOEXEC|os.O_CREATE,


### PR DESCRIPTION
Users are setting up readonly shares and sometimes they forget, or do
not even know that they need to create the lockfile.

Even in the quay.io/podman/stable images Dockerfile, I have to manually
create these files.

Fixes: https://github.com/containers/storage/issues/1029

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>