### PR TITLE
Allow setting quota for individual containers

### DIFF
--- a/store.go
+++ b/store.go
@@ -575,10 +575,11 @@ type ContainerOptions struct {
 	// container's layer will inherit settings from the image's top layer
 	// or, if it is not being created based on an image, the Store object.
 	types.IDMappingOptions
-	LabelOpts []string
-	Flags     map[string]interface{}
-	MountOpts []string
-	Volatile  bool
+	LabelOpts  []string
+	Flags      map[string]interface{}
+	MountOpts  []string
+	Volatile   bool
+	StorageOpt map[string]string
 }
 
 type store struct {
@@ -1384,7 +1385,7 @@ func (s *store) CreateContainer(id string, names []string, image, layer, metadat
 		options.Flags["MountLabel"] = mountLabel
 	}
 
-	clayer, err := rlstore.Create(layer, imageTopLayer, nil, options.Flags["MountLabel"].(string), nil, layerOptions, true)
+	clayer, err := rlstore.Create(layer, imageTopLayer, nil, options.Flags["MountLabel"].(string), options.StorageOpt, layerOptions, true)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Drivers have the ability to support size and inodes quota, but
we don't allow these options to be passed down to the driver.

With this fix, Podman should be able to support --storage-opt size=
per container.

Helps Fix: https://github.com/containers/podman/issues/11016

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>