### PR TITLE
store: lock graphLock during Diff

### DIFF
--- a/store.go
+++ b/store.go
@@ -2831,6 +2831,28 @@ func (s *store) Diff(from, to string, options *DiffOptions) (io.ReadCloser, erro
 	if err != nil {
 		return nil, err
 	}
+
+	// NaiveDiff could cause mounts to happen without a lock, so be safe
+	// and treat the .Diff operation as a Mount.
+	s.graphLock.Lock()
+	defer s.graphLock.Unlock()
+
+	modified, err := s.graphLock.Modified()
+	if err != nil {
+		return nil, err
+	}
+
+	// We need to make sure the home mount is present when the Mount is done.
+	if modified {
+		s.graphDriver = nil
+		s.layerStore = nil
+		s.graphDriver, err = s.getGraphDriver()
+		if err != nil {
+			return nil, err
+		}
+		s.lastLoaded = time.Now()
+	}
+
 	for _, s := range append([]ROLayerStore{lstore}, lstores...) {
 		store := s
 		store.RLock()

--- a/store.go
+++ b/store.go
@@ -2857,6 +2857,7 @@ func (s *store) Diff(from, to string, options *DiffOptions) (io.ReadCloser, erro
 		store := s
 		store.RLock()
 		if err := store.ReloadIfChanged(); err != nil {
+			store.Unlock()
 			return nil, err
 		}
 		if store.Exists(to) {


### PR DESCRIPTION
the NaiveDiff driver could cause a mount to happen without any locking
in place.

For such reason, treat the Diff operation similarly to Mount.

Closes: https://github.com/containers/storage/issues/1034

Alternative to https://github.com/containers/storage/pull/1033

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>