### PR TITLE
Fix: relative path will result infinite loop

### DIFF
--- a/pkg/idtools/idtools_unix.go
+++ b/pkg/idtools/idtools_unix.go
@@ -46,6 +46,9 @@ func mkdirAs(path string, mode os.FileMode, ownerUID, ownerGID int, mkAll, chown
 		// walk back to "/" looking for directories which do not exist
 		// and add them to the paths array for chown after creation
 		dirPath := path
+		if !filepath.IsAbs(dirPath) {
+			return fmt.Errorf("path: %s should be absolute", dirPath)
+		}
 		for {
 			dirPath = filepath.Dir(dirPath)
 			if dirPath == "/" {

--- a/pkg/idtools/idtools_unix_test.go
+++ b/pkg/idtools/idtools_unix_test.go
@@ -76,6 +76,11 @@ func TestMkdirAllAs(t *testing.T) {
 	if err := compareTrees(testTree, verifyTree); err != nil {
 		t.Fatal(err)
 	}
+
+	// relative path will return an error
+	if err := MkdirAllAs("test", 0755, 102, 102); err == nil || err.Error() != "path: test should be absolute" {
+		t.Fatalf("Expect path error, but got:%v", err)
+	}
 }
 
 func TestMkdirAllAndChownNew(t *testing.T) {


### PR DESCRIPTION
https://github.com/containers/storage/blob/73df15cb57ffd432da5f0e26ef6538441a00021a/pkg/idtools/idtools_unix.go#L49 will result an infinite loop when the path is relative.

Add validation to avoid it.

Signed-off-by: chenk008 <kongchen28@gmail.com>