### PR TITLE
[CI:DOCS] Clearup inheritance rules for storage.conf

### DIFF
--- a/docs/containers-storage.conf.5.md
+++ b/docs/containers-storage.conf.5.md
@@ -315,7 +315,11 @@ This is a way to prevent xfs_quota management from conflicting with containers/s
 
 ## FILES
 
-Distributions often provide a `/usr/share/containers/storage.conf` file to define default storage configuration. Administrators can override this file by creating `/etc/containers/storage.conf` to specify their own configuration. The storage.conf file for rootless users is stored in the `$XDG_CONFIG_HOME/containers/storage.conf` file.  If `$XDG_CONFIG_HOME` is not set then the file `$HOME/.config/containers/storage.conf` is used.
+Distributions often provide a `/usr/share/containers/storage.conf` file to define default storage configuration. Administrators can override this file by creating `/etc/containers/storage.conf` to specify their own configuration. Likewise rootless users can create a storage.conf file to override the system storage.conf files. Files should be stored in the `$XDG_CONFIG_HOME/containers/storage.conf` file.  If `$XDG_CONFIG_HOME` is not set then the file `$HOME/.config/containers/storage.conf` is used.
+
+Note: The storage.conf file overrides all other strorage.conf files. Container
+engines run by users with a storage.conf file in their home directory do not
+use options in the system storage.conf files.
 
 /etc/projects - XFS persistent project root definition
 /etc/projid -  XFS project name mapping file

--- a/storage.conf
+++ b/storage.conf
@@ -1,5 +1,14 @@
 # This file is is the configuration file for all tools
-# that use the containers/storage library.
+# that use the containers/storage library. The storage.conf file
+# overrides all other storage.conf files. Container engines using the
+# container/storage library do not inherit fields from other storage.conf
+# files.
+#
+#  Note: The storage.conf file overrides other storage.conf files based on this precedence:
+#      /usr/containers/storage.conf
+#      /etc/containers/storage.conf
+#      $HOME/.config/containers/storage.conf
+#      $XDG_CONFIG_HOME/containers/storage.conf (If XDG_CONFIG_HOME is set)
 # See man 5 containers-storage.conf for more information
 # The "container storage" table contains all of the server options.
 [storage]


### PR DESCRIPTION
We have had cases where users assume that create a storage.conf file in
their home directory, will still inherit fields from the system
storage.conf files. Need to clear this up in the storage.conf file and
man page.

Fixes: https://github.com/containers/podman/issues/11778

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>