### PR TITLE
idtools: fix ToHost conversion

### DIFF
--- a/pkg/idtools/idtools.go
+++ b/pkg/idtools/idtools.go
@@ -185,18 +185,14 @@ func (i *IDMappings) RootPair() IDPair {
 // Remapping is only performed if the ids aren't already the remapped root ids
 func (i *IDMappings) ToHost(pair IDPair) (IDPair, error) {
 	var err error
-	target := i.RootPair()
+	var target IDPair
 
-	if pair.UID != target.UID {
-		target.UID, err = toHost(pair.UID, i.uids)
-		if err != nil {
-			return target, err
-		}
+	target.UID, err = toHost(pair.UID, i.uids)
+	if err != nil {
+		return target, err
 	}
 
-	if pair.GID != target.GID {
-		target.GID, err = toHost(pair.GID, i.gids)
-	}
+	target.GID, err = toHost(pair.GID, i.gids)
 	return target, err
 }
 

--- a/pkg/idtools/idtools_test.go
+++ b/pkg/idtools/idtools_test.go
@@ -4,6 +4,48 @@ import (
 	"testing"
 )
 
+func TestToHost(t *testing.T) {
+	idMappings := []IDMap{
+		{
+			ContainerID: 0,
+			HostID:      1000,
+			Size:        1,
+		},
+		{
+			ContainerID: 1,
+			HostID:      100000,
+			Size:        65536,
+		},
+	}
+
+	mappings := IDMappings{
+		uids: idMappings,
+		gids: idMappings,
+	}
+
+	pair, err := mappings.ToHost(IDPair{UID: 0, GID: 0})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pair.UID != 1000 {
+		t.Fatalf("Converted to the wrong UID")
+	}
+	if pair.GID != 1000 {
+		t.Fatalf("Converted to the wrong GID")
+	}
+
+	pair, err = mappings.ToHost(IDPair{UID: 1000, GID: 1000})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if pair.UID != 100999 {
+		t.Fatalf("Converted to the wrong UID")
+	}
+	if pair.GID != 100999 {
+		t.Fatalf("Converted to the wrong GID")
+	}
+}
+
 func TestGetRootUIDGID(t *testing.T) {
 	mappingsUIDs := []IDMap{
 		{


### PR DESCRIPTION
drop a special case for RootPair that prevented the conversion of the
UID/GID when it was matching the root user in the container.

Closes: https://github.com/containers/storage/issues/1056

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>