### PR TITLE
reexec.Command(): panic if reexec.Init() wasn't called

### DIFF
--- a/pkg/reexec/command_linux.go
+++ b/pkg/reexec/command_linux.go
@@ -17,6 +17,7 @@ func Self() string {
 // This will use the in-memory version (/proc/self/exe) of the current binary,
 // it is thus safe to delete or replace the on-disk binary (os.Args[0]).
 func Command(args ...string) *exec.Cmd {
+	panicIfNotInitialized()
 	cmd := exec.Command(Self())
 	cmd.Args = args
 	return cmd
@@ -26,6 +27,7 @@ func Command(args ...string) *exec.Cmd {
 // This will use the in-memory version (/proc/self/exe) of the current binary,
 // it is thus safe to delete or replace the on-disk binary (os.Args[0]).
 func CommandContext(ctx context.Context, args ...string) *exec.Cmd {
+	panicIfNotInitialized()
 	cmd := exec.CommandContext(ctx, Self())
 	cmd.Args = args
 	return cmd

--- a/pkg/reexec/command_unix.go
+++ b/pkg/reexec/command_unix.go
@@ -17,6 +17,7 @@ func Self() string {
 // For example if current binary is "docker" at "/usr/bin/", then cmd.Path will
 // be set to "/usr/bin/docker".
 func Command(args ...string) *exec.Cmd {
+	panicIfNotInitialized()
 	cmd := exec.Command(Self())
 	cmd.Args = args
 	return cmd
@@ -24,6 +25,7 @@ func Command(args ...string) *exec.Cmd {
 
 // CommandContext returns *exec.Cmd which has Path as current binary.
 func CommandContext(ctx context.Context, args ...string) *exec.Cmd {
+	panicIfNotInitialized()
 	cmd := exec.CommandContext(ctx, Self())
 	cmd.Args = args
 	return cmd

--- a/pkg/reexec/command_unsupported.go
+++ b/pkg/reexec/command_unsupported.go
@@ -9,10 +9,12 @@ import (
 
 // Command is unsupported on operating systems apart from Linux, Windows, Solaris and Darwin.
 func Command(args ...string) *exec.Cmd {
+	panicIfNotInitialized()
 	return nil
 }
 
 // CommandContext is unsupported on operating systems apart from Linux, Windows, Solaris and Darwin.
 func CommandContext(ctx context.Context, args ...string) *exec.Cmd {
+	panicIfNotInitialized()
 	return nil
 }

--- a/pkg/reexec/command_windows.go
+++ b/pkg/reexec/command_windows.go
@@ -17,6 +17,7 @@ func Self() string {
 // For example if current binary is "docker.exe" at "C:\", then cmd.Path will
 // be set to "C:\docker.exe".
 func Command(args ...string) *exec.Cmd {
+	panicIfNotInitialized()
 	cmd := exec.Command(Self())
 	cmd.Args = args
 	return cmd
@@ -26,6 +27,7 @@ func Command(args ...string) *exec.Cmd {
 // For example if current binary is "docker.exe" at "C:\", then cmd.Path will
 // be set to "C:\docker.exe".
 func CommandContext(ctx context.Context, args ...string) *exec.Cmd {
+	panicIfNotInitialized()
 	cmd := exec.CommandContext(ctx, Self())
 	cmd.Args = args
 	return cmd

--- a/pkg/reexec/reexec.go
+++ b/pkg/reexec/reexec.go
@@ -7,7 +7,10 @@ import (
 	"path/filepath"
 )
 
-var registeredInitializers = make(map[string]func())
+var (
+	registeredInitializers = make(map[string]func())
+	initWasCalled          = false
+)
 
 // Register adds an initialization func under the specified name
 func Register(name string, initializer func()) {
@@ -27,7 +30,23 @@ func Init() bool {
 
 		return true
 	}
+	initWasCalled = true
 	return false
+}
+
+func panicIfNotInitialized() {
+	if !initWasCalled {
+		// The reexec package is used to run subroutines in
+		// subprocesses which would otherwise have unacceptable side
+		// effects on the main thread.  If you found this error, then
+		// your program uses a package which needs to do this.  In
+		// order for that to work, main() should start with this
+		// boilerplate, or an equivalent:
+		//     if reexec.Init() {
+		//         return
+		//     }
+		panic("a library subroutine needed to run a subprocess, but reexec.Init() was not called in main()")
+	}
 }
 
 func naiveSelf() string {


### PR DESCRIPTION
If we start preparing to reexec ourselves, but didn't call `Init()` earlier, `panic()`.  The alternative is that the child process we start
won't do the work we want it to do as a dedicated subprocess, failing in a way which could be difficult to troubleshoot.

Fixes https://github.com/containers/image/issues/1401 by making it easier to spot the bug.