### PR TITLE
Use math/rand.Rand.Read to generate slices of random data

### DIFF
--- a/drivers/graphtest/graphtest_unix.go
+++ b/drivers/graphtest/graphtest_unix.go
@@ -1,3 +1,4 @@
+//go:build linux || freebsd || solaris
 // +build linux freebsd solaris
 
 package graphtest
@@ -10,9 +11,7 @@ import (
 	"os"
 	"path"
 	"path/filepath"
-	"reflect"
 	"testing"
-	"unsafe"
 
 	graphdriver "github.com/containers/storage/drivers"
 	"github.com/containers/storage/pkg/archive"
@@ -415,18 +414,12 @@ func DriverTestChanges(t testing.TB, drivername string, driverOptions ...string)
 }
 
 func writeRandomFile(path string, size uint64) error {
-	buf := make([]int64, size/8)
+	data := make([]byte, size)
 
-	r := rand.NewSource(0)
-	for i := range buf {
-		buf[i] = r.Int63()
+	rng := rand.New(rand.NewSource(0))
+	if _, err := rng.Read(data); err != nil {
+		return err
 	}
-
-	// Cast to []byte
-	header := *(*reflect.SliceHeader)(unsafe.Pointer(&buf))
-	header.Len *= 8
-	header.Cap *= 8
-	data := *(*[]byte)(unsafe.Pointer(&header))
 
 	return ioutil.WriteFile(path, data, 0700)
 }

--- a/drivers/graphtest/testutil.go
+++ b/drivers/graphtest/testutil.go
@@ -15,15 +15,12 @@ import (
 )
 
 func randomContent(size int, seed int64) []byte {
-	s := rand.NewSource(seed)
 	content := make([]byte, size)
 
-	for i := 0; i < len(content); i += 7 {
-		val := s.Int63()
-		for j := 0; i+j < len(content) && j < 7; j++ {
-			content[i+j] = byte(val)
-			val >>= 8
-		}
+	rng := rand.New(rand.NewSource(seed))
+	read, err := rng.Read(content)
+	if err != nil || read != size {
+		panic("Unexpected failure of math/rand.Rand.Read")
 	}
 
 	return content


### PR DESCRIPTION
… instead of open-coding loops, primarily to simplify.

In one case this is a speedup, in the other it’s a noticeable slowdown, a correctness improvement in theory at least.