### PR TITLE
reexec: mark us as initialized when calling initializers

### DIFF
--- a/pkg/reexec/reexec.go
+++ b/pkg/reexec/reexec.go
@@ -25,12 +25,12 @@ func Register(name string, initializer func()) {
 // initialization function was called.
 func Init() bool {
 	initializer, exists := registeredInitializers[os.Args[0]]
+	initWasCalled = true
 	if exists {
 		initializer()
 
 		return true
 	}
-	initWasCalled = true
 	return false
 }
 


### PR DESCRIPTION
In cases where one of our initializers needs to itself use reexec, they shouldn't panic().

Follow-up to #1058.