### PR TITLE
archive: ignore the security.selinux xattr

### DIFF
--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -921,6 +921,26 @@ func BenchmarkTarUntarWithLinks(b *testing.B) {
 	}
 }
 
+func TestUntarSelinuxLabel(t *testing.T) {
+	xattrs := map[string]string{
+		"SCHILY.xattr.security.selinux": "invalid-label",
+	}
+	for i, headers := range [][]*tar.Header{
+		{
+			{
+				Name:       "foo",
+				Typeflag:   tar.TypeReg,
+				Mode:       0644,
+				PAXRecords: xattrs,
+			},
+		},
+	} {
+		if err := testBreakout("untar", "storage-TestUntarInvalidFilenames", headers); err != nil {
+			t.Fatalf("i=%d. %v", i, err)
+		}
+	}
+}
+
 func TestUntarInvalidFilenames(t *testing.T) {
 	// TODO Windows: Figure out how to fix this test.
 	if runtime.GOOS == windows {

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -1230,27 +1230,6 @@ func TestReplaceFileTarWrapper(t *testing.T) {
 	}
 }
 
-/*
-// TestPrefixHeaderReadable tests that files that could be created with the
-// version of this package that was built with <=go17 are still readable.
-func TestPrefixHeaderReadable(t *testing.T) {
-	// https://gist.github.com/stevvooe/e2a790ad4e97425896206c0816e1a882#file-out-go
-	var testFile = []byte("\x1f\x8b\x08\x08\x44\x21\x68\x59\x00\x03\x74\x2e\x74\x61\x72\x00\x4b\xcb\xcf\x67\xa0\x35\x30\x80\x00\x86\x06\x10\x47\x01\xc1\x37\x40\x00\x54\xb6\xb1\xa1\xa9\x99\x09\x48\x25\x1d\x40\x69\x71\x49\x62\x91\x02\xe5\x76\xa1\x79\x84\x21\x91\xd6\x80\x72\xaf\x8f\x82\x51\x30\x0a\x46\x36\x00\x00\xf0\x1c\x1e\x95\x00\x06\x00\x00")
-
-	tmpDir, err := ioutil.TempDir("", "prefix-test")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
-	err = Untar(bytes.NewReader(testFile), tmpDir, nil)
-	require.NoError(t, err)
-
-	baseName := "foo"
-	pth := strings.Repeat("a", 100-len(baseName)) + "/" + baseName
-
-	_, err = os.Lstat(filepath.Join(tmpDir, pth))
-	require.NoError(t, err)
-}
-*/
-
 func buildSourceArchive(t *testing.T, numberOfFiles int) (io.ReadCloser, func()) {
 	srcDir, err := ioutil.TempDir("", "storage-test-srcDir")
 	require.NoError(t, err)


### PR DESCRIPTION
ignore the security.selinux xattr if it is present in the tarball header, since invalid labels cannot be set by unprivileged users and the `lsetxattr` syscall fails with EINVAL.

Closes: https://github.com/containers/storage/issues/1076

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>

