### PR TITLE
Reset defaultConfigFile if defaultOverrideConfigFile exits.

### DIFF
--- a/types/options.go
+++ b/types/options.go
@@ -42,6 +42,10 @@ func init() {
 	defaultStoreOptions.GraphDriverName = ""
 
 	if _, err := os.Stat(defaultOverrideConfigFile); err == nil {
+		// The DefaultConfigFile(rootless) function returns the path
+		// of the used storage.conf file, by returning defaultConfigFile
+		// If override exists containers/storage uses it by default.
+		defaultConfigFile = defaultOverrideConfigFile
 		ReloadConfigurationFileIfNeeded(defaultOverrideConfigFile, &defaultStoreOptions)
 	} else {
 		if !os.IsNotExist(err) {


### PR DESCRIPTION
Currently DefaultConfigFile does not report back the storage.conf file
that is actually used if /etc/containers/storage.conf exists it should
be reported back to the user. This issue was seen with Podman.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>