### PR TITLE
idtools: support libsubid 4

### DIFF
--- a/pkg/idtools/idtools_supported.go
+++ b/pkg/idtools/idtools_supported.go
@@ -17,6 +17,12 @@ struct subid_range get_range(struct subid_range *ranges, int i)
 {
     return ranges[i];
 }
+
+#if !defined(SUBID_ABI_MAJOR) || (SUBID_ABI_MAJOR < 4)
+# define subid_get_uid_ranges get_subuid_ranges
+# define subid_get_gid_ranges get_subgid_ranges
+#endif
+
 */
 import "C"
 
@@ -32,9 +38,9 @@ func readSubid(username string, isUser bool) (ranges, error) {
 	var nRanges C.int
 	var cRanges *C.struct_subid_range
 	if isUser {
-		nRanges = C.get_subuid_ranges(cUsername, &cRanges)
+		nRanges = C.subid_get_uid_ranges(cUsername, &cRanges)
 	} else {
-		nRanges = C.get_subgid_ranges(cUsername, &cRanges)
+		nRanges = C.subid_get_gid_ranges(cUsername, &cRanges)
 	}
 	if nRanges < 0 {
 		return nil, errors.New("cannot read subids")


### PR DESCRIPTION
the functions get_subuid_ranges and get_subgid_ranges were renamed
respectively to subid_get_uid_ranges and subid_get_gid_ranges in
libsubid version 4.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>