### PR TITLE
build: fix libsubid test

### DIFF
--- a/hack/libsubid_tag.sh
+++ b/hack/libsubid_tag.sh
@@ -7,9 +7,19 @@ mkdir -p "$tmpdir"
 trap 'rm -fr "$tmpdir"' EXIT
 cc -o "$tmpdir"/libsubid_tag -l subid -x c - > /dev/null 2> /dev/null << EOF
 #include <shadow/subid.h>
+#include <stdio.h>
+#include <stdlib.h>
+
+const char *Prog = "test";
+FILE *shadow_logfd = NULL;
+
 int main() {
 	struct subid_range *ranges = NULL;
+#if SUBID_ABI_MAJOR >= 4
+	subid_get_uid_ranges("root", &ranges);
+#else
 	get_subuid_ranges("root", &ranges);
+#endif
 	free(ranges);
 	return 0;
 }

--- a/pkg/idtools/idtools_supported.go
+++ b/pkg/idtools/idtools_supported.go
@@ -12,10 +12,14 @@ import (
 #cgo LDFLAGS: -l subid
 #include <shadow/subid.h>
 #include <stdlib.h>
+#include <stdio.h>
 const char *Prog = "storage";
+FILE *shadow_logfd = NULL;
+
 struct subid_range get_range(struct subid_range *ranges, int i)
 {
-    return ranges[i];
+	shadow_logfd = stderr;
+	return ranges[i];
 }
 
 #if !defined(SUBID_ABI_MAJOR) || (SUBID_ABI_MAJOR < 4)


### PR DESCRIPTION
libsubid changes its ABI in version 4.  Account for the different name
in the configure script.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>