### PR TITLE
Backport store: lock graphLock during to 1.36

### DIFF
--- a/store.go
+++ b/store.go
@@ -2825,10 +2825,33 @@ func (s *store) Diff(from, to string, options *DiffOptions) (io.ReadCloser, erro
 	if err != nil {
 		return nil, err
 	}
+
+	// NaiveDiff could cause mounts to happen without a lock, so be safe
+	// and treat the .Diff operation as a Mount.
+	s.graphLock.Lock()
+	defer s.graphLock.Unlock()
+
+	modified, err := s.graphLock.Modified()
+	if err != nil {
+		return nil, err
+	}
+
+	// We need to make sure the home mount is present when the Mount is done.
+	if modified {
+		s.graphDriver = nil
+		s.layerStore = nil
+		s.graphDriver, err = s.getGraphDriver()
+		if err != nil {
+			return nil, err
+		}
+		s.lastLoaded = time.Now()
+	}
+
 	for _, s := range append([]ROLayerStore{lstore}, lstores...) {
 		store := s
 		store.RLock()
 		if err := store.ReloadIfChanged(); err != nil {
+			store.Unlock()
 			return nil, err
 		}
 		if store.Exists(to) {


### PR DESCRIPTION
Backport the fix for #1037 to
the release-1.36 branch so that it can then be backported to Podman's
v3.4.2-rhel branch for RHEL 8.5.0.2

Note: #1097 was completed to the 1.37 branch in error.  Podman
v3.4.2-rhel is still on c/storage v1.36

Signed-off-by: tomsweeneyredhat <tsweeney@redhat.com>