### PR TITLE
ImageBigData: add note to error

### DIFF
--- a/store.go
+++ b/store.go
@@ -1613,7 +1613,7 @@ func (s *store) ImageBigData(id, key string) ([]byte, error) {
 		}
 	}
 	if foundImage {
-		return nil, errors.Wrapf(os.ErrNotExist, "error locating item named %q for image with ID %q", key, id)
+		return nil, errors.Wrapf(os.ErrNotExist, "error locating item named %q for image with ID %q (consider removing the image to resolve the issue)", key, id)
 	}
 	return nil, errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
 }


### PR DESCRIPTION
A common error when dealing with corrupted images is

> error locating item named "manifest" for image with ID "...": file does not exist

In many cases, the process writing to the containers storage has been
killed while pulling, building or committing an image.  The best thing
to do in this case is to remove the image as it is not usable.

Add a note to the error to consider removing the image to resolve the
issue to guide the users a bit more.

Fixes: containers/podman/issues/12854
Signed-off-by: Valentin Rothberg <rothberg@redhat.com>