### PR TITLE
archive: skip adding sockets to the tarball

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -511,6 +511,10 @@ func (ta *tarAppender) addTarFile(path, name string) error {
 			return err
 		}
 	}
+	if fi.Mode()&os.ModeSocket != 0 {
+		logrus.Warnf("archive: skipping %q since it is a socket", path)
+		return nil
+	}
 
 	hdr, err := FileInfoHeader(name, fi, link)
 	if err != nil {

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"net"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -571,6 +572,39 @@ func TestCopyFileWithTarSrcFile(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
+	err = os.MkdirAll(dest, 0740)
+	if err != nil {
+		t.Fatal(err)
+	}
+	ioutil.WriteFile(src, []byte("content"), 0777)
+	err = defaultCopyWithTar(src, dest+"/")
+	if err != nil {
+		t.Fatalf("archiver.CopyFileWithTar shouldn't throw an error, %s.", err)
+	}
+	_, err = os.Stat(dest)
+	if err != nil {
+		t.Fatalf("Destination folder should contain the source file but did not.")
+	}
+}
+
+func TestCopySocket(t *testing.T) {
+	folder, err := ioutil.TempDir("", "storage-archive-test")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer os.RemoveAll(folder)
+	dest := filepath.Join(folder, "dest")
+	src := filepath.Join(folder, "src")
+	err = os.MkdirAll(src, 0740)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	_, err = net.Listen("unix", filepath.Join(src, "unix-socket"))
+	if err != nil {
+		t.Fatal(err)
+	}
+
 	err = os.MkdirAll(dest, 0740)
 	if err != nil {
 		t.Fatal(err)


### PR DESCRIPTION
the tar format doesn't support sockets so avoid adding them to the tar
stream.

Closes: https://github.com/containers/storage/issues/1115

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>