### PR TITLE
Naive diff should mount all layers read-only

### DIFF
--- a/drivers/fsdiff.go
+++ b/drivers/fsdiff.go
@@ -127,6 +127,7 @@ func (gdw *NaiveDiffDriver) Changes(id string, idMappings *idtools.IDMappings, p
 	options := MountOpts{
 		MountLabel: mountLabel,
 	}
+	options.Options = append(options.Options, "ro")
 	layerFs, err := driver.Get(id, options)
 	if err != nil {
 		return nil, err
@@ -139,6 +140,7 @@ func (gdw *NaiveDiffDriver) Changes(id string, idMappings *idtools.IDMappings, p
 		options := MountOpts{
 			MountLabel: mountLabel,
 		}
+		options.Options = append(options.Options, "ro")
 		parentFs, err = driver.Get(parent, options)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
We don't need to write for a diff, and if the layers are on read-only
additionalimagestores, trying to mount them fails when they are used
as upperdir.

Similar to e96cd8656f24f56.

This is pretty much shot-in-the-dark, but it seems to fix the issue for me.
We should also investigate whether Diff and DiffSize need the same treatment.

The code also loses the default mount options here due to passing its own,
not sure if this is problematic.

Removing the /merged dir fails, but not sure why that is done in first place,
as overlay directories usually have empty /merged.

Podman issue: [#12926](https://github.com/containers/podman/issues/12926)