### PR TITLE
overlay.Get(): default to read-only for layers in additionalStores

### DIFF
--- a/drivers/fsdiff.go
+++ b/drivers/fsdiff.go
@@ -138,6 +138,7 @@ func (gdw *NaiveDiffDriver) Changes(id string, idMappings *idtools.IDMappings, p
 	if parent != "" {
 		options := MountOpts{
 			MountLabel: mountLabel,
+			Options:    []string{"ro"},
 		}
 		parentFs, err = driver.Get(parent, options)
 		if err != nil {


### PR DESCRIPTION
When mounting a layer, if the layer in question lives in an additional store, default to mounting it read-only, which is how we're treating the additional store's layers.  If we need to generate a diff using the naive diff implementation, this will prevent errors that would crop up if we tried and failed to mount the layer read-write, per #1121.

When mounting a parent layer in `drivers.NaiveDiffDriver.Changes()`, default to mounting it read-only, too, since a layer that is the basis for other layers shouldn't ever need to be mounted read-write anyway.