### PR TITLE
Fix build

### DIFF
--- a/pkg/idtools/idtools_supported.go
+++ b/pkg/idtools/idtools_supported.go
@@ -1,3 +1,4 @@
+//go:build linux && cgo && libsubid
 // +build linux,cgo,libsubid
 
 package idtools


### PR DESCRIPTION
Follow up to pr#1086.

Without this change, podman doesn't build with the latest version of
shadow-utils in fedora rawhide and 36.

Signed-off-by: Lokesh Mandvekar <lsm5@fedoraproject.org>


@rhatdan @giuseppe @vrothberg @mheon PTAL.

That line was automatically added for me by vim-go when I saved the file.