### PR TITLE
RFC: Mark layers for deletion before actually doing so

### DIFF
--- a/layers.go
+++ b/layers.go
@@ -399,14 +399,12 @@ func (r *layerStore) Load() error {
 				if layer.Flags == nil {
 					layer.Flags = make(map[string]interface{})
 				}
-				if cleanup, ok := layer.Flags[incompleteFlag]; ok {
-					if b, ok := cleanup.(bool); ok && b {
-						err = r.deleteInternal(layer.ID)
-						if err != nil {
-							break
-						}
-						shouldSave = true
+				if layerHasIncompleteFlag(layer) {
+					err = r.deleteInternal(layer.ID)
+					if err != nil {
+						break
 					}
+					shouldSave = true
 				}
 			}
 		}
@@ -1147,6 +1145,17 @@ func (r *layerStore) SetMetadata(id, metadata string) error {
 
 func (r *layerStore) tspath(id string) string {
 	return filepath.Join(r.layerdir, id+tarSplitSuffix)
+}
+
+// layerHasIncompleteFlag returns true if layer.Flags contains an incompleteFlag set to true
+func layerHasIncompleteFlag(layer *Layer) bool {
+	// layer.Flags[…] is defined to succeed and return ok == false if Flags == nil
+	if flagValue, ok := layer.Flags[incompleteFlag]; ok {
+		if b, ok := flagValue.(bool); ok && b {
+			return true
+		}
+	}
+	return false
 }
 
 func (r *layerStore) deleteInternal(id string) error {


### PR DESCRIPTION
RFC. This is absolutely untested, and I don’t really know what I’m doing WRT any pre-existing design about crash-resilience or the like.

Currently, we just tell the graph driver to start deleting data, and only after that succeeds, delete the layer metadata. If the graph driver’s deletion process is interrupted for any reason, that could result in a visible / “usable” layer that will nevertheless fail somewhere in the graph driver if on any actual use.

We have an `incompleteFlag` mechanism for layers that have been created but don’t have the content populated on pull; just reuse it for any other deletes.

(In `layerStore.load`, `deleteInternal` is called on layers with that flag already set; in that case we don’t update it again and don’t need to save the layer again, until cleanup finishes.)