### PR TITLE
Improve handling of failures to delete a WIP layer

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -920,7 +920,9 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts, disable
 	defer func() {
 		// Clean up on failure
 		if retErr != nil {
-			os.RemoveAll(dir)
+			if err2 := os.RemoveAll(dir); err2 != nil {
+				logrus.Errorf("While recovering from a failure creating a layer, error deleting %#v: %v", dir, err2)
+			}
 		}
 	}()
 

--- a/layers.go
+++ b/layers.go
@@ -795,6 +795,7 @@ func (r *layerStore) Put(id string, parentLayer *Layer, names []string, mountLab
 		for flag, value := range flags {
 			layer.Flags[flag] = value
 		}
+		savedIncompleteLayer := false
 		if diff != nil {
 			layer.Flags[incompleteFlag] = true
 			err = r.Save()
@@ -806,6 +807,7 @@ func (r *layerStore) Put(id string, parentLayer *Layer, names []string, mountLab
 				}
 				return nil, -1, err
 			}
+			savedIncompleteLayer = true
 			size, err = r.applyDiffWithOptions(layer.ID, moreOptions, diff)
 			if err != nil {
 				if err2 := r.Delete(layer.ID); err2 != nil {
@@ -820,10 +822,19 @@ func (r *layerStore) Put(id string, parentLayer *Layer, names []string, mountLab
 		}
 		err = r.Save()
 		if err != nil {
-			// We don't have a record of this layer, but at least
-			// try to clean it up underneath us.
-			if err2 := r.driver.Remove(id); err2 != nil {
-				logrus.Errorf("While recovering from a failure saving finished layer metadata, error deleting layer %#v: %v", id, err2)
+			if savedIncompleteLayer {
+				if err2 := r.Delete(layer.ID); err2 != nil {
+					// Either a driver error or an error saving.
+					// We now have a layer that's been marked for
+					// deletion but which we failed to remove.
+					logrus.Errorf("While recovering from a failure applying layer diff, error deleting layer %#v: %v", layer.ID, err2)
+				}
+			} else {
+				// We don't have a record of this layer, but at least
+				// try to clean it up underneath us.
+				if err2 := r.driver.Remove(id); err2 != nil {
+					logrus.Errorf("While recovering from a failure saving finished layer metadata, error deleting layer %#v in graph driver: %v", id, err2)
+				}
 			}
 			return nil, -1, err
 		}


### PR DESCRIPTION
- Always log that our cleanup failed.
- Try to remove the metadata of a layer if we succeeded writing that metadata.

See individual commit messages for details.