### PR TITLE
(Alternative to 1148): Don't blindly reuse state from a previous layer when re-creating it

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -939,6 +939,16 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts, disable
 		rootUID = int(st.UID())
 		rootGID = int(st.GID())
 	}
+
+	if _, err := system.Lstat(dir); err == nil {
+		logrus.Warnf("Trying to create a layer %#v while directory %q already exists; removing it first", id, dir)
+		// Don’t just os.RemoveAll(dir) here; d.Remove also removes the link in linkDir,
+		// so that we can’t end up with two symlinks in linkDir pointing to the same layer.
+		if err := d.Remove(id); err != nil {
+			return errors.Wrapf(err, "removing a pre-existing layer directory %q", dir)
+		}
+	}
+
 	if err := idtools.MkdirAllAndChownNew(dir, 0700, idPair); err != nil {
 		return err
 	}


### PR DESCRIPTION
- <s>Use the `Driver.locker` lock when creating a layer in the overlay driver. I don’t know why that lock is necessary, but if it is necessary at all, it seems that it should be held on that code path. Alternatively, maybe that lock should be removed entirely?</s>
- Don't just add files to the layer’s directory; if we find anything pre-existing, remove that, including the symbolic link in `linkDir`, to ensure the layer is created in a known state.

Compare also **EDIT <s>#1133</s> #1139**.