### PR TITLE
drivers, chown: support chown of hard links

### DIFF
--- a/drivers/chown.go
+++ b/drivers/chown.go
@@ -50,11 +50,14 @@ func chownByMapsMain() {
 	if len(toHost.UIDs()) == 0 && len(toHost.GIDs()) == 0 {
 		toHost = nil
 	}
+
+	chowner := newLChowner()
+
 	chown := func(path string, info os.FileInfo, _ error) error {
 		if path == "." {
 			return nil
 		}
-		return platformLChown(path, info, toHost, toContainer)
+		return chowner.LChown(path, info, toHost, toContainer)
 	}
 	if err := pwalk.Walk(".", chown); err != nil {
 		fmt.Fprintf(os.Stderr, "error during chown: %v", err)

--- a/drivers/chown_unix.go
+++ b/drivers/chown_unix.go
@@ -7,18 +7,27 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"sync"
 	"syscall"
 
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/system"
 )
 
+type inode struct {
+	Dev uint64
+	Ino uint64
+}
 
 type platformChowner struct {
+	mutex  sync.Mutex
+	inodes map[inode]bool
 }
 
 func newLChowner() *platformChowner {
-	return &platformChowner{}
+	return &platformChowner{
+		inodes: make(map[inode]bool),
+	}
 }
 
 func (c *platformChowner) LChown(path string, info os.FileInfo, toHost, toContainer *idtools.IDMappings) error {
@@ -26,6 +35,22 @@ func (c *platformChowner) LChown(path string, info os.FileInfo, toHost, toContai
 	if !ok {
 		return nil
 	}
+
+	i := inode{
+		Dev: uint64(st.Dev),
+		Ino: uint64(st.Ino),
+	}
+	c.mutex.Lock()
+	_, found := c.inodes[i]
+	if !found {
+		c.inodes[i] = true
+	}
+	c.mutex.Unlock()
+
+	if found {
+		return nil
+	}
+
 	// Map an on-disk UID/GID pair from host to container
 	// using the first map, then back to the host using the
 	// second map.  Skip that first step if they're 0, to

--- a/drivers/chown_unix.go
+++ b/drivers/chown_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package graphdriver
@@ -12,7 +13,15 @@ import (
 	"github.com/containers/storage/pkg/system"
 )
 
-func platformLChown(path string, info os.FileInfo, toHost, toContainer *idtools.IDMappings) error {
+
+type platformChowner struct {
+}
+
+func newLChowner() *platformChowner {
+	return &platformChowner{}
+}
+
+func (c *platformChowner) LChown(path string, info os.FileInfo, toHost, toContainer *idtools.IDMappings) error {
 	st, ok := info.Sys().(*syscall.Stat_t)
 	if !ok {
 		return nil

--- a/drivers/chown_windows.go
+++ b/drivers/chown_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package graphdriver
@@ -9,6 +10,13 @@ import (
 	"github.com/containers/storage/pkg/idtools"
 )
 
-func platformLChown(path string, info os.FileInfo, toHost, toContainer *idtools.IDMappings) error {
+type platformChowner struct {
+}
+
+func newLChowner() *platformChowner {
+	return &platformChowner{}
+}
+
+func (c *platformChowner) LChown(path string, info os.FileInfo, toHost, toContainer *idtools.IDMappings) error {
 	return &os.PathError{"lchown", path, syscall.EWINDOWS}
 }


### PR DESCRIPTION
make sure the same inode is not chowned twice.  Track all the inodes that are chowned and skip the same inode if it is encountered multiple times.

Closes: https://github.com/containers/storage/issues/1143

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
