### PR TITLE
(Alternative to 1140): Record layers as incomplete before trying to create them

### DIFF
--- a/layers.go
+++ b/layers.go
@@ -844,9 +844,10 @@ func (r *layerStore) Put(id string, parentLayer *Layer, names []string, mountLab
 	layer.Flags[incompleteFlag] = true
 	err = r.Save()
 	if err != nil {
-		// We don't have a record of this layer, but at least
-		// try to clean it up underneath us.
-		if err2 := r.driver.Remove(id); err2 != nil {
+		// We don't have a presistent record of this layer, but
+		// try to remove both the driver’s data as well as
+		// the in-memory layer record.
+		if err2 := r.Delete(layer.ID); err2 != nil {
 			logrus.Errorf("While recovering from a failure saving incomplete layer metadata, error deleting layer %#v: %v", id, err2)
 		}
 		return nil, -1, err


### PR DESCRIPTION
This implements the suggestion in #1139, along with **EDIT partially** fixing #1147 ; as an alternative to #1140 .

Conceptually I like this much better than #1140, but it’s quite a bit more invasive, and potentially risky by invoking the layer removal code in previously-unreachable situations.

Marking as draft because it’s completely untested so far.