### PR TITLE
image, layers, container: append new names to the ones which were written before and `dedupe`

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -378,11 +378,11 @@ func (r *containerStore) removeName(container *Container, name string) {
 }
 
 func (r *containerStore) SetNames(id string, names []string) error {
-	names = dedupeNames(names)
 	if container, ok := r.lookup(id); ok {
 		for _, name := range container.Names {
-			delete(r.byname, name)
+			names = append(names, name)
 		}
+		names = dedupeNames(names)
 		for _, name := range names {
 			if otherContainer, ok := r.byname[name]; ok {
 				r.removeName(otherContainer, name)

--- a/images.go
+++ b/images.go
@@ -509,11 +509,11 @@ func (r *imageStore) SetNames(id string, names []string) error {
 	if !r.IsReadWrite() {
 		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to change image name assignments at %q", r.imagespath())
 	}
-	names = dedupeNames(names)
 	if image, ok := r.lookup(id); ok {
 		for _, name := range image.Names {
-			delete(r.byname, name)
+			names = append(names, name)
 		}
+		names = dedupeNames(names)
 		for _, name := range names {
 			if otherImage, ok := r.byname[name]; ok {
 				r.removeName(otherImage, name)

--- a/layers.go
+++ b/layers.go
@@ -1043,11 +1043,11 @@ func (r *layerStore) SetNames(id string, names []string) error {
 	if !r.IsReadWrite() {
 		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to change layer name assignments at %q", r.layerspath())
 	}
-	names = dedupeNames(names)
 	if layer, ok := r.lookup(id); ok {
 		for _, name := range layer.Names {
-			delete(r.byname, name)
+			names = append(names, name)
 		}
+		names = dedupeNames(names)
 		for _, name := range names {
 			if otherLayer, ok := r.byname[name]; ok {
 				r.removeName(otherLayer, name)


### PR DESCRIPTION
We are deleting names which were already written in store.

This creates faulty behavior when builds are invoked in parallel manner, as
this removes names for other builds.

To fix this behavior we must append to already written names and
override if needed.

Following patch fixes concurrent builds via podman or buildah.

See: https://github.com/containers/buildah/pull/3794 for more details.