### PR TITLE
race, storage:  add independent `AddNames` and `RemoveNames` for images,layers and containers

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -84,7 +84,16 @@ type ContainerStore interface {
 
 	// SetNames updates the list of names associated with the container
 	// with the specified ID.
+	// Deprecated: Prone to race conditions, suggested alternatives are `AddNames` and `RemoveNames`.
 	SetNames(id string, names []string) error
+
+	// AddNames adds the supplied values to the list of names associated with the container with
+	// the specified id.
+	AddNames(id string, names []string) error
+
+	// RemoveNames removes the supplied values from the list of names associated with the container with
+	// the specified id.
+	RemoveNames(id string, names []string) error
 
 	// Get retrieves information about a container given an ID or name.
 	Get(id string) (*Container, error)
@@ -377,22 +386,40 @@ func (r *containerStore) removeName(container *Container, name string) {
 	container.Names = stringSliceWithoutValue(container.Names, name)
 }
 
+// Deprecated: Prone to race conditions, suggested alternatives are `AddNames` and `RemoveNames`.
 func (r *containerStore) SetNames(id string, names []string) error {
-	names = dedupeNames(names)
-	if container, ok := r.lookup(id); ok {
-		for _, name := range container.Names {
-			delete(r.byname, name)
-		}
-		for _, name := range names {
-			if otherContainer, ok := r.byname[name]; ok {
-				r.removeName(otherContainer, name)
-			}
-			r.byname[name] = container
-		}
-		container.Names = names
-		return r.Save()
+	return r.updateNames(id, names, setNames)
+}
+
+func (r *containerStore) AddNames(id string, names []string) error {
+	return r.updateNames(id, names, addNames)
+}
+
+func (r *containerStore) RemoveNames(id string, names []string) error {
+	return r.updateNames(id, names, removeNames)
+}
+
+func (r *containerStore) updateNames(id string, names []string, op updateNameOperation) error {
+	container, ok := r.lookup(id)
+	if !ok {
+		return ErrContainerUnknown
 	}
-	return ErrContainerUnknown
+	oldNames := container.Names
+	names, err := applyNameOperation(oldNames, names, op)
+	if err != nil {
+		return err
+	}
+	for _, name := range oldNames {
+		delete(r.byname, name)
+	}
+	for _, name := range names {
+		if otherContainer, ok := r.byname[name]; ok {
+			r.removeName(otherContainer, name)
+		}
+		r.byname[name] = container
+	}
+	container.Names = names
+	return r.Save()
 }
 
 func (r *containerStore) Delete(id string) error {

--- a/errors.go
+++ b/errors.go
@@ -1,6 +1,8 @@
 package storage
 
 import (
+	"errors"
+
 	"github.com/containers/storage/types"
 )
 
@@ -57,4 +59,7 @@ var (
 	ErrNotSupported = types.ErrNotSupported
 	// ErrInvalidMappings is returned when the specified mappings are invalid.
 	ErrInvalidMappings = types.ErrInvalidMappings
+	// ErrInvalidNameOperation is returned when updateName is called with invalid operation.
+	// Internal error
+	errInvalidUpdateNameOperation = errors.New("invalid update name operation")
 )

--- a/images.go
+++ b/images.go
@@ -136,7 +136,18 @@ type ImageStore interface {
 	// SetNames replaces the list of names associated with an image with the
 	// supplied values.  The values are expected to be valid normalized
 	// named image references.
+	// Deprecated: Prone to race conditions, suggested alternatives are `AddNames` and `RemoveNames`.
 	SetNames(id string, names []string) error
+
+	// AddNames adds the supplied values to the list of names associated with the image with
+	// the specified id. The values are expected to be valid normalized
+	// named image references.
+	AddNames(id string, names []string) error
+
+	// RemoveNames removes the supplied values from the list of names associated with the image with
+	// the specified id.  The values are expected to be valid normalized
+	// named image references.
+	RemoveNames(id string, names []string) error
 
 	// Delete removes the record of the image.
 	Delete(id string) error
@@ -505,26 +516,44 @@ func (i *Image) addNameToHistory(name string) {
 	i.NamesHistory = dedupeNames(append([]string{name}, i.NamesHistory...))
 }
 
+// Deprecated: Prone to race conditions, suggested alternatives are `AddNames` and `RemoveNames`.
 func (r *imageStore) SetNames(id string, names []string) error {
+	return r.updateNames(id, names, setNames)
+}
+
+func (r *imageStore) AddNames(id string, names []string) error {
+	return r.updateNames(id, names, addNames)
+}
+
+func (r *imageStore) RemoveNames(id string, names []string) error {
+	return r.updateNames(id, names, removeNames)
+}
+
+func (r *imageStore) updateNames(id string, names []string, op updateNameOperation) error {
 	if !r.IsReadWrite() {
 		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to change image name assignments at %q", r.imagespath())
 	}
-	names = dedupeNames(names)
-	if image, ok := r.lookup(id); ok {
-		for _, name := range image.Names {
-			delete(r.byname, name)
-		}
-		for _, name := range names {
-			if otherImage, ok := r.byname[name]; ok {
-				r.removeName(otherImage, name)
-			}
-			r.byname[name] = image
-			image.addNameToHistory(name)
-		}
-		image.Names = names
-		return r.Save()
+	image, ok := r.lookup(id)
+	if !ok {
+		return errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
 	}
-	return errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
+	oldNames := image.Names
+	names, err := applyNameOperation(oldNames, names, op)
+	if err != nil {
+		return err
+	}
+	for _, name := range oldNames {
+		delete(r.byname, name)
+	}
+	for _, name := range names {
+		if otherImage, ok := r.byname[name]; ok {
+			r.removeName(otherImage, name)
+		}
+		r.byname[name] = image
+		image.addNameToHistory(name)
+	}
+	image.Names = names
+	return r.Save()
 }
 
 func (r *imageStore) Delete(id string) error {

--- a/images_test.go
+++ b/images_test.go
@@ -91,4 +91,16 @@ func TestHistoryNames(t *testing.T) {
 	require.Len(t, secondImage.NamesHistory, 2)
 	require.Equal(t, secondImage.NamesHistory[0], "3")
 	require.Equal(t, secondImage.NamesHistory[1], "2")
+
+	// test independent add and remove operations
+	require.Nil(t, store.AddNames(firstImageID, []string{"5"}))
+	firstImage, err = store.Get(firstImageID)
+	require.Nil(t, err)
+	require.Equal(t, firstImage.NamesHistory, []string{"4", "3", "2", "1", "5"})
+
+	// history should still contain old values
+	require.Nil(t, store.RemoveNames(firstImageID, []string{"5"}))
+	firstImage, err = store.Get(firstImageID)
+	require.Nil(t, err)
+	require.Equal(t, firstImage.NamesHistory, []string{"4", "3", "2", "1", "5"})
 }

--- a/layers.go
+++ b/layers.go
@@ -221,7 +221,16 @@ type LayerStore interface {
 
 	// SetNames replaces the list of names associated with a layer with the
 	// supplied values.
+	// Deprecated: Prone to race conditions, suggested alternatives are `AddNames` and `RemoveNames`.
 	SetNames(id string, names []string) error
+
+	// AddNames adds the supplied values to the list of names associated with the layer with the
+	// specified id.
+	AddNames(id string, names []string) error
+
+	// RemoveNames remove the supplied values from the list of names associated with the layer with the
+	// specified id.
+	RemoveNames(id string, names []string) error
 
 	// Delete deletes a layer with the specified name or ID.
 	Delete(id string) error
@@ -1040,25 +1049,43 @@ func (r *layerStore) removeName(layer *Layer, name string) {
 	layer.Names = stringSliceWithoutValue(layer.Names, name)
 }
 
+// Deprecated: Prone to race conditions, suggested alternatives are `AddNames` and `RemoveNames`.
 func (r *layerStore) SetNames(id string, names []string) error {
+	return r.updateNames(id, names, setNames)
+}
+
+func (r *layerStore) AddNames(id string, names []string) error {
+	return r.updateNames(id, names, addNames)
+}
+
+func (r *layerStore) RemoveNames(id string, names []string) error {
+	return r.updateNames(id, names, removeNames)
+}
+
+func (r *layerStore) updateNames(id string, names []string, op updateNameOperation) error {
 	if !r.IsReadWrite() {
 		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to change layer name assignments at %q", r.layerspath())
 	}
-	names = dedupeNames(names)
-	if layer, ok := r.lookup(id); ok {
-		for _, name := range layer.Names {
-			delete(r.byname, name)
-		}
-		for _, name := range names {
-			if otherLayer, ok := r.byname[name]; ok {
-				r.removeName(otherLayer, name)
-			}
-			r.byname[name] = layer
-		}
-		layer.Names = names
-		return r.Save()
+	layer, ok := r.lookup(id)
+	if !ok {
+		return ErrLayerUnknown
 	}
-	return ErrLayerUnknown
+	oldNames := layer.Names
+	names, err := applyNameOperation(oldNames, names, op)
+	if err != nil {
+		return err
+	}
+	for _, name := range oldNames {
+		delete(r.byname, name)
+	}
+	for _, name := range names {
+		if otherLayer, ok := r.byname[name]; ok {
+			r.removeName(otherLayer, name)
+		}
+		r.byname[name] = layer
+	}
+	layer.Names = names
+	return r.Save()
 }
 
 func (r *layerStore) datadir(id string) string {

--- a/store.go
+++ b/store.go
@@ -31,6 +31,14 @@ import (
 	"github.com/pkg/errors"
 )
 
+type updateNameOperation int
+
+const (
+	setNames updateNameOperation = iota
+	addNames
+	removeNames
+)
+
 var (
 	stores     []*store
 	storesLock sync.Mutex
@@ -368,7 +376,16 @@ type Store interface {
 
 	// SetNames changes the list of names for a layer, image, or container.
 	// Duplicate names are removed from the list automatically.
+	// Deprecated: Prone to race conditions, suggested alternatives are `AddNames` and `RemoveNames`.
 	SetNames(id string, names []string) error
+
+	// AddNames adds the list of names for a layer, image, or container.
+	// Duplicate names are removed from the list automatically.
+	AddNames(id string, names []string) error
+
+	// RemoveNames removes the list of names for a layer, image, or container.
+	// Duplicate names are removed from the list automatically.
+	RemoveNames(id string, names []string) error
 
 	// ListImageBigData retrieves a list of the (possibly large) chunks of
 	// named data associated with an image.
@@ -2050,7 +2067,20 @@ func dedupeNames(names []string) []string {
 	return deduped
 }
 
+// Deprecated: Prone to race conditions, suggested alternatives are `AddNames` and `RemoveNames`.
 func (s *store) SetNames(id string, names []string) error {
+	return s.updateNames(id, names, setNames)
+}
+
+func (s *store) AddNames(id string, names []string) error {
+	return s.updateNames(id, names, addNames)
+}
+
+func (s *store) RemoveNames(id string, names []string) error {
+	return s.updateNames(id, names, removeNames)
+}
+
+func (s *store) updateNames(id string, names []string, op updateNameOperation) error {
 	deduped := dedupeNames(names)
 
 	rlstore, err := s.LayerStore()
@@ -2063,7 +2093,16 @@ func (s *store) SetNames(id string, names []string) error {
 		return err
 	}
 	if rlstore.Exists(id) {
-		return rlstore.SetNames(id, deduped)
+		switch op {
+		case setNames:
+			return rlstore.SetNames(id, deduped)
+		case removeNames:
+			return rlstore.RemoveNames(id, deduped)
+		case addNames:
+			return rlstore.AddNames(id, deduped)
+		default:
+			return errInvalidUpdateNameOperation
+		}
 	}
 
 	ristore, err := s.ImageStore()
@@ -2076,7 +2115,16 @@ func (s *store) SetNames(id string, names []string) error {
 		return err
 	}
 	if ristore.Exists(id) {
-		return ristore.SetNames(id, deduped)
+		switch op {
+		case setNames:
+			return ristore.SetNames(id, deduped)
+		case removeNames:
+			return ristore.RemoveNames(id, deduped)
+		case addNames:
+			return ristore.AddNames(id, deduped)
+		default:
+			return errInvalidUpdateNameOperation
+		}
 	}
 
 	// Check is id refers to a RO Store
@@ -2114,7 +2162,16 @@ func (s *store) SetNames(id string, names []string) error {
 		return err
 	}
 	if rcstore.Exists(id) {
-		return rcstore.SetNames(id, deduped)
+		switch op {
+		case setNames:
+			return rcstore.SetNames(id, deduped)
+		case removeNames:
+			return rcstore.RemoveNames(id, deduped)
+		case addNames:
+			return rcstore.AddNames(id, deduped)
+		default:
+			return errInvalidUpdateNameOperation
+		}
 	}
 	return ErrLayerUnknown
 }

--- a/utils.go
+++ b/utils.go
@@ -40,3 +40,35 @@ func validateMountOptions(mountOptions []string) error {
 	}
 	return nil
 }
+
+func applyNameOperation(oldNames []string, opParameters []string, op updateNameOperation) ([]string, error) {
+	result := make([]string, 0)
+	switch op {
+	case setNames:
+		// ignore all old names and just return new names
+		return dedupeNames(opParameters), nil
+	case removeNames:
+		// remove given names from old names
+		for _, name := range oldNames {
+			// only keep names in final result which do not intersect with input names
+			// basically `result = oldNames - opParameters`
+			nameShouldBeRemoved := false
+			for _, opName := range opParameters {
+				if name == opName {
+					nameShouldBeRemoved = true
+				}
+			}
+			if !nameShouldBeRemoved {
+				result = append(result, name)
+			}
+		}
+		return dedupeNames(result), nil
+	case addNames:
+		result = append(result, opParameters...)
+		result = append(result, oldNames...)
+		return dedupeNames(result), nil
+	default:
+		return result, errInvalidUpdateNameOperation
+	}
+	return dedupeNames(result), nil
+}


### PR DESCRIPTION
Adds `SetNameWithOptions` so operations which are invoke in parallel
manner can use it without destroying names from storage.

For instance

We are deleting names which were already written in store.
This creates faulty behavior when builds are invoked in parallel manner, as
this removes names for other builds.

To fix this behavior we must append to already written names and
override if needed. But this should be optional and not break public API

Following patch will be used by parallel operations at podman or buildah end, directly or indirectly.

PR replaces: https://github.com/containers/storage/pull/1152