### PR TITLE
overlay: mountFrom read-only mounts using relative paths

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -1530,7 +1530,7 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 			diffDir := path.Join(id, "diff")
 			opts = fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", strings.Join(relLowers, ":"), diffDir, workdir)
 		} else {
-			opts = fmt.Sprintf("lowerdir=%s", strings.Join(absLowers, ":"))
+			opts = fmt.Sprintf("lowerdir=%s", strings.Join(relLowers, ":"))
 		}
 		if len(optsList) > 0 {
 			opts = fmt.Sprintf("%s,%s", opts, strings.Join(optsList, ","))


### PR DESCRIPTION
When we need to shell out to a helper binary to be able to pass relative locations for directories listed in the mount options, whether or not the mount is meant to be writable isn't a factor.