### PR TITLE
ExecRunnable: prevent logging on stderr when its not expected

### DIFF
--- a/pkg/unshare/unshare_linux.go
+++ b/pkg/unshare/unshare_linux.go
@@ -501,11 +501,11 @@ func ExecRunnable(cmd Runnable, cleanup func()) {
 			if exitError.ProcessState.Exited() {
 				if waitStatus, ok := exitError.ProcessState.Sys().(syscall.WaitStatus); ok {
 					if waitStatus.Exited() {
-						logrus.Errorf("%v", exitError)
+						logrus.Debugf("%v", exitError)
 						exit(waitStatus.ExitStatus())
 					}
 					if waitStatus.Signaled() {
-						logrus.Errorf("%v", exitError)
+						logrus.Debugf("%v", exitError)
 						exit(int(waitStatus.Signal()) + 128)
 					}
 				}


### PR DESCRIPTION
ExecRunnable is invoked by buildah and error from c/storage is logged to
stdout. This creates a drift between the between the behavior which is
generated by rootless and rootful buildah.

This corrects the behavior for rootless buildah so it has parity with
buildah invoked for root user.

This helps in issue being discussed here: https://github.com/containers/buildah/pull/3804#discussion_r820904895