### PR TITLE
MaybeReexecUsingUserNamespace: handle SIGHUP/SIGINT/SIGTERM

### DIFF
--- a/pkg/unshare/unshare_linux.go
+++ b/pkg/unshare/unshare_linux.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"os"
 	"os/exec"
+	"os/signal"
 	"os/user"
 	"runtime"
 	"strconv"
@@ -484,6 +485,30 @@ func MaybeReexecUsingUserNamespace(evenForRoot bool) {
 
 	// Finish up.
 	logrus.Debugf("Running %+v with environment %+v, UID map %+v, and GID map %+v", cmd.Cmd.Args, os.Environ(), cmd.UidMappings, cmd.GidMappings)
+
+	// Forward SIGHUP, SIGINT, and SIGTERM to our child process.
+	interrupted := make(chan os.Signal, 100)
+	defer func() {
+		signal.Stop(interrupted)
+		close(interrupted)
+	}()
+	cmd.Hook = func(int) error {
+		go func() {
+			for receivedSignal := range interrupted {
+				cmd.Cmd.Process.Signal(receivedSignal)
+			}
+		}()
+		return nil
+	}
+	signal.Notify(interrupted, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM)
+
+	// Make sure our child process gets SIGKILLed if we exit, for whatever
+	// reason, before it does.
+	if cmd.Cmd.SysProcAttr == nil {
+		cmd.Cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.Cmd.SysProcAttr.Pdeathsig = syscall.SIGKILL
+
 	ExecRunnable(cmd, nil)
 }
 


### PR DESCRIPTION
Pass along SIGHUP, SIGINT, and SIGTERM if the parent receives them while the child process is running.  Set SIGKILL as the child's parent-death signal so that, if we exit for some reason before the child does, it will be stopped.  This addresses part of https://github.com/containers/buildah/issues/3544.