### PR TITLE
idtools: don't say ToHost() makes exceptions in its godoc when it doesn't

### DIFF
--- a/pkg/idtools/idtools.go
+++ b/pkg/idtools/idtools.go
@@ -190,7 +190,6 @@ func (i *IDMappings) RootPair() IDPair {
 }
 
 // ToHost returns the host UID and GID for the container uid, gid.
-// Remapping is only performed if the ids aren't already the remapped root ids
 func (i *IDMappings) ToHost(pair IDPair) (IDPair, error) {
 	var err error
 	var target IDPair


### PR DESCRIPTION
The godoc for pkg/idtools.ToHost() mentions that it makes an exception when either of the IDs to be mapped is 0, but that special case was removed in #1057.
