### PR TITLE
fix storage-chown-by-maps doesnt handle -EOVERFLOW on lgetxattr [Closes #1183]

### DIFF
--- a/drivers/chown_unix.go
+++ b/drivers/chown_unix.go
@@ -84,7 +84,7 @@ func (c *platformChowner) LChown(path string, info os.FileInfo, toHost, toContai
 	}
 	if uid != int(st.Uid) || gid != int(st.Gid) {
 		cap, err := system.Lgetxattr(path, "security.capability")
-		if err != nil && !errors.Is(err, system.EOPNOTSUPP) && err != system.ErrNotSupportedPlatform {
+		if err != nil && !errors.Is(err, system.EOPNOTSUPP) && !errors.Is(err, system.EOVERFLOW) && err != system.ErrNotSupportedPlatform {
 			return fmt.Errorf("%s: %v", os.Args[0], err)
 		}
 

--- a/pkg/system/xattrs_linux.go
+++ b/pkg/system/xattrs_linux.go
@@ -13,6 +13,9 @@ const (
 
 	// Operation not supported
 	EOPNOTSUPP unix.Errno = unix.EOPNOTSUPP
+
+	// Value is too small or too large for maximum size allowed
+	EOVERFLOW unix.Errno = unix.EOVERFLOW
 )
 
 // Lgetxattr retrieves the value of the extended attribute identified by attr

--- a/pkg/system/xattrs_unsupported.go
+++ b/pkg/system/xattrs_unsupported.go
@@ -10,6 +10,9 @@ const (
 
 	// Operation not supported
 	EOPNOTSUPP syscall.Errno = syscall.Errno(0)
+
+	// Value is too small or too large for maximum size allowed
+	EOVERFLOW syscall.Errno = syscall.Errno(0)
 )
 
 // Lgetxattr is not supported on platforms other than linux.


### PR DESCRIPTION
Signed-off-by: Robert Zaage <robert@zaage.it>