### PR TITLE
Revert "[backport v1.24] Lock during store diff and add race-free `AddNames` and `RemoveNames` api."

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -85,16 +85,7 @@ type ContainerStore interface {
 
 	// SetNames updates the list of names associated with the container
 	// with the specified ID.
-	// Deprecated: Prone to race conditions, suggested alternatives are `AddNames` and `RemoveNames`.
 	SetNames(id string, names []string) error
-
-	// AddNames adds the supplied values to the list of names associated with the container with
-	// the specified id.
-	AddNames(id string, names []string) error
-
-	// RemoveNames removes the supplied values from the list of names associated with the container with
-	// the specified id.
-	RemoveNames(id string, names []string) error
 
 	// Get retrieves information about a container given an ID or name.
 	Get(id string) (*Container, error)
@@ -378,40 +369,22 @@ func (r *containerStore) removeName(container *Container, name string) {
 	container.Names = stringSliceWithoutValue(container.Names, name)
 }
 
-// Deprecated: Prone to race conditions, suggested alternatives are `AddNames` and `RemoveNames`.
 func (r *containerStore) SetNames(id string, names []string) error {
-	return r.updateNames(id, names, setNames)
-}
-
-func (r *containerStore) AddNames(id string, names []string) error {
-	return r.updateNames(id, names, addNames)
-}
-
-func (r *containerStore) RemoveNames(id string, names []string) error {
-	return r.updateNames(id, names, removeNames)
-}
-
-func (r *containerStore) updateNames(id string, names []string, op updateNameOperation) error {
-	container, ok := r.lookup(id)
-	if !ok {
-		return ErrContainerUnknown
-	}
-	oldNames := container.Names
-	names, err := applyNameOperation(oldNames, names, op)
-	if err != nil {
-		return err
-	}
-	for _, name := range oldNames {
-		delete(r.byname, name)
-	}
-	for _, name := range names {
-		if otherContainer, ok := r.byname[name]; ok {
-			r.removeName(otherContainer, name)
+	names = dedupeNames(names)
+	if container, ok := r.lookup(id); ok {
+		for _, name := range container.Names {
+			delete(r.byname, name)
 		}
-		r.byname[name] = container
+		for _, name := range names {
+			if otherContainer, ok := r.byname[name]; ok {
+				r.removeName(otherContainer, name)
+			}
+			r.byname[name] = container
+		}
+		container.Names = names
+		return r.Save()
 	}
-	container.Names = names
-	return r.Save()
+	return ErrContainerUnknown
 }
 
 func (r *containerStore) Delete(id string) error {

--- a/errors.go
+++ b/errors.go
@@ -53,9 +53,4 @@ var (
 	ErrDigestUnknown = errors.New("could not compute digest of item")
 	// ErrLayerNotMounted is returned when the requested information can only be computed for a mounted layer, and the layer is not mounted.
 	ErrLayerNotMounted = errors.New("layer is not mounted")
-	// ErrNotSupported is returned when the requested functionality is not supported.
-	ErrNotSupported = errors.New("not supported")
-	// ErrInvalidNameOperation is returned when updateName is called with invalid operation.
-	// Internal error
-	errInvalidUpdateNameOperation = errors.New("invalid update name operation")
 )

--- a/images.go
+++ b/images.go
@@ -137,18 +137,7 @@ type ImageStore interface {
 	// SetNames replaces the list of names associated with an image with the
 	// supplied values.  The values are expected to be valid normalized
 	// named image references.
-	// Deprecated: Prone to race conditions, suggested alternatives are `AddNames` and `RemoveNames`.
 	SetNames(id string, names []string) error
-
-	// AddNames adds the supplied values to the list of names associated with the image with
-	// the specified id. The values are expected to be valid normalized
-	// named image references.
-	AddNames(id string, names []string) error
-
-	// RemoveNames removes the supplied values from the list of names associated with the image with
-	// the specified id.  The values are expected to be valid normalized
-	// named image references.
-	RemoveNames(id string, names []string) error
 
 	// Delete removes the record of the image.
 	Delete(id string) error
@@ -518,44 +507,26 @@ func (i *Image) addNameToHistory(name string) {
 	i.NamesHistory = dedupeNames(append([]string{name}, i.NamesHistory...))
 }
 
-// Deprecated: Prone to race conditions, suggested alternatives are `AddNames` and `RemoveNames`.
 func (r *imageStore) SetNames(id string, names []string) error {
-	return r.updateNames(id, names, setNames)
-}
-
-func (r *imageStore) AddNames(id string, names []string) error {
-	return r.updateNames(id, names, addNames)
-}
-
-func (r *imageStore) RemoveNames(id string, names []string) error {
-	return r.updateNames(id, names, removeNames)
-}
-
-func (r *imageStore) updateNames(id string, names []string, op updateNameOperation) error {
 	if !r.IsReadWrite() {
 		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to change image name assignments at %q", r.imagespath())
 	}
-	image, ok := r.lookup(id)
-	if !ok {
-		return errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
-	}
-	oldNames := image.Names
-	names, err := applyNameOperation(oldNames, names, op)
-	if err != nil {
-		return err
-	}
-	for _, name := range oldNames {
-		delete(r.byname, name)
-	}
-	for _, name := range names {
-		if otherImage, ok := r.byname[name]; ok {
-			r.removeName(otherImage, name)
+	names = dedupeNames(names)
+	if image, ok := r.lookup(id); ok {
+		for _, name := range image.Names {
+			delete(r.byname, name)
 		}
-		r.byname[name] = image
-		image.addNameToHistory(name)
+		for _, name := range names {
+			if otherImage, ok := r.byname[name]; ok {
+				r.removeName(otherImage, name)
+			}
+			r.byname[name] = image
+			image.addNameToHistory(name)
+		}
+		image.Names = names
+		return r.Save()
 	}
-	image.Names = names
-	return r.Save()
+	return errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
 }
 
 func (r *imageStore) Delete(id string) error {

--- a/images_test.go
+++ b/images_test.go
@@ -91,16 +91,4 @@ func TestHistoryNames(t *testing.T) {
 	require.Len(t, secondImage.NamesHistory, 2)
 	require.Equal(t, secondImage.NamesHistory[0], "3")
 	require.Equal(t, secondImage.NamesHistory[1], "2")
-
-	// test independent add and remove operations
-	require.Nil(t, store.AddNames(firstImageID, []string{"5"}))
-	firstImage, err = store.Get(firstImageID)
-	require.Nil(t, err)
-	require.Equal(t, firstImage.NamesHistory, []string{"4", "3", "2", "1", "5"})
-
-	// history should still contain old values
-	require.Nil(t, store.RemoveNames(firstImageID, []string{"5"}))
-	firstImage, err = store.Get(firstImageID)
-	require.Nil(t, err)
-	require.Equal(t, firstImage.NamesHistory, []string{"4", "3", "2", "1", "5"})
 }

--- a/layers.go
+++ b/layers.go
@@ -214,16 +214,7 @@ type LayerStore interface {
 
 	// SetNames replaces the list of names associated with a layer with the
 	// supplied values.
-	// Deprecated: Prone to race conditions, suggested alternatives are `AddNames` and `RemoveNames`.
 	SetNames(id string, names []string) error
-
-	// AddNames adds the supplied values to the list of names associated with the layer with the
-	// specified id.
-	AddNames(id string, names []string) error
-
-	// RemoveNames remove the supplied values from the list of names associated with the layer with the
-	// specified id.
-	RemoveNames(id string, names []string) error
 
 	// Delete deletes a layer with the specified name or ID.
 	Delete(id string) error
@@ -961,43 +952,25 @@ func (r *layerStore) removeName(layer *Layer, name string) {
 	layer.Names = stringSliceWithoutValue(layer.Names, name)
 }
 
-// Deprecated: Prone to race conditions, suggested alternatives are `AddNames` and `RemoveNames`.
 func (r *layerStore) SetNames(id string, names []string) error {
-	return r.updateNames(id, names, setNames)
-}
-
-func (r *layerStore) AddNames(id string, names []string) error {
-	return r.updateNames(id, names, addNames)
-}
-
-func (r *layerStore) RemoveNames(id string, names []string) error {
-	return r.updateNames(id, names, removeNames)
-}
-
-func (r *layerStore) updateNames(id string, names []string, op updateNameOperation) error {
 	if !r.IsReadWrite() {
 		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to change layer name assignments at %q", r.layerspath())
 	}
-	layer, ok := r.lookup(id)
-	if !ok {
-		return ErrLayerUnknown
-	}
-	oldNames := layer.Names
-	names, err := applyNameOperation(oldNames, names, op)
-	if err != nil {
-		return err
-	}
-	for _, name := range oldNames {
-		delete(r.byname, name)
-	}
-	for _, name := range names {
-		if otherLayer, ok := r.byname[name]; ok {
-			r.removeName(otherLayer, name)
+	names = dedupeNames(names)
+	if layer, ok := r.lookup(id); ok {
+		for _, name := range layer.Names {
+			delete(r.byname, name)
 		}
-		r.byname[name] = layer
+		for _, name := range names {
+			if otherLayer, ok := r.byname[name]; ok {
+				r.removeName(otherLayer, name)
+			}
+			r.byname[name] = layer
+		}
+		layer.Names = names
+		return r.Save()
 	}
-	layer.Names = names
-	return r.Save()
+	return ErrLayerUnknown
 }
 
 func (r *layerStore) Metadata(id string) (string, error) {

--- a/store.go
+++ b/store.go
@@ -33,14 +33,6 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-type updateNameOperation int
-
-const (
-	setNames updateNameOperation = iota
-	addNames
-	removeNames
-)
-
 var (
 	// DefaultStoreOptions is a reasonable default set of options.
 	defaultStoreOptions StoreOptions
@@ -372,16 +364,7 @@ type Store interface {
 
 	// SetNames changes the list of names for a layer, image, or container.
 	// Duplicate names are removed from the list automatically.
-	// Deprecated: Prone to race conditions, suggested alternatives are `AddNames` and `RemoveNames`.
 	SetNames(id string, names []string) error
-
-	// AddNames adds the list of names for a layer, image, or container.
-	// Duplicate names are removed from the list automatically.
-	AddNames(id string, names []string) error
-
-	// RemoveNames removes the list of names for a layer, image, or container.
-	// Duplicate names are removed from the list automatically.
-	RemoveNames(id string, names []string) error
 
 	// ListImageBigData retrieves a list of the (possibly large) chunks of
 	// named data associated with an image.
@@ -1958,20 +1941,7 @@ func dedupeNames(names []string) []string {
 	return deduped
 }
 
-// Deprecated: Prone to race conditions, suggested alternatives are `AddNames` and `RemoveNames`.
 func (s *store) SetNames(id string, names []string) error {
-	return s.updateNames(id, names, setNames)
-}
-
-func (s *store) AddNames(id string, names []string) error {
-	return s.updateNames(id, names, addNames)
-}
-
-func (s *store) RemoveNames(id string, names []string) error {
-	return s.updateNames(id, names, removeNames)
-}
-
-func (s *store) updateNames(id string, names []string, op updateNameOperation) error {
 	deduped := dedupeNames(names)
 
 	rlstore, err := s.LayerStore()
@@ -1984,16 +1954,7 @@ func (s *store) updateNames(id string, names []string, op updateNameOperation) e
 		return err
 	}
 	if rlstore.Exists(id) {
-		switch op {
-		case setNames:
-			return rlstore.SetNames(id, deduped)
-		case removeNames:
-			return rlstore.RemoveNames(id, deduped)
-		case addNames:
-			return rlstore.AddNames(id, deduped)
-		default:
-			return errInvalidUpdateNameOperation
-		}
+		return rlstore.SetNames(id, deduped)
 	}
 
 	ristore, err := s.ImageStore()
@@ -2006,16 +1967,7 @@ func (s *store) updateNames(id string, names []string, op updateNameOperation) e
 		return err
 	}
 	if ristore.Exists(id) {
-		switch op {
-		case setNames:
-			return ristore.SetNames(id, deduped)
-		case removeNames:
-			return ristore.RemoveNames(id, deduped)
-		case addNames:
-			return ristore.AddNames(id, deduped)
-		default:
-			return errInvalidUpdateNameOperation
-		}
+		return ristore.SetNames(id, deduped)
 	}
 
 	rcstore, err := s.ContainerStore()
@@ -2028,16 +1980,7 @@ func (s *store) updateNames(id string, names []string, op updateNameOperation) e
 		return err
 	}
 	if rcstore.Exists(id) {
-		switch op {
-		case setNames:
-			return rcstore.SetNames(id, deduped)
-		case removeNames:
-			return rcstore.RemoveNames(id, deduped)
-		case addNames:
-			return rcstore.AddNames(id, deduped)
-		default:
-			return errInvalidUpdateNameOperation
-		}
+		return rcstore.SetNames(id, deduped)
 	}
 	return ErrLayerUnknown
 }
@@ -2736,33 +2679,10 @@ func (s *store) Diff(from, to string, options *DiffOptions) (io.ReadCloser, erro
 	if err != nil {
 		return nil, err
 	}
-
-	// NaiveDiff could cause mounts to happen without a lock, so be safe
-	// and treat the .Diff operation as a Mount.
-	s.graphLock.Lock()
-	defer s.graphLock.Unlock()
-
-	modified, err := s.graphLock.Modified()
-	if err != nil {
-		return nil, err
-	}
-
-	// We need to make sure the home mount is present when the Mount is done.
-	if modified {
-		s.graphDriver = nil
-		s.layerStore = nil
-		s.graphDriver, err = s.getGraphDriver()
-		if err != nil {
-			return nil, err
-		}
-		s.lastLoaded = time.Now()
-	}
-
 	for _, s := range append([]ROLayerStore{lstore}, lstores...) {
 		store := s
 		store.RLock()
 		if err := store.ReloadIfChanged(); err != nil {
-			store.Unlock()
 			return nil, err
 		}
 		if store.Exists(to) {

--- a/utils.go
+++ b/utils.go
@@ -337,35 +337,3 @@ func validateMountOptions(mountOptions []string) error {
 	}
 	return nil
 }
-
-func applyNameOperation(oldNames []string, opParameters []string, op updateNameOperation) ([]string, error) {
-	result := make([]string, 0)
-	switch op {
-	case setNames:
-		// ignore all old names and just return new names
-		return dedupeNames(opParameters), nil
-	case removeNames:
-		// remove given names from old names
-		for _, name := range oldNames {
-			// only keep names in final result which do not intersect with input names
-			// basically `result = oldNames - opParameters`
-			nameShouldBeRemoved := false
-			for _, opName := range opParameters {
-				if name == opName {
-					nameShouldBeRemoved = true
-				}
-			}
-			if !nameShouldBeRemoved {
-				result = append(result, name)
-			}
-		}
-		return dedupeNames(result), nil
-	case addNames:
-		result = append(result, opParameters...)
-		result = append(result, oldNames...)
-		return dedupeNames(result), nil
-	default:
-		return result, errInvalidUpdateNameOperation
-	}
-	return dedupeNames(result), nil
-}


### PR DESCRIPTION
Reverts containers/storage#1191

Backport was re-evaluated only for `release-1.23` buildah branch and backport for `release-1.19` buildah is no longer under consideration. So we must revert this. 