### PR TITLE
pkg/archive/overlayWhiteoutConverter.ConvertWrite(): force mode to 0

### DIFF
--- a/pkg/archive/archive_linux.go
+++ b/pkg/archive/archive_linux.go
@@ -36,7 +36,7 @@ func (o overlayWhiteoutConverter) ConvertWrite(hdr *tar.Header, path string, fi 
 		// we just rename the file and make it normal
 		dir, filename := filepath.Split(hdr.Name)
 		hdr.Name = filepath.Join(dir, WhiteoutPrefix+filename)
-		hdr.Mode = 0600
+		hdr.Mode = 0
 		hdr.Typeflag = tar.TypeReg
 		hdr.Size = 0
 	}

--- a/pkg/archive/archive_linux_test.go
+++ b/pkg/archive/archive_linux_test.go
@@ -22,7 +22,7 @@ import (
 // ├── d2     # opaque, 0750
 // │   └── f1 # empty file, 0660
 // └── d3     # 0700
-//     └── f1 # whiteout, 0644
+//     └── f1 # whiteout, 0000
 func setupOverlayTestDir(t *testing.T, src string) {
 	// Create opaque directory containing single file and permission 0700
 	err := os.Mkdir(filepath.Join(src, "d1"), 0700)
@@ -180,7 +180,7 @@ func TestOverlayTarAUFSUntar(t *testing.T) {
 	checkFileMode(t, filepath.Join(dst, "d3"), 0700|os.ModeDir)
 	checkFileMode(t, filepath.Join(dst, "d1", "f1"), 0600)
 	checkFileMode(t, filepath.Join(dst, "d2", "f1"), 0660)
-	checkFileMode(t, filepath.Join(dst, "d3", WhiteoutPrefix+"f1"), 0600)
+	checkFileMode(t, filepath.Join(dst, "d3", WhiteoutPrefix+"f1"), 0)
 }
 
 func TestNestedOverlayWhiteouts(t *testing.T) {


### PR DESCRIPTION
Force the mode for whiteouts that have been converted from overlay format (produced by overlay native diff) to aufs format to 0x0, to match the permissions we assign to whiteouts we create when using naive diff.

Fixes #1195.