### PR TITLE
DeleteImage(): always delete mapped top layers

### DIFF
--- a/store.go
+++ b/store.go
@@ -2452,6 +2452,10 @@ func (s *store) DeleteImage(id string, commit bool) (layers []string, err error)
 		}
 		layer := image.TopLayer
 		layersToRemoveMap := make(map[string]struct{})
+		layersToRemove = append(layersToRemove, image.MappedTopLayers...)
+		for _, mappedTopLayer := range image.MappedTopLayers {
+			layersToRemoveMap[mappedTopLayer] = struct{}{}
+		}
 		for layer != "" {
 			if rcstore.Exists(layer) {
 				break
@@ -2482,12 +2486,6 @@ func (s *store) DeleteImage(id string, commit bool) (layers []string, err error)
 			}
 			if hasChildrenNotBeingRemoved() {
 				break
-			}
-			if layer == image.TopLayer {
-				layersToRemove = append(layersToRemove, image.MappedTopLayers...)
-				for _, mappedTopLayer := range image.MappedTopLayers {
-					layersToRemoveMap[mappedTopLayer] = struct{}{}
-				}
 			}
 			layersToRemove = append(layersToRemove, layer)
 			layersToRemoveMap[layer] = struct{}{}

--- a/tests/idmaps.bats
+++ b/tests/idmaps.bats
@@ -700,11 +700,27 @@ load helpers
 		test $actual = $expected
 	done
 
-	# Remove the containers and image and check that all of the layers we used got removed.
+	# Create a new layer based on the image.
+	run storage --debug=false create-layer --hostuidmap --hostgidmap $lowerlayer
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	upperlayer="$output"
+	run storage --debug=false applydiff -f "$TESTDIR"/layer.empty $upperlayer
+	# Create an image record for the new layer.
+	run storage --debug=false create-image $upperlayer
+	echo "$output"
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	upperimage="$output"
+	echo upperimage:$upperimage
+
+	# Remove the containers and images and check that all of the layers we used got removed.
 	for container in "${containers[@]}" ; do
 		run storage --debug=false delete-container $container
 	done
 	run storage --debug=false delete-image $image
+	run storage --debug=false delete-image $upperimage
 	run storage --debug=false layers
 	echo "$output"
 	[ "$status" -eq 0 ]


### PR DESCRIPTION
When deleting an image, always delete an image's mapped top layers, even ~if~ when the unmapped top layer is shared with other images and must therefore not be deleted.