### PR TITLE
layerStore.Put(): update digest-based indexes when creating from templates

### DIFF
--- a/layers.go
+++ b/layers.go
@@ -866,6 +866,14 @@ func (r *layerStore) Put(id string, parentLayer *Layer, names []string, mountLab
 				return nil, -1, err
 			}
 			delete(layer.Flags, incompleteFlag)
+		} else {
+			// applyDiffWithOptions in the `diff != nil` case handles this bit for us
+			if layer.CompressedDigest != "" {
+				r.bycompressedsum[layer.CompressedDigest] = append(r.bycompressedsum[layer.CompressedDigest], layer.ID)
+			}
+			if layer.UncompressedDigest != "" {
+				r.byuncompressedsum[layer.UncompressedDigest] = append(r.byuncompressedsum[layer.UncompressedDigest], layer.ID)
+			}
 		}
 		err = r.Save()
 		if err != nil {

--- a/layers.go
+++ b/layers.go
@@ -683,7 +683,7 @@ func (r *layerStore) PutAdditionalLayer(id string, parentLayer *Layer, names []s
 		r.bycompressedsum[layer.CompressedDigest] = append(r.bycompressedsum[layer.CompressedDigest], layer.ID)
 	}
 	if layer.UncompressedDigest != "" {
-		r.byuncompressedsum[layer.CompressedDigest] = append(r.byuncompressedsum[layer.CompressedDigest], layer.ID)
+		r.byuncompressedsum[layer.UncompressedDigest] = append(r.byuncompressedsum[layer.UncompressedDigest], layer.ID)
 	}
 	if err := r.Save(); err != nil {
 		r.driver.Remove(id)


### PR DESCRIPTION
When we're creating a layer using another layer as a template, add the new layer's uncompressed and compressed digest to the maps we use to index layers using those digests.

When we forgot to do that, searching for a layer by either would still turn up the original template, so this didn't really break anything.

We also had a case in layerStore.PutAdditionalLayer() where we mistakenly mixed up the uncompressed and compressed digests when populating the by-uncompressed-digest map; fix that while we're in here.