### PR TITLE
FreeBSD fixes for pkg/mount

### DIFF
--- a/drivers/zfs/zfs_freebsd.go
+++ b/drivers/zfs/zfs_freebsd.go
@@ -2,7 +2,6 @@ package zfs
 
 import (
 	"fmt"
-	"strings"
 
 	"github.com/containers/storage/drivers"
 	"github.com/pkg/errors"
@@ -26,19 +25,10 @@ func checkRootdirFs(rootdir string) error {
 }
 
 func getMountpoint(id string) string {
-	maxlen := 12
-
-	// we need to preserve filesystem suffix
-	suffix := strings.SplitN(id, "-", 2)
-
-	if len(suffix) > 1 {
-		return id[:maxlen] + "-" + suffix[1]
-	}
-
-	return id[:maxlen]
+	return id
 }
 
 func detachUnmount(mountpoint string) error {
-	// FreeBSD doesn't have an equivalent to MNT_DETACH
-	return unix.Unmount(mountpoint, 0)
+	// FreeBSD's MNT_FORCE is roughly equivalent to MNT_DETACH
+	return unix.Unmount(mountpoint, unix.MNT_FORCE)
 }

--- a/pkg/mount/flags_freebsd.go
+++ b/pkg/mount/flags_freebsd.go
@@ -27,6 +27,8 @@ const (
 	// NOATIME will not update the file access time when reading from a file.
 	NOATIME = unix.MNT_NOATIME
 
+	mntDetach = unix.MNT_FORCE
+
 	NODIRATIME  = 0
 	NODEV       = 0
 	DIRSYNC     = 0
@@ -43,5 +45,4 @@ const (
 	RSHARED     = 0
 	RELATIME    = 0
 	STRICTATIME = 0
-	mntDetach   = 0
 )

--- a/pkg/mount/mounter_freebsd.go
+++ b/pkg/mount/mounter_freebsd.go
@@ -28,14 +28,25 @@ func allocateIOVecs(options []string) []C.struct_iovec {
 func mount(device, target, mType string, flag uintptr, data string) error {
 	isNullFS := false
 
-	xs := strings.Split(data, ",")
-	for _, x := range xs {
-		if x == "bind" {
-			isNullFS = true
+	options := []string{"fspath", target}
+
+	if data != "" {
+		xs := strings.Split(data, ",")
+		for _, x := range xs {
+			if x == "bind" {
+				isNullFS = true
+				continue
+			}
+			opt := strings.SplitN(x, "=", 2)
+			options = append(options, opt[0])
+			if len(opt) == 2 {
+				options = append(options, opt[1])
+			} else {
+				options = append(options, "")
+			}
 		}
 	}
 
-	options := []string{"fspath", target}
 	if isNullFS {
 		options = append(options, "fstype", "nullfs", "target", device)
 	} else {


### PR DESCRIPTION
This uses MNT_FORCE as an approximation of Linux MNT_DETACH and passes through key/value options such as devfs' ruleset=N option to the kernel. Also, I removed the code which truncates the zfs mount point to work around a path name limit in obsolete versions of FreeBSD which was fixed in FreeBSD 12.