### PR TITLE
overlay: unix.SYS_PAUSE is not defined on aarch64

### DIFF
--- a/drivers/overlay/idmapped_utils.go
+++ b/drivers/overlay/idmapped_utils.go
@@ -133,7 +133,7 @@ func createUsernsProcess(uidMaps []idtools.IDMap, gidMaps []idtools.IDMap) (int,
 		_ = unix.Prctl(unix.PR_SET_PDEATHSIG, uintptr(unix.SIGKILL), 0, 0, 0)
 		// just wait for the SIGKILL
 		for {
-			syscall.Syscall6(uintptr(unix.SYS_PAUSE), 0, 0, 0, 0, 0, 0)
+			syscall.Pause()
 		}
 	}
 	cleanupFunc := func() {


### PR DESCRIPTION
so use the simpler and more portable time.Sleep() version

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>