### PR TITLE
pkg/chrootarchive: move NSS load to chrootarchive package

### DIFF
--- a/pkg/chrootarchive/archive.go
+++ b/pkg/chrootarchive/archive.go
@@ -5,9 +5,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
-	"net"
 	"os"
-	"os/user"
 	"path/filepath"
 	"sync"
 
@@ -16,13 +14,6 @@ import (
 	"github.com/opencontainers/runc/libcontainer/userns"
 	"github.com/pkg/errors"
 )
-
-func init() {
-	// initialize nss libraries in Glibc so that the dynamic libraries are loaded in the host
-	// environment not in the chroot from untrusted files.
-	_, _ = user.Lookup("storage")
-	_, _ = net.LookupHost("localhost")
-}
 
 // NewArchiver returns a new Archiver which uses chrootarchive.Untar
 func NewArchiver(idMappings *idtools.IDMappings) *archive.Archiver {

--- a/pkg/chrootarchive/chroot_linux.go
+++ b/pkg/chrootarchive/chroot_linux.go
@@ -3,7 +3,9 @@ package chrootarchive
 import (
 	"fmt"
 	"io/ioutil"
+	"net"
 	"os"
+	"os/user"
 	"path/filepath"
 
 	"github.com/containers/storage/pkg/mount"
@@ -22,6 +24,11 @@ func chroot(path string) (err error) {
 	if err != nil {
 		return err
 	}
+
+	// initialize nss libraries in Glibc so that the dynamic libraries are loaded in the host
+	// environment not in the chroot from untrusted files.
+	_, _ = user.Lookup("storage")
+	_, _ = net.LookupHost("localhost")
 
 	// if the process doesn't have CAP_SYS_ADMIN, but does have CAP_SYS_CHROOT, we need to use the actual chroot
 	if !caps.Get(capability.EFFECTIVE, capability.CAP_SYS_ADMIN) && caps.Get(capability.EFFECTIVE, capability.CAP_SYS_CHROOT) {


### PR DESCRIPTION
do not attempt to load NSS modules at init() time but do it just
before creating the chroot environment.

Closes: https://github.com/containers/storage/issues/1227

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>