### PR TITLE
store: skip template copy with layer in different store

### DIFF
--- a/store.go
+++ b/store.go
@@ -1195,6 +1195,11 @@ func (s *store) imageTopLayerForMapping(image *Image, ristore ROImageStore, crea
 				if layer == nil {
 					layer = cLayer
 					parentLayer = cParentLayer
+					if store != rlstore {
+						// The layer is in another store, so we cannot
+						// create a mapped version of it to the image.
+						createMappedLayer = false
+					}
 				}
 			}
 		}


### PR DESCRIPTION
do not attempt to create a layer using a TemplateLayer if the source
layer is in a different store, since the lookup for the source layer
would fail in the layers store.

The reproducer for the error:

Error: error creating container storage: error creating an ID-mapped copy of layer "4fc242d58285699eca05db3cc7c7122a2b8e014d9481f323bd9277baacfa0628": layer not known

Closes: https://github.com/containers/storage/issues/1232

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>