### PR TITLE
overlay: do not check for idmapped mounts if euid!=0

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -207,14 +207,18 @@ func checkSupportVolatile(home, runhome string) (bool, error) {
 // checkAndRecordIDMappedSupport checks and stores if the kernel supports mounting overlay on top of a
 // idmapped lower layer.
 func checkAndRecordIDMappedSupport(home, runhome string) (bool, error) {
+	if os.Geteuid() != 0 {
+		return false, nil
+	}
+
 	feature := "idmapped-lower-dir"
 	overlayCacheResult, overlayCacheText, err := cachedFeatureCheck(runhome, feature)
 	if err == nil {
 		if overlayCacheResult {
-			logrus.Debugf("Cached value indicated that overlay is supported")
+			logrus.Debugf("Cached value indicated that idmapped mounts for overlay are supported")
 			return true, nil
 		}
-		logrus.Debugf("Cached value indicated that overlay is not supported")
+		logrus.Debugf("Cached value indicated that idmapped mounts for overlay are not supported")
 		return false, errors.New(overlayCacheText)
 	}
 	supportsIDMappedMounts, err := supportsIdmappedLowerLayers(home)


### PR DESCRIPTION
do not store the result of the check when running with euid != 0.  The
check must happen and its result stored only once the process is
re-executed in its user namespace and runs with euid == 0.

It doesn't make any real difference at the moment since the  kernel
feature is going to be supported only for root in the initial user
namespace.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>