### PR TITLE
PullOptions should work for rootless users also

### DIFF
--- a/store.go
+++ b/store.go
@@ -173,6 +173,7 @@ type Store interface {
 	GraphRoot() string
 	GraphDriverName() string
 	GraphOptions() []string
+	PullOptions() map[string]string
 	UIDMap() []idtools.IDMap
 	GIDMap() []idtools.IDMap
 
@@ -607,6 +608,7 @@ type store struct {
 	graphRoot       string
 	graphDriverName string
 	graphOptions    []string
+	pullOptions     map[string]string
 	uidMap          []idtools.IDMap
 	gidMap          []idtools.IDMap
 	autoUsernsUser  string
@@ -726,6 +728,7 @@ func GetStore(options types.StoreOptions) (Store, error) {
 		additionalGIDs:  nil,
 		usernsLock:      usernsLock,
 		disableVolatile: options.DisableVolatile,
+		pullOptions:     options.PullOptions,
 	}
 	if err := s.load(); err != nil {
 		return nil, err
@@ -774,6 +777,14 @@ func (s *store) GraphRoot() string {
 
 func (s *store) GraphOptions() []string {
 	return s.graphOptions
+}
+
+func (s *store) PullOptions() map[string]string {
+	cp := make(map[string]string, len(s.pullOptions))
+	for k, v := range s.pullOptions {
+		cp[k] = v
+	}
+	return cp
 }
 
 func (s *store) UIDMap() []idtools.IDMap {

--- a/store_test.go
+++ b/store_test.go
@@ -18,6 +18,7 @@ func TestStore(t *testing.T) {
 	err = os.MkdirAll(wd, 0700)
 	require.NoError(t, err)
 
+	pullOpts := map[string]string{"Test1": "test1", "Test2": "test2"}
 	store, err := GetStore(StoreOptions{
 		RunRoot:            filepath.Join(wd, "run"),
 		GraphRoot:          filepath.Join(wd, "root"),
@@ -33,6 +34,7 @@ func TestStore(t *testing.T) {
 			HostID:      os.Getgid(),
 			Size:        1,
 		}},
+		PullOptions: pullOpts,
 	})
 	require.NoError(t, err)
 
@@ -45,9 +47,14 @@ func TestStore(t *testing.T) {
 	root = store.GraphDriverName()
 	require.NotNil(t, root)
 
-	store.GraphOptions()
+	gopts := store.GraphOptions()
+	assert.Equal(t, []string{}, gopts)
+
 	store.UIDMap()
 	store.GIDMap()
+
+	opts := store.PullOptions()
+	assert.Equal(t, pullOpts, opts)
 
 	_, err = store.GraphDriver()
 	require.Nil(t, err)

--- a/types/options.go
+++ b/types/options.go
@@ -187,6 +187,7 @@ func getRootlessStorageOpts(rootlessUID int, systemOpts StoreOptions) (StoreOpti
 		return opts, err
 	}
 	opts.RunRoot = rootlessRuntime
+	opts.PullOptions = systemOpts.PullOptions
 	if systemOpts.RootlessStoragePath != "" {
 		opts.GraphRoot, err = expandEnvPath(systemOpts.RootlessStoragePath, rootlessUID)
 		if err != nil {


### PR DESCRIPTION
Also add interfaces to allow callers to see the pull options.

While experimenting with pushing and pulling with zstd, I found
that storage pulloptions were not being used in rootless mode.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>