### PR TITLE
Don't try to use %w in testing package logging functions

### DIFF
--- a/pkg/chunked/cache_linux_test.go
+++ b/pkg/chunked/cache_linux_test.go
@@ -57,7 +57,7 @@ const jsonTOC = `
 func TestPrepareMetadata(t *testing.T) {
 	toc, err := prepareMetadata([]byte(jsonTOC))
 	if err != nil {
-		t.Errorf("got error from prepareMetadata: %w", err)
+		t.Errorf("got error from prepareMetadata: %v", err)
 	}
 	if len(toc) != 2 {
 		t.Error("prepareMetadata returns the wrong length")
@@ -85,7 +85,7 @@ func (b *bigDataToBuffer) SetLayerBigData(id, key string, data io.Reader) error 
 func TestWriteCache(t *testing.T) {
 	toc, err := prepareMetadata([]byte(jsonTOC))
 	if err != nil {
-		t.Errorf("got error from prepareMetadata: %w", err)
+		t.Errorf("got error from prepareMetadata: %v", err)
 	}
 
 	dest := bigDataToBuffer{
@@ -93,7 +93,7 @@ func TestWriteCache(t *testing.T) {
 	}
 	cache, err := writeCache([]byte(jsonTOC), "foobar", &dest)
 	if err != nil {
-		t.Errorf("got error from writeCache: %w", err)
+		t.Errorf("got error from writeCache: %v", err)
 	}
 	if digest, _, _ := findTag("foobar", cache); digest != "" {
 		t.Error("found invalid tag")
@@ -117,7 +117,7 @@ func TestWriteCache(t *testing.T) {
 
 			fingerprint, err := calculateHardLinkFingerprint(r)
 			if err != nil {
-				t.Errorf("got error from writeCache: %w", err)
+				t.Errorf("got error from writeCache: %v", err)
 			}
 
 			// find the element in the cache by the hardlink fingerprint
@@ -158,12 +158,12 @@ func TestReadCache(t *testing.T) {
 	}
 	cache, err := writeCache([]byte(jsonTOC), "foobar", &dest)
 	if err != nil {
-		t.Errorf("got error from writeCache: %w", err)
+		t.Errorf("got error from writeCache: %v", err)
 	}
 
 	cacheRead, err := readMetadataFromCache(dest.buf)
 	if err != nil {
-		t.Errorf("got error from readMetadataFromCache: %w", err)
+		t.Errorf("got error from readMetadataFromCache: %v", err)
 	}
 	if !reflect.DeepEqual(cache, cacheRead) {
 		t.Errorf("read a different struct than what was written")

--- a/pkg/chunked/compressor/compressor_test.go
+++ b/pkg/chunked/compressor/compressor_test.go
@@ -17,7 +17,7 @@ func TestHole(t *testing.T) {
 
 	hole, _, err := hf.ReadByte()
 	if err != nil {
-		t.Errorf("got error: %w", err)
+		t.Errorf("got error: %v", err)
 	}
 	if hole != 5 {
 		t.Error("expected hole not found")
@@ -34,7 +34,7 @@ func TestHole(t *testing.T) {
 	for i := 0; i < 5; i++ {
 		hole, byte, err := hf.ReadByte()
 		if err != nil {
-			t.Errorf("got error: %w", err)
+			t.Errorf("got error: %v", err)
 		}
 		if hole != 0 {
 			t.Error("hole found")
@@ -58,7 +58,7 @@ func TestTwoHoles(t *testing.T) {
 
 	hole, _, err := hf.ReadByte()
 	if err != nil {
-		t.Errorf("got error: %w", err)
+		t.Errorf("got error: %v", err)
 	}
 	if hole != 5 {
 		t.Error("hole not found")
@@ -67,7 +67,7 @@ func TestTwoHoles(t *testing.T) {
 	for _, e := range []byte("FOO") {
 		hole, c, err := hf.ReadByte()
 		if err != nil {
-			t.Errorf("got error: %w", err)
+			t.Errorf("got error: %v", err)
 		}
 		if hole != 0 {
 			t.Error("hole found")
@@ -78,7 +78,7 @@ func TestTwoHoles(t *testing.T) {
 	}
 	hole, _, err = hf.ReadByte()
 	if err != nil {
-		t.Errorf("got error: %w", err)
+		t.Errorf("got error: %v", err)
 	}
 	if hole != 5 {
 		t.Error("expected hole not found")


### PR DESCRIPTION
Go 1.18's testing package is adamant that it doesn't support the `%w` specifier for wrapping errors, which makes sense because it outputs text rather than producing an error object like `fmt.Errorf()` does.  Change attempts to use `%w` to `%v`.