### PR TITLE
chown: use Link instead of Chown for dup inodes

### DIFF
--- a/tests/idmaps.bats
+++ b/tests/idmaps.bats
@@ -18,6 +18,7 @@ load helpers
 
 	n=5
 	host=2
+
 	# Create some temporary files.
 	for i in $(seq $n) ; do
 		createrandom "$TESTDIR"/file$i
@@ -53,6 +54,11 @@ load helpers
 	cp -p "$TESTDIR"/file3 ${lowermount}
 	cp -p "$TESTDIR"/file4 ${lowermount}
 	cp -p "$TESTDIR"/file5 ${lowermount}
+
+	# Create a hard link
+	createrandom ${lowermount}/origin-file
+	ln ${lowermount}/origin-file ${lowermount}/ln-file
+
 	# Create new layers.
 	for i in $(seq $n) ; do
 		if test $host -ne $i ; then
@@ -75,6 +81,13 @@ load helpers
 		echo "$output"
 		[ "$status" -eq 0 ]
 		[ "$output" = "" ]
+
+		# Verify that the hard link is maintained
+		origin_ino=$(stat -c %i ${uppermount}/origin-file)
+		ln_ino=$(stat -c %i ${uppermount}/ln-file)
+		echo test ${origin_ino} = ${ln_ino}
+		test ${origin_ino} = ${ln_ino}
+
 		for j in $(seq $n) ; do
 			# Check the inherited original files.
 			cmp ${uppermount}/file$j "$TESTDIR"/file$j


### PR DESCRIPTION
If the inode was already encountered and chowned, use link(2) instead
of chown(2).

This is needed when the underlying storage (as it could be overlay
with index=off) breaks the hard link on copy up.

https://github.com/containers/storage/pull/1144 added the initial
check.

Closes: https://github.com/containers/storage/issues/1257

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
