### PR TITLE
[release-1.24] drivers: enhance check for mount fs type

### DIFF
--- a/drivers/driver_linux.go
+++ b/drivers/driver_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package graphdriver
@@ -128,11 +129,32 @@ func (c *defaultChecker) IsMounted(path string) bool {
 	return m
 }
 
+// isMountPoint checks that the given path is a mount point
+func isMountPoint(mountPath string) (bool, error) {
+	// it is already the root
+	if mountPath == "/" {
+		return true, nil
+	}
+
+	var s1, s2 unix.Stat_t
+	if err := unix.Stat(mountPath, &s1); err != nil {
+		return true, err
+	}
+	if err := unix.Stat(filepath.Dir(mountPath), &s2); err != nil {
+		return true, err
+	}
+	return s1.Dev != s2.Dev, nil
+}
+
 // Mounted checks if the given path is mounted as the fs type
 func Mounted(fsType FsMagic, mountPath string) (bool, error) {
 	var buf unix.Statfs_t
+
 	if err := unix.Statfs(mountPath, &buf); err != nil {
 		return false, err
 	}
-	return FsMagic(buf.Type) == fsType, nil
+	if FsMagic(buf.Type) != fsType {
+		return false, nil
+	}
+	return isMountPoint(mountPath)
 }


### PR DESCRIPTION
when checking that a mount has a specific file system type, also
validate that it is on a different than its parent directory.

This helps when using virtiofs as the underlying file system since the
check used for fuse-overlayfs would fail since they both use FUSE.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
(cherry picked from commit da09b934b6e019279b0489ace2e0194450f36a5b)