### PR TITLE
options: copy all options on explicit config file

### DIFF
--- a/store.go
+++ b/store.go
@@ -643,8 +643,12 @@ type store struct {
 //       return
 //   }
 func GetStore(options types.StoreOptions) (Store, error) {
+	defaultOpts, err := types.Options()
+	if err != nil {
+		return nil, err
+	}
 	if options.RunRoot == "" && options.GraphRoot == "" && options.GraphDriverName == "" && len(options.GraphDriverOptions) == 0 {
-		options = types.Options()
+		options = defaultOpts
 	}
 
 	if options.GraphRoot != "" {
@@ -677,9 +681,9 @@ func GetStore(options types.StoreOptions) (Store, error) {
 	case options.RunRoot == "" && options.GraphRoot == "":
 		return nil, errors.Wrap(ErrIncompleteOptions, "no storage runroot or graphroot specified")
 	case options.GraphRoot == "":
-		options.GraphRoot = types.Options().GraphRoot
+		options.GraphRoot = defaultOpts.GraphRoot
 	case options.RunRoot == "":
-		options.RunRoot = types.Options().RunRoot
+		options.RunRoot = defaultOpts.RunRoot
 	}
 
 	if err := os.MkdirAll(options.RunRoot, 0700); err != nil {
@@ -3715,7 +3719,10 @@ func ReloadConfigurationFile(configFile string, storeOptions *types.StoreOptions
 
 // GetDefaultMountOptions returns the default mountoptions defined in container/storage
 func GetDefaultMountOptions() ([]string, error) {
-	defaultStoreOptions := types.Options()
+	defaultStoreOptions, err := types.Options()
+	if err != nil {
+		return nil, err
+	}
 	return GetMountOptions(defaultStoreOptions.GraphDriverName, defaultStoreOptions.GraphDriverOptions)
 }
 

--- a/types/options.go
+++ b/types/options.go
@@ -288,7 +288,8 @@ func ReloadConfigurationFileIfNeeded(configFile string, storeOptions *StoreOptio
 		return err
 	}
 
-	prevReloadConfig.storeOptions = storeOptions
+	cOptions := *storeOptions
+	prevReloadConfig.storeOptions = &cOptions
 	prevReloadConfig.mod = mtime
 	prevReloadConfig.configFile = configFile
 	return nil

--- a/types/options.go
+++ b/types/options.go
@@ -230,7 +230,11 @@ func getRootlessStorageOpts(rootlessUID int, systemOpts StoreOptions) (StoreOpti
 		opts.GraphDriverName = overlayDriver
 	}
 
-	if opts.GraphDriverName == overlayDriver {
+	// If the configuration file was explicitly set, then copy all the options
+	// present.
+	if defaultConfigFileSet {
+		opts.GraphDriverOptions = systemOpts.GraphDriverOptions
+	} else if opts.GraphDriverName == overlayDriver {
 		for _, o := range systemOpts.GraphDriverOptions {
 			if strings.Contains(o, "ignore_chown_errors") {
 				opts.GraphDriverOptions = append(opts.GraphDriverOptions, o)

--- a/types/options.go
+++ b/types/options.go
@@ -35,7 +35,7 @@ var (
 	defaultStoreOptionsOnce sync.Once
 )
 
-func loaddefaultStoreOptions() {
+func loadDefaultStoreOptions() {
 	defaultStoreOptions.RunRoot = defaultRunRoot
 	defaultStoreOptions.GraphRoot = defaultGraphRoot
 	defaultStoreOptions.GraphDriverName = ""
@@ -73,7 +73,7 @@ func defaultStoreOptionsIsolated(rootless bool, rootlessUID int, storageConf str
 		defaultRootlessGraphRoot string
 		err                      error
 	)
-	defaultStoreOptionsOnce.Do(loaddefaultStoreOptions)
+	defaultStoreOptionsOnce.Do(loadDefaultStoreOptions)
 	storageOpts := defaultStoreOptions
 	if rootless && rootlessUID != 0 {
 		storageOpts, err = getRootlessStorageOpts(rootlessUID, storageOpts)
@@ -401,7 +401,7 @@ func ReloadConfigurationFile(configFile string, storeOptions *StoreOptions) {
 }
 
 func Options() StoreOptions {
-	defaultStoreOptionsOnce.Do(loaddefaultStoreOptions)
+	defaultStoreOptionsOnce.Do(loadDefaultStoreOptions)
 	return defaultStoreOptions
 }
 

--- a/types/options.go
+++ b/types/options.go
@@ -43,9 +43,11 @@ func loadDefaultStoreOptions() {
 
 	if path, ok := os.LookupEnv(storageConfEnv); ok {
 		defaultOverrideConfigFile = path
-	}
-
-	if _, err := os.Stat(defaultOverrideConfigFile); err == nil {
+		if err := ReloadConfigurationFileIfNeeded(path, &defaultStoreOptions); err != nil {
+			loadDefaultStoreOptionsErr = err
+			return
+		}
+	} else if _, err := os.Stat(defaultOverrideConfigFile); err == nil {
 		// The DefaultConfigFile(rootless) function returns the path
 		// of the used storage.conf file, by returning defaultConfigFile
 		// If override exists containers/storage uses it by default.


### PR DESCRIPTION
when the configuration file was explicitly specified, all the graph
drivers options are copied, not only the ones allowed for rootless.

Closes: https://github.com/containers/storage/issues/1278

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
