### PR TITLE
Switch to golang native error wrapping

### DIFF
--- a/drivers/aufs/aufs.go
+++ b/drivers/aufs/aufs.go
@@ -25,6 +25,7 @@ package aufs
 
 import (
 	"bufio"
+	"errors"
 	"fmt"
 	"io"
 	"io/fs"
@@ -48,7 +49,6 @@ import (
 	"github.com/containers/storage/pkg/system"
 	"github.com/opencontainers/runc/libcontainer/userns"
 	"github.com/opencontainers/selinux/go-selinux/label"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/vbatts/tar-split/tar/storage"
 	"golang.org/x/sys/unix"
@@ -91,7 +91,7 @@ func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) 
 
 	// Try to load the aufs kernel module
 	if err := supportsAufs(); err != nil {
-		return nil, errors.Wrap(graphdriver.ErrNotSupported, "kernel does not support aufs")
+		return nil, fmt.Errorf("kernel does not support aufs: %w", graphdriver.ErrNotSupported)
 
 	}
 
@@ -106,7 +106,7 @@ func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) 
 	switch fsMagic {
 	case graphdriver.FsMagicAufs, graphdriver.FsMagicBtrfs, graphdriver.FsMagicEcryptfs:
 		logrus.Errorf("AUFS is not supported over %s", backingFs)
-		return nil, errors.Wrapf(graphdriver.ErrIncompatibleFS, "AUFS is not supported over %q", backingFs)
+		return nil, fmt.Errorf("AUFS is not supported over %q: %w", backingFs, graphdriver.ErrIncompatibleFS)
 	}
 
 	var mountOptions string
@@ -374,10 +374,10 @@ func (a *Driver) Remove(id string) error {
 		}
 
 		if err != unix.EBUSY {
-			return errors.Wrapf(err, "aufs: unmount error: %s", mountpoint)
+			return fmt.Errorf("aufs: unmount error: %s: %w", mountpoint, err)
 		}
 		if retries >= 5 {
-			return errors.Wrapf(err, "aufs: unmount error after retries: %s", mountpoint)
+			return fmt.Errorf("aufs: unmount error after retries: %s: %w", mountpoint, err)
 		}
 		// If unmount returns EBUSY, it could be a transient error. Sleep and retry.
 		retries++
@@ -387,21 +387,21 @@ func (a *Driver) Remove(id string) error {
 
 	// Remove the layers file for the id
 	if err := os.Remove(path.Join(a.rootPath(), "layers", id)); err != nil && !os.IsNotExist(err) {
-		return errors.Wrapf(err, "error removing layers dir for %s", id)
+		return fmt.Errorf("error removing layers dir for %s: %w", id, err)
 	}
 
 	if err := atomicRemove(a.getDiffPath(id)); err != nil {
-		return errors.Wrapf(err, "could not remove diff path for id %s", id)
+		return fmt.Errorf("could not remove diff path for id %s: %w", id, err)
 	}
 
 	// Atomically remove each directory in turn by first moving it out of the
 	// way (so that container runtime doesn't find it anymore) before doing removal of
 	// the whole tree.
 	if err := atomicRemove(mountpoint); err != nil {
-		if errors.Cause(err) == unix.EBUSY {
+		if errors.Is(err, unix.EBUSY) {
 			logger.WithField("dir", mountpoint).WithError(err).Warn("error performing atomic remove due to EBUSY")
 		}
-		return errors.Wrapf(err, "could not remove mountpoint for id %s", id)
+		return fmt.Errorf("could not remove mountpoint for id %s: %w", id, err)
 	}
 
 	a.pathCacheLock.Lock()
@@ -419,10 +419,10 @@ func atomicRemove(source string) error {
 	case os.IsExist(err):
 		// Got error saying the target dir already exists, maybe the source doesn't exist due to a previous (failed) remove
 		if _, e := os.Stat(source); !os.IsNotExist(e) {
-			return errors.Wrapf(err, "target rename dir '%s' exists but should not, this needs to be manually cleaned up", target)
+			return fmt.Errorf("target rename dir '%s' exists but should not, this needs to be manually cleaned up: %w", target, err)
 		}
 	default:
-		return errors.Wrapf(err, "error preparing atomic delete")
+		return fmt.Errorf("error preparing atomic delete: %w", err)
 	}
 
 	return system.EnsureRemoveAll(target)

--- a/drivers/aufs/aufs_test.go
+++ b/drivers/aufs/aufs_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package aufs
@@ -5,6 +6,7 @@ package aufs
 import (
 	"crypto/sha256"
 	"encoding/hex"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -18,7 +20,6 @@ import (
 	"github.com/containers/storage/pkg/archive"
 	"github.com/containers/storage/pkg/reexec"
 	"github.com/containers/storage/pkg/stringid"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -35,7 +36,7 @@ func init() {
 func testInit(dir string, t testing.TB) graphdriver.Driver {
 	d, err := Init(dir, graphdriver.Options{})
 	if err != nil {
-		if errors.Cause(err) == graphdriver.ErrNotSupported {
+		if errors.Is(err, graphdriver.ErrNotSupported) {
 			t.Skip(err)
 		} else {
 			t.Fatal(err)

--- a/drivers/btrfs/btrfs.go
+++ b/drivers/btrfs/btrfs.go
@@ -36,7 +36,6 @@ import (
 	"github.com/containers/storage/pkg/system"
 	"github.com/docker/go-units"
 	"github.com/opencontainers/selinux/go-selinux/label"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
@@ -62,7 +61,7 @@ func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) 
 	}
 
 	if fsMagic != graphdriver.FsMagicBtrfs {
-		return nil, errors.Wrapf(graphdriver.ErrPrerequisites, "%q is not on a btrfs filesystem", home)
+		return nil, fmt.Errorf("%q is not on a btrfs filesystem: %w", home, graphdriver.ErrPrerequisites)
 	}
 
 	rootUID, rootGID, err := idtools.GetRootUIDGID(options.UIDMaps, options.GIDMaps)

--- a/drivers/devmapper/device_setup.go
+++ b/drivers/devmapper/device_setup.go
@@ -1,3 +1,4 @@
+//go:build linux && cgo
 // +build linux,cgo
 
 package devmapper
@@ -5,6 +6,7 @@ package devmapper
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -12,7 +14,6 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -59,7 +60,7 @@ func checkDevAvailable(dev string) error {
 	}
 
 	if !bytes.Contains(out, []byte(dev)) {
-		return errors.Errorf("%s is not available for use with devicemapper", dev)
+		return fmt.Errorf("%s is not available for use with devicemapper", dev)
 	}
 	return nil
 }
@@ -84,7 +85,7 @@ func checkDevInVG(dev string) error {
 			// got "VG Name" line"
 			vg := strings.TrimSpace(fields[1])
 			if len(vg) > 0 {
-				return errors.Errorf("%s is already part of a volume group %q: must remove this device from any volume group or provide a different device", dev, vg)
+				return fmt.Errorf("%s is already part of a volume group %q: must remove this device from any volume group or provide a different device", dev, vg)
 			}
 			logrus.Error(fields)
 			break
@@ -112,7 +113,7 @@ func checkDevHasFS(dev string) error {
 		if bytes.Equal(kv[0], []byte("TYPE")) {
 			v := bytes.Trim(kv[1], "\"")
 			if len(v) > 0 {
-				return errors.Errorf("%s has a filesystem already, use dm.directlvm_device_force=true if you want to wipe the device", dev)
+				return fmt.Errorf("%s has a filesystem already, use dm.directlvm_device_force=true if you want to wipe the device", dev)
 			}
 			return nil
 		}
@@ -123,16 +124,16 @@ func checkDevHasFS(dev string) error {
 func verifyBlockDevice(dev string, force bool) error {
 	absPath, err := filepath.Abs(dev)
 	if err != nil {
-		return errors.Errorf("unable to get absolute path for %s: %s", dev, err)
+		return fmt.Errorf("unable to get absolute path for %s: %s", dev, err)
 	}
 	realPath, err := filepath.EvalSymlinks(absPath)
 	if err != nil {
-		return errors.Errorf("failed to canonicalise path for %s: %s", dev, err)
+		return fmt.Errorf("failed to canonicalise path for %s: %s", dev, err)
 	}
 	if err := checkDevAvailable(absPath); err != nil {
 		logrus.Infof("block device '%s' not available, checking '%s'", absPath, realPath)
 		if err := checkDevAvailable(realPath); err != nil {
-			return errors.Errorf("neither '%s' nor '%s' are in the output of lvmdiskscan, can't use device.", absPath, realPath)
+			return fmt.Errorf("neither '%s' nor '%s' are in the output of lvmdiskscan, can't use device", absPath, realPath)
 		}
 	}
 	if err := checkDevInVG(realPath); err != nil {
@@ -158,7 +159,7 @@ func readLVMConfig(root string) (directLVMConfig, error) {
 		if os.IsNotExist(err) {
 			return cfg, nil
 		}
-		return cfg, errors.Wrap(err, "error reading existing setup config")
+		return cfg, fmt.Errorf("error reading existing setup config: %w", err)
 	}
 
 	// check if this is just an empty file, no need to produce a json error later if so
@@ -167,17 +168,17 @@ func readLVMConfig(root string) (directLVMConfig, error) {
 	}
 
 	err = json.Unmarshal(b, &cfg)
-	return cfg, errors.Wrap(err, "error unmarshaling previous device setup config")
+	return cfg, fmt.Errorf("error unmarshaling previous device setup config: %w", err)
 }
 
 func writeLVMConfig(root string, cfg directLVMConfig) error {
 	p := filepath.Join(root, "setup-config.json")
 	b, err := json.Marshal(cfg)
 	if err != nil {
-		return errors.Wrap(err, "error marshalling direct lvm config")
+		return fmt.Errorf("error marshalling direct lvm config: %w", err)
 	}
 	err = ioutil.WriteFile(p, b, 0600)
-	return errors.Wrap(err, "error writing direct lvm config to file")
+	return fmt.Errorf("error writing direct lvm config to file: %w", err)
 }
 
 func setupDirectLVM(cfg directLVMConfig) error {
@@ -186,13 +187,13 @@ func setupDirectLVM(cfg directLVMConfig) error {
 
 	for _, bin := range binaries {
 		if _, err := exec.LookPath(bin); err != nil {
-			return errors.Wrap(err, "error looking up command `"+bin+"` while setting up direct lvm")
+			return fmt.Errorf("error looking up command `"+bin+"` while setting up direct lvm: %w", err)
 		}
 	}
 
 	err := os.MkdirAll(lvmProfileDir, 0755)
 	if err != nil {
-		return errors.Wrap(err, "error creating lvm profile directory")
+		return fmt.Errorf("error creating lvm profile directory: %w", err)
 	}
 
 	if cfg.AutoExtendPercent == 0 {
@@ -215,34 +216,34 @@ func setupDirectLVM(cfg directLVMConfig) error {
 
 	out, err := exec.Command("pvcreate", "--metadatasize", cfg.MetaDataSize, "-f", cfg.Device).CombinedOutput()
 	if err != nil {
-		return errors.Wrap(err, string(out))
+		return fmt.Errorf("%v: %w", string(out), err)
 	}
 
 	out, err = exec.Command("vgcreate", "storage", cfg.Device).CombinedOutput()
 	if err != nil {
-		return errors.Wrap(err, string(out))
+		return fmt.Errorf("%v: %w", string(out), err)
 	}
 
 	out, err = exec.Command("lvcreate", "--wipesignatures", "y", "-n", "thinpool", "storage", "--extents", fmt.Sprintf("%d%%VG", cfg.ThinpPercent)).CombinedOutput()
 	if err != nil {
-		return errors.Wrap(err, string(out))
+		return fmt.Errorf("%v: %w", string(out), err)
 	}
 	out, err = exec.Command("lvcreate", "--wipesignatures", "y", "-n", "thinpoolmeta", "storage", "--extents", fmt.Sprintf("%d%%VG", cfg.ThinpMetaPercent)).CombinedOutput()
 	if err != nil {
-		return errors.Wrap(err, string(out))
+		return fmt.Errorf("%v: %w", string(out), err)
 	}
 
 	out, err = exec.Command("lvconvert", "-y", "--zero", "n", "-c", "512K", "--thinpool", "storage/thinpool", "--poolmetadata", "storage/thinpoolmeta").CombinedOutput()
 	if err != nil {
-		return errors.Wrap(err, string(out))
+		return fmt.Errorf("%v: %w", string(out), err)
 	}
 
 	profile := fmt.Sprintf("activation{\nthin_pool_autoextend_threshold=%d\nthin_pool_autoextend_percent=%d\n}", cfg.AutoExtendThreshold, cfg.AutoExtendPercent)
 	err = ioutil.WriteFile(lvmProfileDir+"/storage-thinpool.profile", []byte(profile), 0600)
 	if err != nil {
-		return errors.Wrap(err, "error writing storage thinp autoextend profile")
+		return fmt.Errorf("error writing storage thinp autoextend profile: %w", err)
 	}
 
 	out, err = exec.Command("lvchange", "--metadataprofile", "storage-thinpool", "storage/thinpool").CombinedOutput()
-	return errors.Wrap(err, string(out))
+	return fmt.Errorf("%v: %w", string(out), err)
 }

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -1,13 +1,13 @@
 package graphdriver
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/vbatts/tar-split/tar/storage"
 
@@ -296,7 +296,7 @@ func GetDriver(name string, config Options) (Driver, error) {
 	}
 
 	logrus.Errorf("Failed to GetDriver graph %s %s", name, config.Root)
-	return nil, errors.Wrapf(ErrNotSupported, "failed to GetDriver graph %s %s", name, config.Root)
+	return nil, fmt.Errorf("failed to GetDriver graph %s %s: %w", name, config.Root, ErrNotSupported)
 }
 
 // getBuiltinDriver initializes and returns the registered driver, but does not try to load from plugins
@@ -305,7 +305,7 @@ func getBuiltinDriver(name, home string, options Options) (Driver, error) {
 		return initFunc(filepath.Join(home, name), options)
 	}
 	logrus.Errorf("Failed to built-in GetDriver graph %s %s", name, home)
-	return nil, errors.Wrapf(ErrNotSupported, "failed to built-in GetDriver graph %s %s", name, home)
+	return nil, fmt.Errorf("failed to built-in GetDriver graph %s %s: %w", name, home, ErrNotSupported)
 }
 
 // Options is used to initialize a graphdriver
@@ -390,8 +390,7 @@ func New(name string, config Options) (Driver, error) {
 // isDriverNotSupported returns true if the error initializing
 // the graph driver is a non-supported error.
 func isDriverNotSupported(err error) bool {
-	cause := errors.Cause(err)
-	return cause == ErrNotSupported || cause == ErrPrerequisites || cause == ErrIncompatibleFS
+	return errors.Is(err, ErrNotSupported) || errors.Is(err, ErrPrerequisites) || errors.Is(err, ErrIncompatibleFS)
 }
 
 // scanPriorDrivers returns an un-ordered scan of directories of prior storage drivers

--- a/drivers/graphtest/graphtest_unix.go
+++ b/drivers/graphtest/graphtest_unix.go
@@ -5,6 +5,7 @@ package graphtest
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"math/rand"
@@ -17,7 +18,6 @@ import (
 	"github.com/containers/storage/pkg/archive"
 	"github.com/containers/storage/pkg/stringid"
 	"github.com/docker/go-units"
-	"github.com/pkg/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sys/unix"
@@ -52,8 +52,7 @@ func newDriver(t testing.TB, name string, options []string) *Driver {
 	d, err := graphdriver.GetDriver(name, graphdriver.Options{DriverOptions: options, Root: root, RunRoot: runroot})
 	if err != nil {
 		t.Logf("graphdriver: %v\n", err)
-		cause := errors.Cause(err)
-		if cause == graphdriver.ErrNotSupported || cause == graphdriver.ErrPrerequisites || cause == graphdriver.ErrIncompatibleFS {
+		if errors.Is(err, graphdriver.ErrNotSupported) || errors.Is(err, graphdriver.ErrPrerequisites) || errors.Is(err, graphdriver.ErrIncompatibleFS) {
 			t.Skipf("Driver %s not supported", name)
 		}
 		t.Fatal(err)

--- a/drivers/overlay/check.go
+++ b/drivers/overlay/check.go
@@ -4,6 +4,7 @@
 package overlay
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -17,7 +18,6 @@ import (
 	"github.com/containers/storage/pkg/mount"
 	"github.com/containers/storage/pkg/system"
 	"github.com/containers/storage/pkg/unshare"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
@@ -59,7 +59,7 @@ func doesSupportNativeDiff(d, mountOpts string) error {
 
 	// Mark l2/d as opaque
 	if err := system.Lsetxattr(filepath.Join(td, "l2", "d"), archive.GetOverlayXattrName("opaque"), []byte("y"), 0); err != nil {
-		return errors.Wrap(err, "failed to set opaque flag on middle layer")
+		return fmt.Errorf("failed to set opaque flag on middle layer: %w", err)
 	}
 
 	mountFlags := "lowerdir=%s:%s,upperdir=%s,workdir=%s"
@@ -73,7 +73,7 @@ func doesSupportNativeDiff(d, mountOpts string) error {
 		opts = fmt.Sprintf("%s,%s", opts, data)
 	}
 	if err := unix.Mount("overlay", filepath.Join(td, "merged"), "overlay", uintptr(flags), opts); err != nil {
-		return errors.Wrap(err, "failed to mount overlay")
+		return fmt.Errorf("failed to mount overlay: %w", err)
 	}
 	defer func() {
 		if err := unix.Unmount(filepath.Join(td, "merged"), 0); err != nil {
@@ -83,13 +83,13 @@ func doesSupportNativeDiff(d, mountOpts string) error {
 
 	// Touch file in d to force copy up of opaque directory "d" from "l2" to "l3"
 	if err := ioutil.WriteFile(filepath.Join(td, "merged", "d", "f"), []byte{}, 0644); err != nil {
-		return errors.Wrap(err, "failed to write to merged directory")
+		return fmt.Errorf("failed to write to merged directory: %w", err)
 	}
 
 	// Check l3/d does not have opaque flag
 	xattrOpaque, err := system.Lgetxattr(filepath.Join(td, "l3", "d"), archive.GetOverlayXattrName("opaque"))
 	if err != nil {
-		return errors.Wrap(err, "failed to read opaque flag on upper layer")
+		return fmt.Errorf("failed to read opaque flag on upper layer: %w", err)
 	}
 	if string(xattrOpaque) == "y" {
 		return errors.New("opaque flag erroneously copied up, consider update to kernel 4.8 or later to fix")
@@ -101,12 +101,12 @@ func doesSupportNativeDiff(d, mountOpts string) error {
 		if err.(*os.LinkError).Err == syscall.EXDEV {
 			return nil
 		}
-		return errors.Wrap(err, "failed to rename dir in merged directory")
+		return fmt.Errorf("failed to rename dir in merged directory: %w", err)
 	}
 	// get the xattr of "d2"
 	xattrRedirect, err := system.Lgetxattr(filepath.Join(td, "l3", "d2"), archive.GetOverlayXattrName("redirect"))
 	if err != nil {
-		return errors.Wrap(err, "failed to read redirect flag on upper layer")
+		return fmt.Errorf("failed to read redirect flag on upper layer: %w", err)
 	}
 
 	if string(xattrRedirect) == "d1" {
@@ -157,11 +157,11 @@ func doesMetacopy(d, mountOpts string) (bool, error) {
 		opts = fmt.Sprintf("%s,%s", opts, data)
 	}
 	if err := unix.Mount("overlay", filepath.Join(td, "merged"), "overlay", uintptr(flags), opts); err != nil {
-		if errors.Cause(err) == unix.EINVAL {
+		if errors.Is(err, unix.EINVAL) {
 			logrus.Info("metacopy option not supported on this kernel", mountOpts)
 			return false, nil
 		}
-		return false, errors.Wrapf(err, "failed to mount overlay for metacopy check with %q options", mountOpts)
+		return false, fmt.Errorf("failed to mount overlay for metacopy check with %q options: %w", mountOpts, err)
 	}
 	defer func() {
 		if err := unix.Unmount(filepath.Join(td, "merged"), 0); err != nil {
@@ -171,7 +171,7 @@ func doesMetacopy(d, mountOpts string) (bool, error) {
 	// Make a change that only impacts the inode, and check if the pulled-up copy is marked
 	// as a metadata-only copy
 	if err := os.Chmod(filepath.Join(td, "merged", "f"), 0600); err != nil {
-		return false, errors.Wrap(err, "error changing permissions on file for metacopy check")
+		return false, fmt.Errorf("error changing permissions on file for metacopy check: %w", err)
 	}
 	metacopy, err := system.Lgetxattr(filepath.Join(td, "l2", "f"), archive.GetOverlayXattrName("metacopy"))
 	if err != nil {
@@ -179,7 +179,7 @@ func doesMetacopy(d, mountOpts string) (bool, error) {
 			logrus.Info("metacopy option not supported")
 			return false, nil
 		}
-		return false, errors.Wrap(err, "metacopy flag was not set on file in upper layer")
+		return false, fmt.Errorf("metacopy flag was not set on file in upper layer: %w", err)
 	}
 	return metacopy != nil, nil
 }
@@ -211,7 +211,7 @@ func doesVolatile(d string) (bool, error) {
 	// Mount using the mandatory options and configured options
 	opts := fmt.Sprintf("volatile,lowerdir=%s,upperdir=%s,workdir=%s", path.Join(td, "lower"), path.Join(td, "upper"), path.Join(td, "work"))
 	if err := unix.Mount("overlay", filepath.Join(td, "merged"), "overlay", 0, opts); err != nil {
-		return false, errors.Wrapf(err, "failed to mount overlay for volatile check")
+		return false, fmt.Errorf("failed to mount overlay for volatile check: %w", err)
 	}
 	defer func() {
 		if err := unix.Unmount(filepath.Join(td, "merged"), 0); err != nil {
@@ -258,7 +258,7 @@ func supportsIdmappedLowerLayers(home string) (bool, error) {
 	defer cleanupFunc()
 
 	if err := createIDMappedMount(lowerDir, lowerMappedDir, int(pid)); err != nil {
-		return false, errors.Wrapf(err, "create mapped mount")
+		return false, fmt.Errorf("create mapped mount: %w", err)
 	}
 	defer unix.Unmount(lowerMappedDir, unix.MNT_DETACH)
 

--- a/drivers/overlay/idmapped_utils.go
+++ b/drivers/overlay/idmapped_utils.go
@@ -11,7 +11,6 @@ import (
 	"unsafe"
 
 	"github.com/containers/storage/pkg/idtools"
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
 
@@ -95,7 +94,7 @@ func createIDMappedMount(source, target string, pid int) error {
 	path := fmt.Sprintf("/proc/%d/ns/user", pid)
 	userNsFile, err := os.Open(path)
 	if err != nil {
-		return errors.Wrapf(err, "unable to get user ns file descriptor for %q", path)
+		return fmt.Errorf("unable to get user ns file descriptor for %q: %w", path, err)
 	}
 
 	var attr attr

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -6,6 +6,7 @@ package overlay
 import (
 	"bytes"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -36,7 +37,6 @@ import (
 	"github.com/opencontainers/runc/libcontainer/userns"
 	"github.com/opencontainers/selinux/go-selinux"
 	"github.com/opencontainers/selinux/go-selinux/label"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
@@ -197,7 +197,7 @@ func checkSupportVolatile(home, runhome string) (bool, error) {
 				logrus.Debugf("overlay: test mount indicated that volatile is not being used")
 			}
 			if err = cachedFeatureRecord(runhome, feature, usingVolatile, ""); err != nil {
-				return false, errors.Wrap(err, "recording volatile-being-used status")
+				return false, fmt.Errorf("recording volatile-being-used status: %w", err)
 			}
 		}
 	}
@@ -223,7 +223,7 @@ func checkAndRecordIDMappedSupport(home, runhome string) (bool, error) {
 	}
 	supportsIDMappedMounts, err := supportsIdmappedLowerLayers(home)
 	if err2 := cachedFeatureRecord(runhome, feature, supportsIDMappedMounts, ""); err2 != nil {
-		return false, errors.Wrap(err2, "recording overlay idmapped mounts support status")
+		return false, fmt.Errorf("recording overlay idmapped mounts support status: %w", err2)
 	}
 	return supportsIDMappedMounts, err
 }
@@ -256,14 +256,14 @@ func checkAndRecordOverlaySupport(fsMagic graphdriver.FsMagic, home, runhome str
 			if ok && patherr.Err == syscall.ENOSPC {
 				return false, err
 			}
-			err = errors.Wrap(err, "kernel does not support overlay fs")
+			err = fmt.Errorf("kernel does not support overlay fs: %w", err)
 			if err2 := cachedFeatureRecord(runhome, feature, false, err.Error()); err2 != nil {
-				return false, errors.Wrapf(err2, "recording overlay not being supported (%v)", err)
+				return false, fmt.Errorf("recording overlay not being supported (%v): %w", err, err2)
 			}
 			return false, err
 		}
 		if err = cachedFeatureRecord(runhome, feature, supportsDType, ""); err != nil {
-			return false, errors.Wrap(err, "recording overlay support status")
+			return false, fmt.Errorf("recording overlay support status: %w", err)
 		}
 	}
 	return supportsDType, nil
@@ -357,10 +357,10 @@ func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) 
 		// check if they are running over btrfs, aufs, zfs, overlay, or ecryptfs
 		switch fsMagic {
 		case graphdriver.FsMagicAufs, graphdriver.FsMagicZfs, graphdriver.FsMagicOverlay, graphdriver.FsMagicEcryptfs:
-			return nil, errors.Wrapf(graphdriver.ErrIncompatibleFS, "'overlay' is not supported over %s, a mount_program is required", backingFs)
+			return nil, fmt.Errorf("'overlay' is not supported over %s, a mount_program is required: %w", backingFs, graphdriver.ErrIncompatibleFS)
 		}
 		if unshare.IsRootless() && isNetworkFileSystem(fsMagic) {
-			return nil, errors.Wrapf(graphdriver.ErrIncompatibleFS, "A network file system with user namespaces is not supported.  Please use a mount_program")
+			return nil, fmt.Errorf("a network file system with user namespaces is not supported.  Please use a mount_program: %w", graphdriver.ErrIncompatibleFS)
 		}
 	}
 
@@ -394,7 +394,7 @@ func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) 
 					logrus.Debugf("overlay: test mount indicated that metacopy is not being used")
 				}
 				if err = cachedFeatureRecord(runhome, feature, usingMetacopy, ""); err != nil {
-					return nil, errors.Wrap(err, "recording metacopy-being-used status")
+					return nil, fmt.Errorf("recording metacopy-being-used status: %w", err)
 				}
 			} else {
 				logrus.Infof("overlay: test mount did not indicate whether or not metacopy is being used: %v", err)
@@ -509,7 +509,7 @@ func parseOptions(options []string) (*overlayOptions, error) {
 				}
 				st, err := os.Stat(lstore)
 				if err != nil {
-					return nil, errors.Wrap(err, "overlay: can't stat additionallayerstore dir")
+					return nil, fmt.Errorf("overlay: can't stat additionallayerstore dir: %w", err)
 				}
 				if !st.IsDir() {
 					return nil, fmt.Errorf("overlay: additionallayerstore path %q must be a directory", lstore)
@@ -536,7 +536,7 @@ func parseOptions(options []string) (*overlayOptions, error) {
 			if val != "" {
 				_, err := os.Stat(val)
 				if err != nil {
-					return nil, errors.Wrapf(err, "overlay: can't stat program %q", val)
+					return nil, fmt.Errorf("overlay: can't stat program %q: %w", val, err)
 				}
 			}
 			o.mountProgram = val
@@ -707,7 +707,7 @@ func supportsOverlay(home string, homeMagic graphdriver.FsMagic, rootUID, rootGI
 		}
 		if err := syscall.Mknod(filepath.Join(upperDir, "whiteout"), syscall.S_IFCHR|0600, int(unix.Mkdev(0, 0))); err != nil {
 			logrus.Debugf("Unable to create kernel-style whiteout: %v", err)
-			return supportsDType, errors.Wrapf(err, "unable to create kernel-style whiteout")
+			return supportsDType, fmt.Errorf("unable to create kernel-style whiteout: %w", err)
 		}
 
 		if len(flags) < unix.Getpagesize() {
@@ -726,16 +726,16 @@ func supportsOverlay(home string, homeMagic graphdriver.FsMagic, rootUID, rootGI
 			err := unix.Mount("overlay", mergedDir, "overlay", 0, flags)
 			if err == nil {
 				logrus.StandardLogger().Logf(logLevel, "overlay: test mount with multiple lowers failed, but succeeded with a single lower")
-				return supportsDType, errors.Wrap(graphdriver.ErrNotSupported, "kernel too old to provide multiple lowers feature for overlay")
+				return supportsDType, fmt.Errorf("kernel too old to provide multiple lowers feature for overlay: %w", graphdriver.ErrNotSupported)
 			}
 			logrus.Debugf("overlay: test mount with a single lower failed %v", err)
 		}
 		logrus.StandardLogger().Logf(logLevel, "'overlay' is not supported over %s at %q", backingFs, home)
-		return supportsDType, errors.Wrapf(graphdriver.ErrIncompatibleFS, "'overlay' is not supported over %s at %q", backingFs, home)
+		return supportsDType, fmt.Errorf("'overlay' is not supported over %s at %q: %w", backingFs, home, graphdriver.ErrIncompatibleFS)
 	}
 
 	logrus.StandardLogger().Logf(logLevel, "'overlay' not found as a supported filesystem on this host. Please ensure kernel is new enough and has overlay support loaded.")
-	return supportsDType, errors.Wrap(graphdriver.ErrNotSupported, "'overlay' not found as a supported filesystem on this host. Please ensure kernel is new enough and has overlay support loaded.")
+	return supportsDType, fmt.Errorf("'overlay' not found as a supported filesystem on this host. Please ensure kernel is new enough and has overlay support loaded.: %w", graphdriver.ErrNotSupported)
 }
 
 func (d *Driver) useNaiveDiff() bool {
@@ -949,7 +949,7 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts, disable
 		// Don’t just os.RemoveAll(dir) here; d.Remove also removes the link in linkDir,
 		// so that we can’t end up with two symlinks in linkDir pointing to the same layer.
 		if err := d.Remove(id); err != nil {
-			return errors.Wrapf(err, "removing a pre-existing layer directory %q", dir)
+			return fmt.Errorf("removing a pre-existing layer directory %q: %w", dir, err)
 		}
 	}
 
@@ -1080,7 +1080,7 @@ func (d *Driver) getLower(parent string) (string, error) {
 		}
 		logrus.Warnf("Can't read parent link %q because it does not exist. Going through storage to recreate the missing links.", path.Join(parentDir, "link"))
 		if err := d.recreateSymlinks(); err != nil {
-			return "", errors.Wrap(err, "recreating the links")
+			return "", fmt.Errorf("recreating the links: %w", err)
 		}
 		parentLink, err = ioutil.ReadFile(path.Join(parentDir, "link"))
 		if err != nil {
@@ -1235,7 +1235,7 @@ func (d *Driver) recreateSymlinks() error {
 			// Read the "link" file under each layer to get the name of the symlink
 			data, err := ioutil.ReadFile(path.Join(d.dir(dir.Name()), "link"))
 			if err != nil {
-				errs = multierror.Append(errs, errors.Wrapf(err, "reading name of symlink for %q", dir.Name()))
+				errs = multierror.Append(errs, fmt.Errorf("reading name of symlink for %q: %w", dir.Name(), err))
 				continue
 			}
 			linkPath := path.Join(d.home, linkDir, strings.Trim(string(data), "\n"))
@@ -1273,11 +1273,11 @@ func (d *Driver) recreateSymlinks() error {
 			}
 			targetComponents := strings.Split(target, string(os.PathSeparator))
 			if len(targetComponents) != 3 || targetComponents[0] != ".." || targetComponents[2] != "diff" {
-				errs = multierror.Append(errs, errors.Errorf("link target of %q looks weird: %q", link, target))
+				errs = multierror.Append(errs, fmt.Errorf("link target of %q looks weird: %q", link, target))
 				// force the link to be recreated on the next pass
 				if err := os.Remove(filepath.Join(linkDirFullPath, link.Name())); err != nil {
 					if !os.IsNotExist(err) {
-						errs = multierror.Append(errs, errors.Wrapf(err, "removing link %q", link))
+						errs = multierror.Append(errs, fmt.Errorf("removing link %q: %w", link, err))
 					} // else don’t report any error, but also don’t set madeProgress.
 					continue
 				}
@@ -1293,7 +1293,7 @@ func (d *Driver) recreateSymlinks() error {
 				// NOTE: If two or more links point to the same target, we will update linkFile
 				// with every value of link.Name(), and set madeProgress = true every time.
 				if err := ioutil.WriteFile(linkFile, []byte(link.Name()), 0644); err != nil {
-					errs = multierror.Append(errs, errors.Wrapf(err, "correcting link for layer %s", targetID))
+					errs = multierror.Append(errs, fmt.Errorf("correcting link for layer %s: %w", targetID, err))
 					continue
 				}
 				madeProgress = true
@@ -1381,7 +1381,7 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 		}
 		logrus.Warnf("Can't read parent link %q because it does not exist. Going through storage to recreate the missing links.", path.Join(dir, "link"))
 		if err := d.recreateSymlinks(); err != nil {
-			return "", errors.Wrap(err, "recreating the links")
+			return "", fmt.Errorf("recreating the links: %w", err)
 		}
 		link, err = ioutil.ReadFile(path.Join(dir, "link"))
 		if err != nil {
@@ -1535,7 +1535,7 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 				root = filepath.Join(mappedRoot, fmt.Sprintf("%d", c))
 				c++
 				if err := createIDMappedMount(mappedMountSrc, root, int(pid)); err != nil {
-					return "", errors.Wrapf(err, "create mapped mount for %q on %q", mappedMountSrc, root)
+					return "", fmt.Errorf("create mapped mount for %q on %q: %w", mappedMountSrc, root, err)
 				}
 				idMappedMounts[mappedMountSrc] = root
 
@@ -1592,7 +1592,7 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 				if output == "" {
 					output = "<stderr empty>"
 				}
-				return errors.Wrapf(err, "using mount program %s: %s", d.options.mountProgram, output)
+				return fmt.Errorf("using mount program %s: %s: %w", d.options.mountProgram, output, err)
 			}
 			return nil
 		}
@@ -1672,7 +1672,7 @@ func (d *Driver) Put(id string) error {
 		// If they fail, fallback to unix.Unmount
 		for _, v := range []string{"fusermount3", "fusermount"} {
 			err := exec.Command(v, "-u", mountpoint).Run()
-			if err != nil && errors.Cause(err) != exec.ErrNotFound {
+			if err != nil && !errors.Is(err, exec.ErrNotFound) {
 				logrus.Debugf("Error unmounting %s with %s - %v", mountpoint, v, err)
 			}
 			if err == nil {
@@ -2115,15 +2115,14 @@ func (d *Driver) getAdditionalLayerPath(dgst digest.Digest, ref string) (string,
 			filepath.Join(target, "blob"),
 		} {
 			if _, err := os.Stat(p); err != nil {
-				return "", errors.Wrapf(graphdriver.ErrLayerUnknown,
-					"failed to stat additional layer %q: %v", p, err)
+				wrapped := fmt.Errorf("failed to stat additional layer %q: %w", p, err)
+				return "", fmt.Errorf("%v: %w", wrapped, graphdriver.ErrLayerUnknown)
 			}
 		}
 		return target, nil
 	}
 
-	return "", errors.Wrapf(graphdriver.ErrLayerUnknown,
-		"additional layer (%q, %q) not found", dgst, ref)
+	return "", fmt.Errorf("additional layer (%q, %q) not found: %w", dgst, ref, graphdriver.ErrLayerUnknown)
 }
 
 func (d *Driver) releaseAdditionalLayerByID(id string) {

--- a/drivers/overlayutils/overlayutils.go
+++ b/drivers/overlayutils/overlayutils.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package overlayutils
@@ -6,7 +7,6 @@ import (
 	"fmt"
 
 	graphdriver "github.com/containers/storage/drivers"
-	"github.com/pkg/errors"
 )
 
 // ErrDTypeNotSupported denotes that the backing filesystem doesn't support d_type.
@@ -16,5 +16,5 @@ func ErrDTypeNotSupported(driver, backingFs string) error {
 		msg += " Reformat the filesystem with ftype=1 to enable d_type support."
 	}
 	msg += " Running without d_type is not supported."
-	return errors.Wrap(graphdriver.ErrNotSupported, msg)
+	return fmt.Errorf("%s: %w", msg, graphdriver.ErrNotSupported)
 }

--- a/drivers/quota/projectquota_unsupported.go
+++ b/drivers/quota/projectquota_unsupported.go
@@ -1,9 +1,10 @@
+//go:build !linux || exclude_disk_quota || !cgo
 // +build !linux exclude_disk_quota !cgo
 
 package quota
 
 import (
-	"github.com/pkg/errors"
+	"errors"
 )
 
 // Quota limit params - currently we only control blocks hard limit

--- a/drivers/zfs/zfs_freebsd.go
+++ b/drivers/zfs/zfs_freebsd.go
@@ -3,8 +3,7 @@ package zfs
 import (
 	"fmt"
 
-	"github.com/containers/storage/drivers"
-	"github.com/pkg/errors"
+	graphdriver "github.com/containers/storage/drivers"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
@@ -18,7 +17,7 @@ func checkRootdirFs(rootdir string) error {
 	// on FreeBSD buf.Fstypename contains ['z', 'f', 's', 0 ... ]
 	if (buf.Fstypename[0] != 122) || (buf.Fstypename[1] != 102) || (buf.Fstypename[2] != 115) || (buf.Fstypename[3] != 0) {
 		logrus.WithField("storage-driver", "zfs").Debugf("no zfs dataset found for rootdir '%s'", rootdir)
-		return errors.Wrapf(graphdriver.ErrPrerequisites, "no zfs dataset found for rootdir '%s'", rootdir)
+		return fmt.Errorf("no zfs dataset found for rootdir '%s': %w", rootdir, graphdriver.ErrPrerequisites)
 	}
 
 	return nil

--- a/drivers/zfs/zfs_linux.go
+++ b/drivers/zfs/zfs_linux.go
@@ -1,8 +1,9 @@
 package zfs
 
 import (
+	"fmt"
+
 	graphdriver "github.com/containers/storage/drivers"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
@@ -19,7 +20,7 @@ func checkRootdirFs(rootDir string) error {
 
 	if fsMagic != graphdriver.FsMagicZfs {
 		logrus.WithField("root", rootDir).WithField("backingFS", backingFS).WithField("storage-driver", "zfs").Error("No zfs dataset found for root")
-		return errors.Wrapf(graphdriver.ErrPrerequisites, "no zfs dataset found for rootdir '%s'", rootDir)
+		return fmt.Errorf("no zfs dataset found for rootdir '%s': %w", rootDir, graphdriver.ErrPrerequisites)
 	}
 
 	return nil

--- a/go.mod
+++ b/go.mod
@@ -21,7 +21,6 @@ require (
 	github.com/opencontainers/runc v1.1.1-0.20220607072441-a7a45d7d2721
 	github.com/opencontainers/runtime-spec v1.0.3-0.20210326190908-1c3f411f0417
 	github.com/opencontainers/selinux v1.10.1
-	github.com/pkg/errors v0.9.1
 	github.com/sirupsen/logrus v1.8.1
 	github.com/stretchr/testify v1.8.0
 	github.com/syndtr/gocapability v0.0.0-20200815063812-42c35b437635

--- a/idset.go
+++ b/idset.go
@@ -1,12 +1,12 @@
 package storage
 
 import (
+	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/google/go-intervals/intervalset"
-	"github.com/pkg/errors"
 )
 
 // idSet represents a set of integer IDs. It is stored as an ordered set of intervals.
@@ -257,9 +257,9 @@ func hasOverlappingRanges(mappings []idtools.IDMap) error {
 
 	if conflicts != nil {
 		if len(conflicts) == 1 {
-			return errors.Wrapf(ErrInvalidMappings, "the specified UID and/or GID mapping %s conflicts with other mappings", conflicts[0])
+			return fmt.Errorf("the specified UID and/or GID mapping %s conflicts with other mappings: %w", conflicts[0], ErrInvalidMappings)
 		}
-		return errors.Wrapf(ErrInvalidMappings, "the specified UID and/or GID mappings %s conflict with other mappings", strings.Join(conflicts, ", "))
+		return fmt.Errorf("the specified UID and/or GID mappings %s conflict with other mappings: %w", strings.Join(conflicts, ", "), ErrInvalidMappings)
 	}
 	return nil
 }

--- a/images.go
+++ b/images.go
@@ -1,6 +1,8 @@
 package storage
 
 import (
+	"errors"
+	"fmt"
 	"io/ioutil"
 	"os"
 	"path/filepath"
@@ -13,7 +15,6 @@ import (
 	"github.com/containers/storage/pkg/stringutils"
 	"github.com/containers/storage/pkg/truncindex"
 	digest "github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
 )
 
 const (
@@ -232,7 +233,7 @@ func (i *Image) recomputeDigests() error {
 	digests := make(map[digest.Digest]struct{})
 	if i.Digest != "" {
 		if err := i.Digest.Validate(); err != nil {
-			return errors.Wrapf(err, "error validating image digest %q", string(i.Digest))
+			return fmt.Errorf("error validating image digest %q: %w", string(i.Digest), err)
 		}
 		digests[i.Digest] = struct{}{}
 		validDigests = append(validDigests, i.Digest)
@@ -242,7 +243,7 @@ func (i *Image) recomputeDigests() error {
 			continue
 		}
 		if digest.Validate() != nil {
-			return errors.Wrapf(digest.Validate(), "error validating digest %q for big data item %q", string(digest), name)
+			return fmt.Errorf("error validating digest %q for big data item %q: %w", string(digest), name, digest.Validate())
 		}
 		// Deduplicate the digest values.
 		if _, known := digests[digest]; !known {
@@ -283,7 +284,7 @@ func (r *imageStore) Load() error {
 			// Compute the digest list.
 			err = image.recomputeDigests()
 			if err != nil {
-				return errors.Wrapf(err, "error computing digests for image with ID %q (%v)", image.ID, image.Names)
+				return fmt.Errorf("error computing digests for image with ID %q (%v): %w", image.ID, image.Names, err)
 			}
 			for _, name := range image.Names {
 				names[name] = image
@@ -311,7 +312,7 @@ func (r *imageStore) Load() error {
 
 func (r *imageStore) Save() error {
 	if !r.IsReadWrite() {
-		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to modify the image store at %q", r.imagespath())
+		return fmt.Errorf("not allowed to modify the image store at %q: %w", r.imagespath(), ErrStoreIsReadOnly)
 	}
 	if !r.Locked() {
 		return errors.New("image store is not locked for writing")
@@ -387,11 +388,11 @@ func (r *imageStore) lookup(id string) (*Image, bool) {
 
 func (r *imageStore) ClearFlag(id string, flag string) error {
 	if !r.IsReadWrite() {
-		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to clear flags on images at %q", r.imagespath())
+		return fmt.Errorf("not allowed to clear flags on images at %q: %w", r.imagespath(), ErrStoreIsReadOnly)
 	}
 	image, ok := r.lookup(id)
 	if !ok {
-		return errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
+		return fmt.Errorf("error locating image with ID %q: %w", id, ErrImageUnknown)
 	}
 	delete(image.Flags, flag)
 	return r.Save()
@@ -399,11 +400,11 @@ func (r *imageStore) ClearFlag(id string, flag string) error {
 
 func (r *imageStore) SetFlag(id string, flag string, value interface{}) error {
 	if !r.IsReadWrite() {
-		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to set flags on images at %q", r.imagespath())
+		return fmt.Errorf("not allowed to set flags on images at %q: %w", r.imagespath(), ErrStoreIsReadOnly)
 	}
 	image, ok := r.lookup(id)
 	if !ok {
-		return errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
+		return fmt.Errorf("error locating image with ID %q: %w", id, ErrImageUnknown)
 	}
 	if image.Flags == nil {
 		image.Flags = make(map[string]interface{})
@@ -414,7 +415,7 @@ func (r *imageStore) SetFlag(id string, flag string, value interface{}) error {
 
 func (r *imageStore) Create(id string, names []string, layer, metadata string, created time.Time, searchableDigest digest.Digest) (image *Image, err error) {
 	if !r.IsReadWrite() {
-		return nil, errors.Wrapf(ErrStoreIsReadOnly, "not allowed to create new images at %q", r.imagespath())
+		return nil, fmt.Errorf("not allowed to create new images at %q: %w", r.imagespath(), ErrStoreIsReadOnly)
 	}
 	if id == "" {
 		id = stringid.GenerateRandomID()
@@ -425,12 +426,12 @@ func (r *imageStore) Create(id string, names []string, layer, metadata string, c
 		}
 	}
 	if _, idInUse := r.byid[id]; idInUse {
-		return nil, errors.Wrapf(ErrDuplicateID, "an image with ID %q already exists", id)
+		return nil, fmt.Errorf("an image with ID %q already exists: %w", id, ErrDuplicateID)
 	}
 	names = dedupeNames(names)
 	for _, name := range names {
 		if image, nameInUse := r.byname[name]; nameInUse {
-			return nil, errors.Wrapf(ErrDuplicateName, "image name %q is already associated with image %q", name, image.ID)
+			return nil, fmt.Errorf("image name %q is already associated with image %q: %w", name, image.ID, ErrDuplicateName)
 		}
 	}
 	if created.IsZero() {
@@ -452,7 +453,7 @@ func (r *imageStore) Create(id string, names []string, layer, metadata string, c
 	}
 	err = image.recomputeDigests()
 	if err != nil {
-		return nil, errors.Wrapf(err, "error validating digests for new image")
+		return nil, fmt.Errorf("error validating digests for new image: %w", err)
 	}
 	r.images = append(r.images, image)
 	r.idindex.Add(id)
@@ -474,7 +475,7 @@ func (r *imageStore) addMappedTopLayer(id, layer string) error {
 		image.MappedTopLayers = append(image.MappedTopLayers, layer)
 		return r.Save()
 	}
-	return errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
+	return fmt.Errorf("error locating image with ID %q: %w", id, ErrImageUnknown)
 }
 
 func (r *imageStore) removeMappedTopLayer(id, layer string) error {
@@ -487,25 +488,25 @@ func (r *imageStore) removeMappedTopLayer(id, layer string) error {
 		}
 		return r.Save()
 	}
-	return errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
+	return fmt.Errorf("error locating image with ID %q: %w", id, ErrImageUnknown)
 }
 
 func (r *imageStore) Metadata(id string) (string, error) {
 	if image, ok := r.lookup(id); ok {
 		return image.Metadata, nil
 	}
-	return "", errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
+	return "", fmt.Errorf("error locating image with ID %q: %w", id, ErrImageUnknown)
 }
 
 func (r *imageStore) SetMetadata(id, metadata string) error {
 	if !r.IsReadWrite() {
-		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to modify image metadata at %q", r.imagespath())
+		return fmt.Errorf("not allowed to modify image metadata at %q: %w", r.imagespath(), ErrStoreIsReadOnly)
 	}
 	if image, ok := r.lookup(id); ok {
 		image.Metadata = metadata
 		return r.Save()
 	}
-	return errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
+	return fmt.Errorf("error locating image with ID %q: %w", id, ErrImageUnknown)
 }
 
 func (r *imageStore) removeName(image *Image, name string) {
@@ -531,11 +532,11 @@ func (r *imageStore) RemoveNames(id string, names []string) error {
 
 func (r *imageStore) updateNames(id string, names []string, op updateNameOperation) error {
 	if !r.IsReadWrite() {
-		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to change image name assignments at %q", r.imagespath())
+		return fmt.Errorf("not allowed to change image name assignments at %q: %w", r.imagespath(), ErrStoreIsReadOnly)
 	}
 	image, ok := r.lookup(id)
 	if !ok {
-		return errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
+		return fmt.Errorf("error locating image with ID %q: %w", id, ErrImageUnknown)
 	}
 	oldNames := image.Names
 	names, err := applyNameOperation(oldNames, names, op)
@@ -558,11 +559,11 @@ func (r *imageStore) updateNames(id string, names []string, op updateNameOperati
 
 func (r *imageStore) Delete(id string) error {
 	if !r.IsReadWrite() {
-		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to delete images at %q", r.imagespath())
+		return fmt.Errorf("not allowed to delete images at %q: %w", r.imagespath(), ErrStoreIsReadOnly)
 	}
 	image, ok := r.lookup(id)
 	if !ok {
-		return errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
+		return fmt.Errorf("error locating image with ID %q: %w", id, ErrImageUnknown)
 	}
 	id = image.ID
 	toDeleteIndex := -1
@@ -605,14 +606,14 @@ func (r *imageStore) Get(id string) (*Image, error) {
 	if image, ok := r.lookup(id); ok {
 		return copyImage(image), nil
 	}
-	return nil, errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
+	return nil, fmt.Errorf("error locating image with ID %q: %w", id, ErrImageUnknown)
 }
 
 func (r *imageStore) Lookup(name string) (id string, err error) {
 	if image, ok := r.lookup(name); ok {
 		return image.ID, nil
 	}
-	return "", errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
+	return "", fmt.Errorf("error locating image with ID %q: %w", id, ErrImageUnknown)
 }
 
 func (r *imageStore) Exists(id string) bool {
@@ -624,27 +625,27 @@ func (r *imageStore) ByDigest(d digest.Digest) ([]*Image, error) {
 	if images, ok := r.bydigest[d]; ok {
 		return copyImageSlice(images), nil
 	}
-	return nil, errors.Wrapf(ErrImageUnknown, "error locating image with digest %q", d)
+	return nil, fmt.Errorf("error locating image with digest %q: %w", d, ErrImageUnknown)
 }
 
 func (r *imageStore) BigData(id, key string) ([]byte, error) {
 	if key == "" {
-		return nil, errors.Wrapf(ErrInvalidBigDataName, "can't retrieve image big data value for empty name")
+		return nil, fmt.Errorf("can't retrieve image big data value for empty name: %w", ErrInvalidBigDataName)
 	}
 	image, ok := r.lookup(id)
 	if !ok {
-		return nil, errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
+		return nil, fmt.Errorf("error locating image with ID %q: %w", id, ErrImageUnknown)
 	}
 	return ioutil.ReadFile(r.datapath(image.ID, key))
 }
 
 func (r *imageStore) BigDataSize(id, key string) (int64, error) {
 	if key == "" {
-		return -1, errors.Wrapf(ErrInvalidBigDataName, "can't retrieve size of image big data with empty name")
+		return -1, fmt.Errorf("can't retrieve size of image big data with empty name: %w", ErrInvalidBigDataName)
 	}
 	image, ok := r.lookup(id)
 	if !ok {
-		return -1, errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
+		return -1, fmt.Errorf("error locating image with ID %q: %w", id, ErrImageUnknown)
 	}
 	if image.BigDataSizes == nil {
 		image.BigDataSizes = make(map[string]int64)
@@ -660,11 +661,11 @@ func (r *imageStore) BigDataSize(id, key string) (int64, error) {
 
 func (r *imageStore) BigDataDigest(id, key string) (digest.Digest, error) {
 	if key == "" {
-		return "", errors.Wrapf(ErrInvalidBigDataName, "can't retrieve digest of image big data value with empty name")
+		return "", fmt.Errorf("can't retrieve digest of image big data value with empty name: %w", ErrInvalidBigDataName)
 	}
 	image, ok := r.lookup(id)
 	if !ok {
-		return "", errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
+		return "", fmt.Errorf("error locating image with ID %q: %w", id, ErrImageUnknown)
 	}
 	if image.BigDataDigests == nil {
 		image.BigDataDigests = make(map[string]digest.Digest)
@@ -678,7 +679,7 @@ func (r *imageStore) BigDataDigest(id, key string) (digest.Digest, error) {
 func (r *imageStore) BigDataNames(id string) ([]string, error) {
 	image, ok := r.lookup(id)
 	if !ok {
-		return nil, errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
+		return nil, fmt.Errorf("error locating image with ID %q: %w", id, ErrImageUnknown)
 	}
 	return copyStringSlice(image.BigDataNames), nil
 }
@@ -696,14 +697,14 @@ func imageSliceWithoutValue(slice []*Image, value *Image) []*Image {
 
 func (r *imageStore) SetBigData(id, key string, data []byte, digestManifest func([]byte) (digest.Digest, error)) error {
 	if key == "" {
-		return errors.Wrapf(ErrInvalidBigDataName, "can't set empty name for image big data item")
+		return fmt.Errorf("can't set empty name for image big data item: %w", ErrInvalidBigDataName)
 	}
 	if !r.IsReadWrite() {
-		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to save data items associated with images at %q", r.imagespath())
+		return fmt.Errorf("not allowed to save data items associated with images at %q: %w", r.imagespath(), ErrStoreIsReadOnly)
 	}
 	image, ok := r.lookup(id)
 	if !ok {
-		return errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
+		return fmt.Errorf("error locating image with ID %q: %w", id, ErrImageUnknown)
 	}
 	err := os.MkdirAll(r.datadir(image.ID), 0700)
 	if err != nil {
@@ -712,10 +713,10 @@ func (r *imageStore) SetBigData(id, key string, data []byte, digestManifest func
 	var newDigest digest.Digest
 	if bigDataNameIsManifest(key) {
 		if digestManifest == nil {
-			return errors.Wrapf(ErrDigestUnknown, "error digesting manifest: no manifest digest callback provided")
+			return fmt.Errorf("error digesting manifest: no manifest digest callback provided: %w", ErrDigestUnknown)
 		}
 		if newDigest, err = digestManifest(data); err != nil {
-			return errors.Wrapf(err, "error digesting manifest")
+			return fmt.Errorf("error digesting manifest: %w", err)
 		}
 	} else {
 		newDigest = digest.Canonical.FromBytes(data)
@@ -759,7 +760,7 @@ func (r *imageStore) SetBigData(id, key string, data []byte, digestManifest func
 			}
 		}
 		if err = image.recomputeDigests(); err != nil {
-			return errors.Wrapf(err, "error loading recomputing image digest information for %s", image.ID)
+			return fmt.Errorf("error loading recomputing image digest information for %s: %w", image.ID, err)
 		}
 		for _, newDigest := range image.Digests {
 			// add the image to the list of images in the digest-based index which
@@ -780,7 +781,7 @@ func (r *imageStore) SetBigData(id, key string, data []byte, digestManifest func
 
 func (r *imageStore) Wipe() error {
 	if !r.IsReadWrite() {
-		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to delete images at %q", r.imagespath())
+		return fmt.Errorf("not allowed to delete images at %q: %w", r.imagespath(), ErrStoreIsReadOnly)
 	}
 	ids := make([]string, 0, len(r.byid))
 	for id := range r.byid {

--- a/layers.go
+++ b/layers.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -27,7 +28,6 @@ import (
 	"github.com/klauspost/pgzip"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/opencontainers/selinux/go-selinux/label"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/vbatts/tar-split/archive/tar"
 	"github.com/vbatts/tar-split/tar/asm"
@@ -481,7 +481,7 @@ func (r *layerStore) Save() error {
 
 func (r *layerStore) saveLayers() error {
 	if !r.IsReadWrite() {
-		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to modify the layer store at %q", r.layerspath())
+		return fmt.Errorf("not allowed to modify the layer store at %q: %w", r.layerspath(), ErrStoreIsReadOnly)
 	}
 	if !r.Locked() {
 		return errors.New("layer store is not locked for writing")
@@ -500,7 +500,7 @@ func (r *layerStore) saveLayers() error {
 
 func (r *layerStore) saveMounts() error {
 	if !r.IsReadWrite() {
-		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to modify the layer store at %q", r.layerspath())
+		return fmt.Errorf("not allowed to modify the layer store at %q: %w", r.layerspath(), ErrStoreIsReadOnly)
 	}
 	if !r.mountsLockfile.Locked() {
 		return errors.New("layer store mount information is not locked for writing")
@@ -611,7 +611,7 @@ func (r *layerStore) Size(name string) (int64, error) {
 
 func (r *layerStore) ClearFlag(id string, flag string) error {
 	if !r.IsReadWrite() {
-		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to clear flags on layers at %q", r.layerspath())
+		return fmt.Errorf("not allowed to clear flags on layers at %q: %w", r.layerspath(), ErrStoreIsReadOnly)
 	}
 	layer, ok := r.lookup(id)
 	if !ok {
@@ -623,7 +623,7 @@ func (r *layerStore) ClearFlag(id string, flag string) error {
 
 func (r *layerStore) SetFlag(id string, flag string, value interface{}) error {
 	if !r.IsReadWrite() {
-		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to set flags on layers at %q", r.layerspath())
+		return fmt.Errorf("not allowed to set flags on layers at %q: %w", r.layerspath(), ErrStoreIsReadOnly)
 	}
 	layer, ok := r.lookup(id)
 	if !ok {
@@ -694,7 +694,7 @@ func (r *layerStore) PutAdditionalLayer(id string, parentLayer *Layer, names []s
 
 func (r *layerStore) Put(id string, parentLayer *Layer, names []string, mountLabel string, options map[string]string, moreOptions *LayerOptions, writeable bool, flags map[string]interface{}, diff io.Reader) (*Layer, int64, error) {
 	if !r.IsReadWrite() {
-		return nil, -1, errors.Wrapf(ErrStoreIsReadOnly, "not allowed to create new layers at %q", r.layerspath())
+		return nil, -1, fmt.Errorf("not allowed to create new layers at %q: %w", r.layerspath(), ErrStoreIsReadOnly)
 	}
 	if err := os.MkdirAll(r.rundir, 0700); err != nil {
 		return nil, -1, err
@@ -824,19 +824,19 @@ func (r *layerStore) Put(id string, parentLayer *Layer, names []string, mountLab
 	if moreOptions.TemplateLayer != "" {
 		if err := r.driver.CreateFromTemplate(id, moreOptions.TemplateLayer, templateIDMappings, parent, parentMappings, &opts, writeable); err != nil {
 			cleanupFailureContext = "creating a layer from template"
-			return nil, -1, errors.Wrapf(err, "error creating copy of template layer %q with ID %q", moreOptions.TemplateLayer, id)
+			return nil, -1, fmt.Errorf("error creating copy of template layer %q with ID %q: %w", moreOptions.TemplateLayer, id, err)
 		}
 		oldMappings = templateIDMappings
 	} else {
 		if writeable {
 			if err := r.driver.CreateReadWrite(id, parent, &opts); err != nil {
 				cleanupFailureContext = "creating a read-write layer"
-				return nil, -1, errors.Wrapf(err, "error creating read-write layer with ID %q", id)
+				return nil, -1, fmt.Errorf("error creating read-write layer with ID %q: %w", id, err)
 			}
 		} else {
 			if err := r.driver.Create(id, parent, &opts); err != nil {
 				cleanupFailureContext = "creating a read-only layer"
-				return nil, -1, errors.Wrapf(err, "error creating layer with ID %q", id)
+				return nil, -1, fmt.Errorf("error creating layer with ID %q: %w", id, err)
 			}
 		}
 		oldMappings = parentMappings
@@ -897,7 +897,7 @@ func (r *layerStore) Create(id string, parent *Layer, names []string, mountLabel
 
 func (r *layerStore) Mounted(id string) (int, error) {
 	if !r.IsReadWrite() {
-		return 0, errors.Wrapf(ErrStoreIsReadOnly, "no mount information for layers at %q", r.mountspath())
+		return 0, fmt.Errorf("no mount information for layers at %q: %w", r.mountspath(), ErrStoreIsReadOnly)
 	}
 	r.mountsLockfile.RLock()
 	defer r.mountsLockfile.Unlock()
@@ -927,7 +927,7 @@ func (r *layerStore) Mount(id string, options drivers.MountOpts) (string, error)
 	// You are not allowed to mount layers from readonly stores if they
 	// are not mounted read/only.
 	if !r.IsReadWrite() && !hasReadOnlyOpt(options.Options) {
-		return "", errors.Wrapf(ErrStoreIsReadOnly, "not allowed to update mount locations for layers at %q", r.mountspath())
+		return "", fmt.Errorf("not allowed to update mount locations for layers at %q: %w", r.mountspath(), ErrStoreIsReadOnly)
 	}
 	r.mountsLockfile.Lock()
 	defer r.mountsLockfile.Unlock()
@@ -978,7 +978,7 @@ func (r *layerStore) Mount(id string, options drivers.MountOpts) (string, error)
 
 func (r *layerStore) Unmount(id string, force bool) (bool, error) {
 	if !r.IsReadWrite() {
-		return false, errors.Wrapf(ErrStoreIsReadOnly, "not allowed to update mount locations for layers at %q", r.mountspath())
+		return false, fmt.Errorf("not allowed to update mount locations for layers at %q: %w", r.mountspath(), ErrStoreIsReadOnly)
 	}
 	r.mountsLockfile.Lock()
 	defer r.mountsLockfile.Unlock()
@@ -1017,7 +1017,7 @@ func (r *layerStore) Unmount(id string, force bool) (bool, error) {
 
 func (r *layerStore) ParentOwners(id string) (uids, gids []int, err error) {
 	if !r.IsReadWrite() {
-		return nil, nil, errors.Wrapf(ErrStoreIsReadOnly, "no mount information for layers at %q", r.mountspath())
+		return nil, nil, fmt.Errorf("no mount information for layers at %q: %w", r.mountspath(), ErrStoreIsReadOnly)
 	}
 	r.mountsLockfile.RLock()
 	defer r.mountsLockfile.Unlock()
@@ -1040,7 +1040,7 @@ func (r *layerStore) ParentOwners(id string) (uids, gids []int, err error) {
 	}
 	rootuid, rootgid, err := idtools.GetRootUIDGID(layer.UIDMap, layer.GIDMap)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "error reading root ID values for layer %q", layer.ID)
+		return nil, nil, fmt.Errorf("error reading root ID values for layer %q: %w", layer.ID, err)
 	}
 	m := idtools.NewIDMappingsFromMaps(layer.UIDMap, layer.GIDMap)
 	fsuids := make(map[int]struct{})
@@ -1048,7 +1048,7 @@ func (r *layerStore) ParentOwners(id string) (uids, gids []int, err error) {
 	for dir := filepath.Dir(layer.MountPoint); dir != "" && dir != string(os.PathSeparator); dir = filepath.Dir(dir) {
 		st, err := system.Stat(dir)
 		if err != nil {
-			return nil, nil, errors.Wrap(err, "read directory ownership")
+			return nil, nil, fmt.Errorf("read directory ownership: %w", err)
 		}
 		lst, err := system.Lstat(dir)
 		if err != nil {
@@ -1105,7 +1105,7 @@ func (r *layerStore) RemoveNames(id string, names []string) error {
 
 func (r *layerStore) updateNames(id string, names []string, op updateNameOperation) error {
 	if !r.IsReadWrite() {
-		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to change layer name assignments at %q", r.layerspath())
+		return fmt.Errorf("not allowed to change layer name assignments at %q: %w", r.layerspath(), ErrStoreIsReadOnly)
 	}
 	layer, ok := r.lookup(id)
 	if !ok {
@@ -1139,25 +1139,25 @@ func (r *layerStore) datapath(id, key string) string {
 
 func (r *layerStore) BigData(id, key string) (io.ReadCloser, error) {
 	if key == "" {
-		return nil, errors.Wrapf(ErrInvalidBigDataName, "can't retrieve layer big data value for empty name")
+		return nil, fmt.Errorf("can't retrieve layer big data value for empty name: %w", ErrInvalidBigDataName)
 	}
 	layer, ok := r.lookup(id)
 	if !ok {
-		return nil, errors.Wrapf(ErrLayerUnknown, "error locating layer with ID %q", id)
+		return nil, fmt.Errorf("error locating layer with ID %q: %w", id, ErrLayerUnknown)
 	}
 	return os.Open(r.datapath(layer.ID, key))
 }
 
 func (r *layerStore) SetBigData(id, key string, data io.Reader) error {
 	if key == "" {
-		return errors.Wrapf(ErrInvalidBigDataName, "can't set empty name for layer big data item")
+		return fmt.Errorf("can't set empty name for layer big data item: %w", ErrInvalidBigDataName)
 	}
 	if !r.IsReadWrite() {
-		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to save data items associated with layers at %q", r.layerspath())
+		return fmt.Errorf("not allowed to save data items associated with layers at %q: %w", r.layerspath(), ErrStoreIsReadOnly)
 	}
 	layer, ok := r.lookup(id)
 	if !ok {
-		return errors.Wrapf(ErrLayerUnknown, "error locating layer with ID %q to write bigdata", id)
+		return fmt.Errorf("error locating layer with ID %q to write bigdata: %w", id, ErrLayerUnknown)
 	}
 	err := os.MkdirAll(r.datadir(layer.ID), 0700)
 	if err != nil {
@@ -1169,16 +1169,16 @@ func (r *layerStore) SetBigData(id, key string, data io.Reader) error {
 	// so that it is either accessing the old data or the new one.
 	writer, err := ioutils.NewAtomicFileWriter(r.datapath(layer.ID, key), 0600)
 	if err != nil {
-		return errors.Wrapf(err, "error opening bigdata file")
+		return fmt.Errorf("error opening bigdata file: %w", err)
 	}
 
 	if _, err := io.Copy(writer, data); err != nil {
 		writer.Close()
-		return errors.Wrapf(err, "error copying bigdata for the layer")
+		return fmt.Errorf("error copying bigdata for the layer: %w", err)
 
 	}
 	if err := writer.Close(); err != nil {
-		return errors.Wrapf(err, "error closing bigdata file for the layer")
+		return fmt.Errorf("error closing bigdata file for the layer: %w", err)
 	}
 
 	addName := true
@@ -1198,7 +1198,7 @@ func (r *layerStore) SetBigData(id, key string, data io.Reader) error {
 func (r *layerStore) BigDataNames(id string) ([]string, error) {
 	layer, ok := r.lookup(id)
 	if !ok {
-		return nil, errors.Wrapf(ErrImageUnknown, "error locating layer with ID %q to retrieve bigdata names", id)
+		return nil, fmt.Errorf("error locating layer with ID %q to retrieve bigdata names: %w", id, ErrImageUnknown)
 	}
 	return copyStringSlice(layer.BigDataNames), nil
 }
@@ -1212,7 +1212,7 @@ func (r *layerStore) Metadata(id string) (string, error) {
 
 func (r *layerStore) SetMetadata(id, metadata string) error {
 	if !r.IsReadWrite() {
-		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to modify layer metadata at %q", r.layerspath())
+		return fmt.Errorf("not allowed to modify layer metadata at %q: %w", r.layerspath(), ErrStoreIsReadOnly)
 	}
 	if layer, ok := r.lookup(id); ok {
 		layer.Metadata = metadata
@@ -1238,7 +1238,7 @@ func layerHasIncompleteFlag(layer *Layer) bool {
 
 func (r *layerStore) deleteInternal(id string) error {
 	if !r.IsReadWrite() {
-		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to delete layers at %q", r.layerspath())
+		return fmt.Errorf("not allowed to delete layers at %q: %w", r.layerspath(), ErrStoreIsReadOnly)
 	}
 	layer, ok := r.lookup(id)
 	if !ok {
@@ -1337,7 +1337,7 @@ func (r *layerStore) Delete(id string) error {
 	// driver level.
 	mountCount, err := r.Mounted(id)
 	if err != nil {
-		return errors.Wrapf(err, "error checking if layer %q is still mounted", id)
+		return fmt.Errorf("error checking if layer %q is still mounted: %w", id, err)
 	}
 	for mountCount > 0 {
 		if _, err := r.Unmount(id, false); err != nil {
@@ -1345,7 +1345,7 @@ func (r *layerStore) Delete(id string) error {
 		}
 		mountCount, err = r.Mounted(id)
 		if err != nil {
-			return errors.Wrapf(err, "error checking if layer %q is still mounted", id)
+			return fmt.Errorf("error checking if layer %q is still mounted: %w", id, err)
 		}
 	}
 	if err := r.deleteInternal(id); err != nil {
@@ -1375,7 +1375,7 @@ func (r *layerStore) Get(id string) (*Layer, error) {
 
 func (r *layerStore) Wipe() error {
 	if !r.IsReadWrite() {
-		return errors.Wrapf(ErrStoreIsReadOnly, "not allowed to delete layers at %q", r.layerspath())
+		return fmt.Errorf("not allowed to delete layers at %q: %w", r.layerspath(), ErrStoreIsReadOnly)
 	}
 	ids := make([]string, 0, len(r.byid))
 	for id := range r.byid {
@@ -1530,7 +1530,7 @@ func (r *layerStore) Diff(from, to string, options *DiffOptions) (io.ReadCloser,
 				diff, err := archive.DecompressStream(blob)
 				if err != nil {
 					if err2 := blob.Close(); err2 != nil {
-						err = errors.Wrapf(err, "failed to close blob file: %v", err2)
+						err = fmt.Errorf("failed to close blob file: %v: %w", err2, err)
 					}
 					aLayer.Release()
 					return nil, err
@@ -1538,7 +1538,7 @@ func (r *layerStore) Diff(from, to string, options *DiffOptions) (io.ReadCloser,
 				rc, err := maybeCompressReadCloser(diff)
 				if err != nil {
 					if err2 := closeAll(blob.Close, diff.Close); err2 != nil {
-						err = errors.Wrapf(err, "failed to cleanup: %v", err2)
+						err = fmt.Errorf("failed to cleanup: %v: %w", err2, err)
 					}
 					aLayer.Release()
 					return nil, err
@@ -1576,12 +1576,12 @@ func (r *layerStore) Diff(from, to string, options *DiffOptions) (io.ReadCloser,
 
 	fgetter, err := r.newFileGetter(to)
 	if err != nil {
-		errs := multierror.Append(nil, errors.Wrapf(err, "creating file-getter"))
+		errs := multierror.Append(nil, fmt.Errorf("creating file-getter: %w", err))
 		if err := decompressor.Close(); err != nil {
-			errs = multierror.Append(errs, errors.Wrapf(err, "closing decompressor"))
+			errs = multierror.Append(errs, fmt.Errorf("closing decompressor: %w", err))
 		}
 		if err := tsfile.Close(); err != nil {
-			errs = multierror.Append(errs, errors.Wrapf(err, "closing tarstream headers"))
+			errs = multierror.Append(errs, fmt.Errorf("closing tarstream headers: %w", err))
 		}
 		return nil, errs.ErrorOrNil()
 	}
@@ -1590,16 +1590,16 @@ func (r *layerStore) Diff(from, to string, options *DiffOptions) (io.ReadCloser,
 	rc := ioutils.NewReadCloserWrapper(tarstream, func() error {
 		var errs *multierror.Error
 		if err := decompressor.Close(); err != nil {
-			errs = multierror.Append(errs, errors.Wrapf(err, "closing decompressor"))
+			errs = multierror.Append(errs, fmt.Errorf("closing decompressor: %w", err))
 		}
 		if err := tsfile.Close(); err != nil {
-			errs = multierror.Append(errs, errors.Wrapf(err, "closing tarstream headers"))
+			errs = multierror.Append(errs, fmt.Errorf("closing tarstream headers: %w", err))
 		}
 		if err := tarstream.Close(); err != nil {
-			errs = multierror.Append(errs, errors.Wrapf(err, "closing reconstructed tarstream"))
+			errs = multierror.Append(errs, fmt.Errorf("closing reconstructed tarstream: %w", err))
 		}
 		if err := fgetter.Close(); err != nil {
-			errs = multierror.Append(errs, errors.Wrapf(err, "closing file-getter"))
+			errs = multierror.Append(errs, fmt.Errorf("closing file-getter: %w", err))
 		}
 		if errs != nil {
 			return errs.ErrorOrNil()
@@ -1624,7 +1624,7 @@ func (r *layerStore) ApplyDiff(to string, diff io.Reader) (size int64, err error
 
 func (r *layerStore) applyDiffWithOptions(to string, layerOptions *LayerOptions, diff io.Reader) (size int64, err error) {
 	if !r.IsReadWrite() {
-		return -1, errors.Wrapf(ErrStoreIsReadOnly, "not allowed to modify layer contents at %q", r.layerspath())
+		return -1, fmt.Errorf("not allowed to modify layer contents at %q: %w", r.layerspath(), ErrStoreIsReadOnly)
 	}
 
 	layer, ok := r.lookup(to)
@@ -1920,7 +1920,7 @@ func (r *layerStore) Modified() (bool, error) {
 	// reload the storage in any case.
 	info, err := os.Stat(r.layerspath())
 	if err != nil && !os.IsNotExist(err) {
-		return false, errors.Wrap(err, "stat layers file")
+		return false, fmt.Errorf("stat layers file: %w", err)
 	}
 	if info != nil {
 		tmodified = info.ModTime() != r.layerspathModified
@@ -1957,10 +1957,10 @@ func closeAll(closes ...func() error) (rErr error) {
 	for _, f := range closes {
 		if err := f(); err != nil {
 			if rErr == nil {
-				rErr = errors.Wrapf(err, "close error")
+				rErr = fmt.Errorf("close error: %w", err)
 				continue
 			}
-			rErr = errors.Wrapf(rErr, "%v", err)
+			rErr = fmt.Errorf("%v: %w", err, rErr)
 		}
 	}
 	return

--- a/pkg/chrootarchive/archive.go
+++ b/pkg/chrootarchive/archive.go
@@ -12,7 +12,6 @@ import (
 	"github.com/containers/storage/pkg/archive"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/opencontainers/runc/libcontainer/userns"
-	"github.com/pkg/errors"
 )
 
 // NewArchiver returns a new Archiver which uses chrootarchive.Untar
@@ -115,7 +114,7 @@ func CopyFileWithTarAndChown(chownOpts *idtools.IDPair, hasher io.Writer, uidmap
 		archiver.Untar = func(tarArchive io.Reader, dest string, options *archive.TarOptions) error {
 			contentReader, contentWriter, err := os.Pipe()
 			if err != nil {
-				return errors.Wrapf(err, "error creating pipe extract data to %q", dest)
+				return fmt.Errorf("error creating pipe extract data to %q: %w", dest, err)
 			}
 			defer contentReader.Close()
 			defer contentWriter.Close()
@@ -134,11 +133,11 @@ func CopyFileWithTarAndChown(chownOpts *idtools.IDPair, hasher io.Writer, uidmap
 				hashWorker.Done()
 			}()
 			if err = originalUntar(io.TeeReader(tarArchive, contentWriter), dest, options); err != nil {
-				err = errors.Wrapf(err, "error extracting data to %q while copying", dest)
+				err = fmt.Errorf("error extracting data to %q while copying: %w", dest, err)
 			}
 			hashWorker.Wait()
 			if err == nil {
-				err = errors.Wrapf(hashError, "error calculating digest of data for %q while copying", dest)
+				err = fmt.Errorf("error calculating digest of data for %q while copying: %w", dest, hashError)
 			}
 			return err
 		}

--- a/pkg/chunked/cache_linux.go
+++ b/pkg/chunked/cache_linux.go
@@ -3,6 +3,7 @@ package chunked
 import (
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -19,7 +20,6 @@ import (
 	"github.com/containers/storage/pkg/ioutils"
 	jsoniter "github.com/json-iterator/go"
 	digest "github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -117,7 +117,7 @@ func (c *layersCache) load() error {
 				continue
 			}
 			logrus.Warningf("Error reading cache file for layer %q: %v", r.ID, err)
-		} else if errors.Cause(err) != os.ErrNotExist {
+		} else if !errors.Is(err, os.ErrNotExist) {
 			return err
 		}
 

--- a/pkg/chunked/compression.go
+++ b/pkg/chunked/compression.go
@@ -4,6 +4,7 @@ import (
 	archivetar "archive/tar"
 	"bytes"
 	"encoding/binary"
+	"errors"
 	"fmt"
 	"io"
 	"strconv"
@@ -14,7 +15,6 @@ import (
 	"github.com/klauspost/compress/zstd"
 	"github.com/klauspost/pgzip"
 	digest "github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
 	"github.com/vbatts/tar-split/archive/tar"
 )
 
@@ -92,7 +92,7 @@ func readEstargzChunkedManifest(blobStream ImageSourceSeekable, blobSize int64, 
 	*/
 	tocOffset, err := strconv.ParseInt(string(footer[16:16+22-6]), 16, 64)
 	if err != nil {
-		return nil, 0, errors.Wrap(err, "parse ToC offset")
+		return nil, 0, fmt.Errorf("parse ToC offset: %w", err)
 	}
 
 	size := int64(blobSize - footerSize - tocOffset)

--- a/pkg/chunked/storage_linux.go
+++ b/pkg/chunked/storage_linux.go
@@ -4,6 +4,7 @@ import (
 	archivetar "archive/tar"
 	"context"
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"hash"
 	"io"
@@ -31,7 +32,6 @@ import (
 	"github.com/klauspost/compress/zstd"
 	"github.com/klauspost/pgzip"
 	digest "github.com/opencontainers/go-digest"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/vbatts/tar-split/archive/tar"
 	"golang.org/x/sys/unix"
@@ -406,7 +406,7 @@ func (o *originFile) OpenFile() (io.ReadCloser, error) {
 // setFileAttrs sets the file attributes for file given metadata
 func setFileAttrs(dirfd int, file *os.File, mode os.FileMode, metadata *internal.FileMetadata, options *archive.TarOptions, usePath bool) error {
 	if file == nil || file.Fd() < 0 {
-		return errors.Errorf("invalid file")
+		return errors.New("invalid file")
 	}
 	fd := int(file.Fd())
 
@@ -847,10 +847,10 @@ func (c *chunkedDiffer) storeMissingFiles(streams chan io.ReadCloser, errs chan 
 				return err
 			}
 			if part == nil {
-				return errors.Errorf("invalid stream returned")
+				return errors.New("invalid stream returned")
 			}
 		default:
-			return errors.Errorf("internal error: missing part misses both local and remote data stream")
+			return errors.New("internal error: missing part misses both local and remote data stream")
 		}
 
 		for _, mf := range missingPart.Chunks {
@@ -865,7 +865,7 @@ func (c *chunkedDiffer) storeMissingFiles(streams chan io.ReadCloser, errs chan 
 			}
 
 			if mf.File.Name == "" {
-				Err = errors.Errorf("file name empty")
+				Err = errors.New("file name empty")
 				goto exit
 			}
 

--- a/pkg/chunked/storage_unsupported.go
+++ b/pkg/chunked/storage_unsupported.go
@@ -1,13 +1,14 @@
+//go:build !linux
 // +build !linux
 
 package chunked
 
 import (
 	"context"
+	"errors"
 
 	storage "github.com/containers/storage"
 	graphdriver "github.com/containers/storage/drivers"
-	"github.com/pkg/errors"
 )
 
 // GetDiffer returns a differ than can be used with ApplyDiffWithDiffer.

--- a/pkg/fileutils/fileutils.go
+++ b/pkg/fileutils/fileutils.go
@@ -1,6 +1,7 @@
 package fileutils
 
 import (
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -9,7 +10,6 @@ import (
 	"strings"
 	"text/scanner"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -340,13 +340,13 @@ func ReadSymlinkedDirectory(path string) (string, error) {
 // The target of the symbolic link can be a file and a directory.
 func ReadSymlinkedPath(path string) (realPath string, err error) {
 	if realPath, err = filepath.Abs(path); err != nil {
-		return "", errors.Wrapf(err, "unable to get absolute path for %q", path)
+		return "", fmt.Errorf("unable to get absolute path for %q: %w", path, err)
 	}
 	if realPath, err = filepath.EvalSymlinks(realPath); err != nil {
-		return "", errors.Wrapf(err, "failed to canonicalise path for %q", path)
+		return "", fmt.Errorf("failed to canonicalise path for %q: %w", path, err)
 	}
 	if _, err := os.Stat(realPath); err != nil {
-		return "", errors.Wrapf(err, "failed to stat target %q of %q", realPath, path)
+		return "", fmt.Errorf("failed to stat target %q of %q: %w", realPath, path, err)
 	}
 	return realPath, nil
 }

--- a/pkg/idtools/idtools.go
+++ b/pkg/idtools/idtools.go
@@ -14,7 +14,6 @@ import (
 	"syscall"
 
 	"github.com/containers/storage/pkg/system"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -362,7 +361,7 @@ func parseSubidFile(path, username string) (ranges, error) {
 
 func checkChownErr(err error, name string, uid, gid int) error {
 	if e, ok := err.(*os.PathError); ok && e.Err == syscall.EINVAL {
-		return errors.Wrapf(err, "potentially insufficient UIDs or GIDs available in user namespace (requested %d:%d for %s): Check /etc/subuid and /etc/subgid if configured locally and run podman-system-migrate", uid, gid, name)
+		return fmt.Errorf("potentially insufficient UIDs or GIDs available in user namespace (requested %d:%d for %s): Check /etc/subuid and /etc/subgid if configured locally and run podman-system-migrate: %w", uid, gid, name, err)
 	}
 	return err
 }

--- a/pkg/idtools/idtools_supported.go
+++ b/pkg/idtools/idtools_supported.go
@@ -4,10 +4,9 @@
 package idtools
 
 import (
+	"errors"
 	"os/user"
 	"unsafe"
-
-	"github.com/pkg/errors"
 )
 
 /*

--- a/pkg/lockfile/lockfile.go
+++ b/pkg/lockfile/lockfile.go
@@ -1,11 +1,10 @@
 package lockfile
 
 import (
+	"fmt"
 	"path/filepath"
 	"sync"
 	"time"
-
-	"github.com/pkg/errors"
 )
 
 // A Locker represents a file lock where the file is used to cache an
@@ -87,14 +86,14 @@ func getLockfile(path string, ro bool) (Locker, error) {
 	}
 	cleanPath, err := filepath.Abs(path)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error ensuring that path %q is an absolute path", path)
+		return nil, fmt.Errorf("error ensuring that path %q is an absolute path: %w", path, err)
 	}
 	if locker, ok := lockfiles[cleanPath]; ok {
 		if ro && locker.IsReadWrite() {
-			return nil, errors.Errorf("lock %q is not a read-only lock", cleanPath)
+			return nil, fmt.Errorf("lock %q is not a read-only lock", cleanPath)
 		}
 		if !ro && !locker.IsReadWrite() {
-			return nil, errors.Errorf("lock %q is not a read-write lock", cleanPath)
+			return nil, fmt.Errorf("lock %q is not a read-write lock", cleanPath)
 		}
 		return locker, nil
 	}

--- a/pkg/lockfile/lockfile_unix.go
+++ b/pkg/lockfile/lockfile_unix.go
@@ -15,7 +15,6 @@ import (
 	"time"
 
 	"github.com/containers/storage/pkg/system"
-	"github.com/pkg/errors"
 	"golang.org/x/sys/unix"
 )
 
@@ -86,7 +85,7 @@ func openLock(path string, ro bool) (fd int, err error) {
 	// the directory of the lockfile seems to be removed, try to create it
 	if os.IsNotExist(err) {
 		if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
-			return fd, errors.Wrap(err, "creating locker directory")
+			return fd, fmt.Errorf("creating locker directory: %w", err)
 		}
 
 		return openLock(path, ro)
@@ -112,7 +111,7 @@ func createLockerForPath(path string, ro bool) (Locker, error) {
 	// Check if we can open the lock.
 	fd, err := openLock(path, ro)
 	if err != nil {
-		return nil, errors.Wrapf(err, "error opening %q", path)
+		return nil, fmt.Errorf("error opening %q: %w", path, err)
 	}
 	unix.Close(fd)
 

--- a/pkg/system/rm.go
+++ b/pkg/system/rm.go
@@ -1,12 +1,12 @@
 package system
 
 import (
+	"fmt"
 	"os"
 	"syscall"
 	"time"
 
 	"github.com/containers/storage/pkg/mount"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -67,7 +67,7 @@ func EnsureRemoveAll(dir string) error {
 		}
 
 		if e := mount.Unmount(pe.Path); e != nil {
-			return errors.Wrapf(e, "error while removing %s", dir)
+			return fmt.Errorf("error while removing %s: %w", dir, e)
 		}
 
 		if exitOnErr[pe.Path] == maxRetry {

--- a/pkg/system/syscall_unix.go
+++ b/pkg/system/syscall_unix.go
@@ -1,9 +1,11 @@
+//go:build linux || freebsd || darwin
 // +build linux freebsd darwin
 
 package system
 
 import (
-	"github.com/pkg/errors"
+	"errors"
+
 	"golang.org/x/sys/unix"
 )
 

--- a/pkg/unshare/unshare.go
+++ b/pkg/unshare/unshare.go
@@ -6,7 +6,6 @@ import (
 	"os/user"
 	"sync"
 
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -27,7 +26,7 @@ func HomeDir() (string, error) {
 		if home == "" {
 			usr, err := user.LookupId(fmt.Sprintf("%d", GetRootlessUID()))
 			if err != nil {
-				homeDir, homeDirErr = "", errors.Wrapf(err, "unable to resolve HOME directory")
+				homeDir, homeDirErr = "", fmt.Errorf("unable to resolve HOME directory: %w", err)
 				return
 			}
 			homeDir, homeDirErr = usr.HomeDir, nil

--- a/pkg/unshare/unshare_freebsd.go
+++ b/pkg/unshare/unshare_freebsd.go
@@ -5,6 +5,7 @@ package unshare
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -14,7 +15,6 @@ import (
 	"syscall"
 
 	"github.com/containers/storage/pkg/reexec"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -49,7 +49,7 @@ func (c *Cmd) Start() error {
 	// Create the pipe for reading the child's PID.
 	pidRead, pidWrite, err := os.Pipe()
 	if err != nil {
-		return errors.Wrapf(err, "error creating pid pipe")
+		return fmt.Errorf("error creating pid pipe: %w", err)
 	}
 	c.Env = append(c.Env, fmt.Sprintf("_Containers-pid-pipe=%d", len(c.ExtraFiles)+3))
 	c.ExtraFiles = append(c.ExtraFiles, pidWrite)
@@ -59,7 +59,7 @@ func (c *Cmd) Start() error {
 	if err != nil {
 		pidRead.Close()
 		pidWrite.Close()
-		return errors.Wrapf(err, "error creating pid pipe")
+		return fmt.Errorf("error creating pid pipe: %w", err)
 	}
 	c.Env = append(c.Env, fmt.Sprintf("_Containers-continue-pipe=%d", len(c.ExtraFiles)+3))
 	c.ExtraFiles = append(c.ExtraFiles, continueRead)
@@ -108,13 +108,13 @@ func (c *Cmd) Start() error {
 	pidString := ""
 	b := new(bytes.Buffer)
 	if _, err := io.Copy(b, pidRead); err != nil {
-		return errors.Wrapf(err, "Reading child PID")
+		return fmt.Errorf("Reading child PID: %w", err)
 	}
 	pidString = b.String()
 	pid, err := strconv.Atoi(pidString)
 	if err != nil {
 		fmt.Fprintf(continueWrite, "error parsing PID %q: %v", pidString, err)
-		return errors.Wrapf(err, "error parsing PID %q", pidString)
+		return fmt.Errorf("error parsing PID %q: %w", pidString, err)
 	}
 
 	// Run any additional setup that we want to do before the child starts running proper.
@@ -157,7 +157,7 @@ func ExecRunnable(cmd Runnable, cleanup func()) {
 		os.Exit(status)
 	}
 	if err := cmd.Run(); err != nil {
-		if exitError, ok := errors.Cause(err).(*exec.ExitError); ok {
+		if exitError, ok := err.(*exec.ExitError); ok {
 			if exitError.ProcessState.Exited() {
 				if waitStatus, ok := exitError.ProcessState.Sys().(syscall.WaitStatus); ok {
 					if waitStatus.Exited() {

--- a/pkg/unshare/unshare_linux.go
+++ b/pkg/unshare/unshare_linux.go
@@ -6,6 +6,7 @@ package unshare
 import (
 	"bufio"
 	"bytes"
+	"errors"
 	"fmt"
 	"io"
 	"os"
@@ -21,7 +22,6 @@ import (
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/reexec"
 	"github.com/opencontainers/runtime-spec/specs-go"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 	"github.com/syndtr/gocapability/capability"
 )
@@ -119,7 +119,7 @@ func (c *Cmd) Start() error {
 	// Create the pipe for reading the child's PID.
 	pidRead, pidWrite, err := os.Pipe()
 	if err != nil {
-		return errors.Wrapf(err, "error creating pid pipe")
+		return fmt.Errorf("error creating pid pipe: %w", err)
 	}
 	c.Env = append(c.Env, fmt.Sprintf("_Containers-pid-pipe=%d", len(c.ExtraFiles)+3))
 	c.ExtraFiles = append(c.ExtraFiles, pidWrite)
@@ -129,7 +129,7 @@ func (c *Cmd) Start() error {
 	if err != nil {
 		pidRead.Close()
 		pidWrite.Close()
-		return errors.Wrapf(err, "error creating pid pipe")
+		return fmt.Errorf("error creating pid pipe: %w", err)
 	}
 	c.Env = append(c.Env, fmt.Sprintf("_Containers-continue-pipe=%d", len(c.ExtraFiles)+3))
 	c.ExtraFiles = append(c.ExtraFiles, continueRead)
@@ -178,13 +178,13 @@ func (c *Cmd) Start() error {
 	pidString := ""
 	b := new(bytes.Buffer)
 	if _, err := io.Copy(b, pidRead); err != nil {
-		return errors.Wrapf(err, "Reading child PID")
+		return fmt.Errorf("reading child PID: %w", err)
 	}
 	pidString = b.String()
 	pid, err := strconv.Atoi(pidString)
 	if err != nil {
 		fmt.Fprintf(continueWrite, "error parsing PID %q: %v", pidString, err)
-		return errors.Wrapf(err, "error parsing PID %q", pidString)
+		return fmt.Errorf("error parsing PID %q: %w", pidString, err)
 	}
 	pidString = fmt.Sprintf("%d", pid)
 
@@ -194,18 +194,18 @@ func (c *Cmd) Start() error {
 		setgroups, err := os.OpenFile(fmt.Sprintf("/proc/%s/setgroups", pidString), os.O_TRUNC|os.O_WRONLY, 0)
 		if err != nil {
 			fmt.Fprintf(continueWrite, "error opening setgroups: %v", err)
-			return errors.Wrapf(err, "error opening /proc/%s/setgroups", pidString)
+			return fmt.Errorf("error opening /proc/%s/setgroups: %w", pidString, err)
 		}
 		defer setgroups.Close()
 		if c.GidMappingsEnableSetgroups {
 			if _, err := fmt.Fprintf(setgroups, "allow"); err != nil {
 				fmt.Fprintf(continueWrite, "error writing \"allow\" to setgroups: %v", err)
-				return errors.Wrapf(err, "error opening \"allow\" to /proc/%s/setgroups", pidString)
+				return fmt.Errorf("error opening \"allow\" to /proc/%s/setgroups: %w", pidString, err)
 			}
 		} else {
 			if _, err := fmt.Fprintf(setgroups, "deny"); err != nil {
 				fmt.Fprintf(continueWrite, "error writing \"deny\" to setgroups: %v", err)
-				return errors.Wrapf(err, "error writing \"deny\" to /proc/%s/setgroups", pidString)
+				return fmt.Errorf("error writing \"deny\" to /proc/%s/setgroups: %w", pidString, err)
 			}
 		}
 
@@ -213,7 +213,7 @@ func (c *Cmd) Start() error {
 			uidmap, gidmap, err := GetHostIDMappings("")
 			if err != nil {
 				fmt.Fprintf(continueWrite, "Reading ID mappings in parent: %v", err)
-				return errors.Wrapf(err, "Reading ID mappings in parent")
+				return fmt.Errorf("reading ID mappings in parent: %w", err)
 			}
 			if len(c.UidMappings) == 0 {
 				c.UidMappings = uidmap
@@ -240,7 +240,7 @@ func (c *Cmd) Start() error {
 			if c.UseNewgidmap {
 				path, err := exec.LookPath("newgidmap")
 				if err != nil {
-					return errors.Wrapf(err, "error finding newgidmap")
+					return fmt.Errorf("error finding newgidmap: %w", err)
 				}
 				cmd := exec.Command(path, append([]string{pidString}, strings.Fields(strings.Replace(g.String(), "\n", " ", -1))...)...)
 				g.Reset()
@@ -268,23 +268,23 @@ func (c *Cmd) Start() error {
 					setgroups, err := os.OpenFile(fmt.Sprintf("/proc/%s/setgroups", pidString), os.O_TRUNC|os.O_WRONLY, 0)
 					if err != nil {
 						fmt.Fprintf(continueWrite, "error opening /proc/%s/setgroups: %v", pidString, err)
-						return errors.Wrapf(err, "error opening /proc/%s/setgroups", pidString)
+						return fmt.Errorf("error opening /proc/%s/setgroups: %w", pidString, err)
 					}
 					defer setgroups.Close()
 					if _, err := fmt.Fprintf(setgroups, "deny"); err != nil {
 						fmt.Fprintf(continueWrite, "error writing 'deny' to /proc/%s/setgroups: %v", pidString, err)
-						return errors.Wrapf(err, "error writing 'deny' to /proc/%s/setgroups", pidString)
+						return fmt.Errorf("error writing 'deny' to /proc/%s/setgroups: %w", pidString, err)
 					}
 				}
 				gidmap, err := os.OpenFile(fmt.Sprintf("/proc/%s/gid_map", pidString), os.O_TRUNC|os.O_WRONLY, 0)
 				if err != nil {
 					fmt.Fprintf(continueWrite, "error opening /proc/%s/gid_map: %v", pidString, err)
-					return errors.Wrapf(err, "error opening /proc/%s/gid_map", pidString)
+					return fmt.Errorf("error opening /proc/%s/gid_map: %w", pidString, err)
 				}
 				defer gidmap.Close()
 				if _, err := fmt.Fprintf(gidmap, "%s", g.String()); err != nil {
 					fmt.Fprintf(continueWrite, "error writing %q to /proc/%s/gid_map: %v", g.String(), pidString, err)
-					return errors.Wrapf(err, "error writing %q to /proc/%s/gid_map", g.String(), pidString)
+					return fmt.Errorf("error writing %q to /proc/%s/gid_map: %w", g.String(), pidString, err)
 				}
 			}
 		}
@@ -300,7 +300,7 @@ func (c *Cmd) Start() error {
 			if c.UseNewuidmap {
 				path, err := exec.LookPath("newuidmap")
 				if err != nil {
-					return errors.Wrapf(err, "error finding newuidmap")
+					return fmt.Errorf("error finding newuidmap: %w", err)
 				}
 				cmd := exec.Command(path, append([]string{pidString}, strings.Fields(strings.Replace(u.String(), "\n", " ", -1))...)...)
 				u.Reset()
@@ -328,12 +328,12 @@ func (c *Cmd) Start() error {
 				uidmap, err := os.OpenFile(fmt.Sprintf("/proc/%s/uid_map", pidString), os.O_TRUNC|os.O_WRONLY, 0)
 				if err != nil {
 					fmt.Fprintf(continueWrite, "error opening /proc/%s/uid_map: %v", pidString, err)
-					return errors.Wrapf(err, "error opening /proc/%s/uid_map", pidString)
+					return fmt.Errorf("error opening /proc/%s/uid_map: %w", pidString, err)
 				}
 				defer uidmap.Close()
 				if _, err := fmt.Fprintf(uidmap, "%s", u.String()); err != nil {
 					fmt.Fprintf(continueWrite, "error writing %q to /proc/%s/uid_map: %v", u.String(), pidString, err)
-					return errors.Wrapf(err, "error writing %q to /proc/%s/uid_map", u.String(), pidString)
+					return fmt.Errorf("error writing %q to /proc/%s/uid_map: %w", u.String(), pidString, err)
 				}
 			}
 		}
@@ -343,12 +343,12 @@ func (c *Cmd) Start() error {
 		oomScoreAdj, err := os.OpenFile(fmt.Sprintf("/proc/%s/oom_score_adj", pidString), os.O_TRUNC|os.O_WRONLY, 0)
 		if err != nil {
 			fmt.Fprintf(continueWrite, "error opening oom_score_adj: %v", err)
-			return errors.Wrapf(err, "error opening /proc/%s/oom_score_adj", pidString)
+			return fmt.Errorf("error opening /proc/%s/oom_score_adj: %w", pidString, err)
 		}
 		defer oomScoreAdj.Close()
 		if _, err := fmt.Fprintf(oomScoreAdj, "%d\n", *c.OOMScoreAdj); err != nil {
 			fmt.Fprintf(continueWrite, "error writing \"%d\" to oom_score_adj: %v", c.OOMScoreAdj, err)
-			return errors.Wrapf(err, "error writing \"%d\" to /proc/%s/oom_score_adj", c.OOMScoreAdj, pidString)
+			return fmt.Errorf("error writing \"%d\" to /proc/%s/oom_score_adj: %w", c.OOMScoreAdj, pidString, err)
 		}
 	}
 	// Run any additional setup that we want to do before the child starts running proper.
@@ -557,7 +557,7 @@ func ExecRunnable(cmd Runnable, cleanup func()) {
 		os.Exit(status)
 	}
 	if err := cmd.Run(); err != nil {
-		if exitError, ok := errors.Cause(err).(*exec.ExitError); ok {
+		if exitError, ok := err.(*exec.ExitError); ok {
 			if exitError.ProcessState.Exited() {
 				if waitStatus, ok := exitError.ProcessState.Sys().(syscall.WaitStatus); ok {
 					if waitStatus.Exited() {
@@ -583,7 +583,7 @@ func getHostIDMappings(path string) ([]specs.LinuxIDMapping, error) {
 	var mappings []specs.LinuxIDMapping
 	f, err := os.Open(path)
 	if err != nil {
-		return nil, errors.Wrapf(err, "Reading ID mappings from %q", path)
+		return nil, fmt.Errorf("reading ID mappings from %q: %w", path, err)
 	}
 	defer f.Close()
 	scanner := bufio.NewScanner(f)
@@ -591,19 +591,19 @@ func getHostIDMappings(path string) ([]specs.LinuxIDMapping, error) {
 		line := scanner.Text()
 		fields := strings.Fields(line)
 		if len(fields) != 3 {
-			return nil, errors.Errorf("line %q from %q has %d fields, not 3", line, path, len(fields))
+			return nil, fmt.Errorf("line %q from %q has %d fields, not 3", line, path, len(fields))
 		}
 		cid, err := strconv.ParseUint(fields[0], 10, 32)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error parsing container ID value %q from line %q in %q", fields[0], line, path)
+			return nil, fmt.Errorf("error parsing container ID value %q from line %q in %q: %w", fields[0], line, path, err)
 		}
 		hid, err := strconv.ParseUint(fields[1], 10, 32)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error parsing host ID value %q from line %q in %q", fields[1], line, path)
+			return nil, fmt.Errorf("error parsing host ID value %q from line %q in %q: %w", fields[1], line, path, err)
 		}
 		size, err := strconv.ParseUint(fields[2], 10, 32)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error parsing size value %q from line %q in %q", fields[2], line, path)
+			return nil, fmt.Errorf("error parsing size value %q from line %q in %q: %w", fields[2], line, path, err)
 		}
 		mappings = append(mappings, specs.LinuxIDMapping{ContainerID: uint32(cid), HostID: uint32(hid), Size: uint32(size)})
 	}
@@ -631,7 +631,7 @@ func GetHostIDMappings(pid string) ([]specs.LinuxIDMapping, []specs.LinuxIDMappi
 func GetSubIDMappings(user, group string) ([]specs.LinuxIDMapping, []specs.LinuxIDMapping, error) {
 	mappings, err := idtools.NewIDMappings(user, group)
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "Reading subuid mappings for user %q and subgid mappings for group %q", user, group)
+		return nil, nil, fmt.Errorf("reading subuid mappings for user %q and subgid mappings for group %q: %w", user, group, err)
 	}
 	var uidmap, gidmap []specs.LinuxIDMapping
 	for _, m := range mappings.UIDs() {

--- a/store.go
+++ b/store.go
@@ -2,6 +2,7 @@ package storage
 
 import (
 	"encoding/base64"
+	"errors"
 	"fmt"
 	"io"
 	"io/ioutil"
@@ -27,7 +28,6 @@ import (
 	"github.com/hashicorp/go-multierror"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/opencontainers/selinux/go-selinux/label"
-	"github.com/pkg/errors"
 )
 
 type updateNameOperation int
@@ -679,7 +679,7 @@ func GetStore(options types.StoreOptions) (Store, error) {
 	// if passed a run-root or graph-root alone, the other should be defaulted only error if we have neither.
 	switch {
 	case options.RunRoot == "" && options.GraphRoot == "":
-		return nil, errors.Wrap(ErrIncompleteOptions, "no storage runroot or graphroot specified")
+		return nil, fmt.Errorf("no storage runroot or graphroot specified: %w", ErrIncompleteOptions)
 	case options.GraphRoot == "":
 		options.GraphRoot = defaultOpts.GraphRoot
 	case options.RunRoot == "":
@@ -1248,13 +1248,13 @@ func (s *store) imageTopLayerForMapping(image *Image, ristore ROImageStore, crea
 		layerOptions.TemplateLayer = layer.ID
 		mappedLayer, _, err := rlstore.Put("", parentLayer, nil, layer.MountLabel, nil, &layerOptions, false, nil, nil)
 		if err != nil {
-			return nil, errors.Wrapf(err, "error creating an ID-mapped copy of layer %q", layer.ID)
+			return nil, fmt.Errorf("error creating an ID-mapped copy of layer %q: %w", layer.ID, err)
 		}
 		if err = istore.addMappedTopLayer(image.ID, mappedLayer.ID); err != nil {
 			if err2 := rlstore.Delete(mappedLayer.ID); err2 != nil {
-				err = errors.WithMessage(err, fmt.Sprintf("error deleting layer %q: %v", mappedLayer.ID, err2))
+				err = fmt.Errorf("error deleting layer %q: %v: %w", mappedLayer.ID, err2, err)
 			}
-			return nil, errors.Wrapf(err, "error registering ID-mapped layer with image %q", image.ID)
+			return nil, fmt.Errorf("error registering ID-mapped layer with image %q: %w", image.ID, err)
 		}
 		layer = mappedLayer
 	}
@@ -1330,7 +1330,7 @@ func (s *store) CreateContainer(id string, names []string, image, layer, metadat
 			}
 		}
 		if cimage == nil {
-			return nil, errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", image)
+			return nil, fmt.Errorf("error locating image with ID %q: %w", image, ErrImageUnknown)
 		}
 		imageID = cimage.ID
 	}
@@ -1403,7 +1403,7 @@ func (s *store) CreateContainer(id string, names []string, image, layer, metadat
 	mlabel, _ := options.Flags["MountLabel"].(string)
 	if (plabel == "" && mlabel != "") ||
 		(plabel != "" && mlabel == "") {
-		return nil, errors.Errorf("ProcessLabel and Mountlabel must either not be specified or both specified")
+		return nil, errors.New("processLabel and Mountlabel must either not be specified or both specified")
 	}
 
 	if plabel == "" {
@@ -1561,7 +1561,7 @@ func (s *store) ListImageBigData(id string) ([]string, error) {
 			return bigDataNames, err
 		}
 	}
-	return nil, errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
+	return nil, fmt.Errorf("error locating image with ID %q: %w", id, ErrImageUnknown)
 }
 
 func (s *store) ImageBigDataSize(id, key string) (int64, error) {
@@ -1639,9 +1639,9 @@ func (s *store) ImageBigData(id, key string) ([]byte, error) {
 		}
 	}
 	if foundImage {
-		return nil, errors.Wrapf(os.ErrNotExist, "error locating item named %q for image with ID %q (consider removing the image to resolve the issue)", key, id)
+		return nil, fmt.Errorf("error locating item named %q for image with ID %q (consider removing the image to resolve the issue): %w", key, id, os.ErrNotExist)
 	}
-	return nil, errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
+	return nil, fmt.Errorf("error locating image with ID %q: %w", id, ErrImageUnknown)
 }
 
 // ListLayerBigData retrieves a list of the (possibly large) chunks of
@@ -1672,9 +1672,9 @@ func (s *store) ListLayerBigData(id string) ([]string, error) {
 		}
 	}
 	if foundLayer {
-		return nil, errors.Wrapf(os.ErrNotExist, "error locating big data for layer with ID %q", id)
+		return nil, fmt.Errorf("error locating big data for layer with ID %q: %w", id, os.ErrNotExist)
 	}
-	return nil, errors.Wrapf(ErrLayerUnknown, "error locating layer with ID %q", id)
+	return nil, fmt.Errorf("error locating layer with ID %q: %w", id, ErrLayerUnknown)
 }
 
 // LayerBigData retrieves a (possibly large) chunk of named data
@@ -1705,9 +1705,9 @@ func (s *store) LayerBigData(id, key string) (io.ReadCloser, error) {
 		}
 	}
 	if foundLayer {
-		return nil, errors.Wrapf(os.ErrNotExist, "error locating item named %q for layer with ID %q", key, id)
+		return nil, fmt.Errorf("error locating item named %q for layer with ID %q: %w", key, id, os.ErrNotExist)
 	}
-	return nil, errors.Wrapf(ErrLayerUnknown, "error locating layer with ID %q", id)
+	return nil, fmt.Errorf("error locating layer with ID %q: %w", id, ErrLayerUnknown)
 }
 
 // SetLayerBigData stores a (possibly large) chunk of named data
@@ -1746,11 +1746,11 @@ func (s *store) ImageSize(id string) (int64, error) {
 
 	lstore, err := s.LayerStore()
 	if err != nil {
-		return -1, errors.Wrapf(err, "error loading primary layer store data")
+		return -1, fmt.Errorf("error loading primary layer store data: %w", err)
 	}
 	lstores, err := s.ROLayerStores()
 	if err != nil {
-		return -1, errors.Wrapf(err, "error loading additional layer stores")
+		return -1, fmt.Errorf("error loading additional layer stores: %w", err)
 	}
 	for _, s := range append([]ROLayerStore{lstore}, lstores...) {
 		store := s
@@ -1764,11 +1764,11 @@ func (s *store) ImageSize(id string) (int64, error) {
 	var imageStore ROBigDataStore
 	istore, err := s.ImageStore()
 	if err != nil {
-		return -1, errors.Wrapf(err, "error loading primary image store data")
+		return -1, fmt.Errorf("error loading primary image store data: %w", err)
 	}
 	istores, err := s.ROImageStores()
 	if err != nil {
-		return -1, errors.Wrapf(err, "error loading additional image stores")
+		return -1, fmt.Errorf("error loading additional image stores: %w", err)
 	}
 
 	// Look for the image's record.
@@ -1785,7 +1785,7 @@ func (s *store) ImageSize(id string) (int64, error) {
 		}
 	}
 	if image == nil {
-		return -1, errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
+		return -1, fmt.Errorf("error locating image with ID %q: %w", id, ErrImageUnknown)
 	}
 
 	// Start with a list of the image's top layers, if it has any.
@@ -1815,7 +1815,7 @@ func (s *store) ImageSize(id string) (int64, error) {
 				}
 			}
 			if layer == nil {
-				return -1, errors.Wrapf(ErrLayerUnknown, "error locating layer with ID %q", layerID)
+				return -1, fmt.Errorf("error locating layer with ID %q: %w", layerID, ErrLayerUnknown)
 			}
 			// The UncompressedSize is only valid if there's a digest to go with it.
 			n := layer.UncompressedSize
@@ -1823,7 +1823,7 @@ func (s *store) ImageSize(id string) (int64, error) {
 				// Compute the size.
 				n, err = layerStore.DiffSize("", layer.ID)
 				if err != nil {
-					return -1, errors.Wrapf(err, "size/digest of layer with ID %q could not be calculated", layerID)
+					return -1, fmt.Errorf("size/digest of layer with ID %q could not be calculated: %w", layerID, err)
 				}
 			}
 			// Count this layer.
@@ -1838,12 +1838,12 @@ func (s *store) ImageSize(id string) (int64, error) {
 	// Count big data items.
 	names, err := imageStore.BigDataNames(id)
 	if err != nil {
-		return -1, errors.Wrapf(err, "error reading list of big data items for image %q", id)
+		return -1, fmt.Errorf("error reading list of big data items for image %q: %w", id, err)
 	}
 	for _, name := range names {
 		n, err := imageStore.BigDataSize(id, name)
 		if err != nil {
-			return -1, errors.Wrapf(err, "error reading size of big data item %q for image %q", name, id)
+			return -1, fmt.Errorf("error reading size of big data item %q for image %q: %w", name, id, err)
 		}
 		size += n
 	}
@@ -1903,24 +1903,24 @@ func (s *store) ContainerSize(id string) (int64, error) {
 		if layer, err = store.Get(container.LayerID); err == nil {
 			size, err = store.DiffSize("", layer.ID)
 			if err != nil {
-				return -1, errors.Wrapf(err, "error determining size of layer with ID %q", layer.ID)
+				return -1, fmt.Errorf("error determining size of layer with ID %q: %w", layer.ID, err)
 			}
 			break
 		}
 	}
 	if layer == nil {
-		return -1, errors.Wrapf(ErrLayerUnknown, "error locating layer with ID %q", container.LayerID)
+		return -1, fmt.Errorf("error locating layer with ID %q: %w", container.LayerID, ErrLayerUnknown)
 	}
 
 	// Count big data items.
 	names, err := rcstore.BigDataNames(id)
 	if err != nil {
-		return -1, errors.Wrapf(err, "error reading list of big data items for container %q", container.ID)
+		return -1, fmt.Errorf("error reading list of big data items for container %q: %w", container.ID, err)
 	}
 	for _, name := range names {
 		n, err := rcstore.BigDataSize(id, name)
 		if err != nil {
-			return -1, errors.Wrapf(err, "error reading size of big data item %q for container %q", name, id)
+			return -1, fmt.Errorf("error reading size of big data item %q for container %q: %w", name, id, err)
 		}
 		size += n
 	}
@@ -2338,7 +2338,7 @@ func (s *store) DeleteLayer(id string) error {
 		}
 		for _, layer := range layers {
 			if layer.Parent == id {
-				return errors.Wrapf(ErrLayerHasChildren, "used by layer %v", layer.ID)
+				return fmt.Errorf("used by layer %v: %w", layer.ID, ErrLayerHasChildren)
 			}
 		}
 		images, err := ristore.Images()
@@ -2348,12 +2348,12 @@ func (s *store) DeleteLayer(id string) error {
 
 		for _, image := range images {
 			if image.TopLayer == id {
-				return errors.Wrapf(ErrLayerUsedByImage, "layer %v used by image %v", id, image.ID)
+				return fmt.Errorf("layer %v used by image %v: %w", id, image.ID, ErrLayerUsedByImage)
 			}
 			if stringutils.InSlice(image.MappedTopLayers, id) {
 				// No write access to the image store, fail before the layer is deleted
 				if _, ok := ristore.(*imageStore); !ok {
-					return errors.Wrapf(ErrLayerUsedByImage, "layer %v used by image %v", id, image.ID)
+					return fmt.Errorf("layer %v used by image %v: %w", id, image.ID, ErrLayerUsedByImage)
 				}
 			}
 		}
@@ -2363,11 +2363,11 @@ func (s *store) DeleteLayer(id string) error {
 		}
 		for _, container := range containers {
 			if container.LayerID == id {
-				return errors.Wrapf(ErrLayerUsedByContainer, "layer %v used by container %v", id, container.ID)
+				return fmt.Errorf("layer %v used by container %v: %w", id, container.ID, ErrLayerUsedByContainer)
 			}
 		}
 		if err := rlstore.Delete(id); err != nil {
-			return errors.Wrapf(err, "delete layer %v", id)
+			return fmt.Errorf("delete layer %v: %w", id, err)
 		}
 
 		// The check here is used to avoid iterating the images if we don't need to.
@@ -2376,7 +2376,7 @@ func (s *store) DeleteLayer(id string) error {
 			for _, image := range images {
 				if stringutils.InSlice(image.MappedTopLayers, id) {
 					if err = istore.removeMappedTopLayer(image.ID, id); err != nil {
-						return errors.Wrapf(err, "remove mapped top layer %v from image %v", id, image.ID)
+						return fmt.Errorf("remove mapped top layer %v from image %v: %w", id, image.ID, err)
 					}
 				}
 			}
@@ -2431,7 +2431,7 @@ func (s *store) DeleteImage(id string, commit bool) (layers []string, err error)
 			aContainerByImage[container.ImageID] = container.ID
 		}
 		if container, ok := aContainerByImage[id]; ok {
-			return nil, errors.Wrapf(ErrImageUsedByContainer, "Image used by %v", container)
+			return nil, fmt.Errorf("image used by %v: %w", container, ErrImageUsedByContainer)
 		}
 		images, err := ristore.Images()
 		if err != nil {
@@ -3049,7 +3049,7 @@ func (s *store) layersByMappedDigest(m func(ROLayerStore, digest.Digest) ([]Laye
 		}
 		storeLayers, err := m(store, d)
 		if err != nil {
-			if errors.Cause(err) != ErrLayerUnknown {
+			if !errors.Is(err, ErrLayerUnknown) {
 				return nil, err
 			}
 			continue
@@ -3064,14 +3064,14 @@ func (s *store) layersByMappedDigest(m func(ROLayerStore, digest.Digest) ([]Laye
 
 func (s *store) LayersByCompressedDigest(d digest.Digest) ([]Layer, error) {
 	if err := d.Validate(); err != nil {
-		return nil, errors.Wrapf(err, "error looking for compressed layers matching digest %q", d)
+		return nil, fmt.Errorf("error looking for compressed layers matching digest %q: %w", d, err)
 	}
 	return s.layersByMappedDigest(func(r ROLayerStore, d digest.Digest) ([]Layer, error) { return r.LayersByCompressedDigest(d) }, d)
 }
 
 func (s *store) LayersByUncompressedDigest(d digest.Digest) ([]Layer, error) {
 	if err := d.Validate(); err != nil {
-		return nil, errors.Wrapf(err, "error looking for layers matching digest %q", d)
+		return nil, fmt.Errorf("error looking for layers matching digest %q: %w", d, err)
 	}
 	return s.layersByMappedDigest(func(r ROLayerStore, d digest.Digest) ([]Layer, error) { return r.LayersByUncompressedDigest(d) }, d)
 }
@@ -3351,7 +3351,7 @@ func (s *store) Image(id string) (*Image, error) {
 			return image, nil
 		}
 	}
-	return nil, errors.Wrapf(ErrImageUnknown, "error locating image with ID %q", id)
+	return nil, fmt.Errorf("error locating image with ID %q: %w", id, ErrImageUnknown)
 }
 
 func (s *store) ImagesByTopLayer(id string) ([]*Image, error) {
@@ -3409,7 +3409,7 @@ func (s *store) ImagesByDigest(d digest.Digest) ([]*Image, error) {
 			return nil, err
 		}
 		imageList, err := store.ByDigest(d)
-		if err != nil && errors.Cause(err) != ErrImageUnknown {
+		if err != nil && !errors.Is(err, ErrImageUnknown) {
 			return nil, err
 		}
 		images = append(images, imageList...)
@@ -3605,7 +3605,7 @@ func (s *store) Shutdown(force bool) ([]string, error) {
 		}
 	}
 	if len(mounted) > 0 && err == nil {
-		err = errors.Wrap(ErrLayerUsedByContainer, "A layer is mounted")
+		err = fmt.Errorf("a layer is mounted: %w", ErrLayerUsedByContainer)
 	}
 	if err == nil {
 		err = s.graphDriver.Cleanup()

--- a/types/idmappings.go
+++ b/types/idmappings.go
@@ -5,7 +5,6 @@ import (
 	"os"
 
 	"github.com/containers/storage/pkg/idtools"
-	"github.com/pkg/errors"
 )
 
 // AutoUserNsOptions defines how to automatically create a user namespace.
@@ -77,18 +76,18 @@ func ParseIDMapping(UIDMapSlice, GIDMapSlice []string, subUIDMap, subGIDMap stri
 	if subUIDMap != "" && subGIDMap != "" {
 		mappings, err := idtools.NewIDMappings(subUIDMap, subGIDMap)
 		if err != nil {
-			return nil, errors.Wrapf(err, "failed to create NewIDMappings for uidmap=%s gidmap=%s", subUIDMap, subGIDMap)
+			return nil, fmt.Errorf("failed to create NewIDMappings for uidmap=%s gidmap=%s: %w", subUIDMap, subGIDMap, err)
 		}
 		options.UIDMap = mappings.UIDs()
 		options.GIDMap = mappings.GIDs()
 	}
 	parsedUIDMap, err := idtools.ParseIDMap(UIDMapSlice, "UID")
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create ParseUIDMap UID=%s", UIDMapSlice)
+		return nil, fmt.Errorf("failed to create ParseUIDMap UID=%s: %w", UIDMapSlice, err)
 	}
 	parsedGIDMap, err := idtools.ParseIDMap(GIDMapSlice, "GID")
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed to create ParseGIDMap GID=%s", UIDMapSlice)
+		return nil, fmt.Errorf("failed to create ParseGIDMap GID=%s: %w", UIDMapSlice, err)
 	}
 	options.UIDMap = append(options.UIDMap, parsedUIDMap...)
 	options.GIDMap = append(options.GIDMap, parsedGIDMap...)

--- a/types/utils.go
+++ b/types/utils.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -10,7 +11,6 @@ import (
 
 	"github.com/containers/storage/pkg/homedir"
 	"github.com/containers/storage/pkg/system"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -22,7 +22,7 @@ func GetRootlessRuntimeDir(rootlessUID int) (string, error) {
 	}
 	path = filepath.Join(path, "containers")
 	if err := os.MkdirAll(path, 0700); err != nil {
-		return "", errors.Wrapf(err, "unable to make rootless runtime")
+		return "", fmt.Errorf("unable to make rootless runtime: %w", err)
 	}
 	return path, nil
 }
@@ -132,7 +132,7 @@ func getRootlessDirInfo(rootlessUID int) (string, string, error) {
 
 	home := homedir.Get()
 	if home == "" {
-		return "", "", errors.Wrapf(err, "neither XDG_DATA_HOME nor HOME was set non-empty")
+		return "", "", fmt.Errorf("neither XDG_DATA_HOME nor HOME was set non-empty: %w", err)
 	}
 	// runc doesn't like symlinks in the rootfs path, and at least
 	// on CoreOS /home is a symlink to /var/home, so resolve any symlink.

--- a/userns.go
+++ b/userns.go
@@ -1,6 +1,7 @@
 package storage
 
 import (
+	"fmt"
 	"os"
 	"os/user"
 	"path/filepath"
@@ -11,7 +12,6 @@ import (
 	"github.com/containers/storage/pkg/unshare"
 	"github.com/containers/storage/types"
 	libcontainerUser "github.com/opencontainers/runc/libcontainer/user"
-	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
 )
 
@@ -164,7 +164,7 @@ outer:
 			}
 			continue outer
 		}
-		return 0, errors.Errorf("cannot find layer %q", layerName)
+		return 0, fmt.Errorf("cannot find layer %q", layerName)
 	}
 
 	rlstore, err := s.LayerStore()
@@ -223,7 +223,7 @@ func (s *store) getAutoUserNS(options *types.AutoUserNsOptions, image *Image) ([
 
 	availableUIDs, availableGIDs, err := s.getAvailableIDs()
 	if err != nil {
-		return nil, nil, errors.Wrapf(err, "cannot read mappings")
+		return nil, nil, fmt.Errorf("cannot read mappings: %w", err)
 	}
 
 	// Look every container that is using a user namespace and store
@@ -259,7 +259,7 @@ func (s *store) getAutoUserNS(options *types.AutoUserNsOptions, image *Image) ([
 			}
 		}
 		if s.autoNsMaxSize > 0 && size > s.autoNsMaxSize {
-			return nil, nil, errors.Errorf("the container needs a user namespace with size %q that is bigger than the maximum value allowed with userns=auto %q", size, s.autoNsMaxSize)
+			return nil, nil, fmt.Errorf("the container needs a user namespace with size %q that is bigger than the maximum value allowed with userns=auto %q", size, s.autoNsMaxSize)
 		}
 	}
 

--- a/vendor/modules.txt
+++ b/vendor/modules.txt
@@ -115,7 +115,6 @@ github.com/opencontainers/selinux/go-selinux/label
 github.com/opencontainers/selinux/pkg/pwalk
 github.com/opencontainers/selinux/pkg/pwalkdir
 # github.com/pkg/errors v0.9.1
-## explicit
 github.com/pkg/errors
 # github.com/pmezard/go-difflib v1.0.0
 github.com/pmezard/go-difflib/difflib


### PR DESCRIPTION
We now use the golang error wrapping format specifier `%w` instead of the deprecated github.com/pkg/errors package.
