### PR TITLE
Wrap errors properly with fmt.Errorf

### DIFF
--- a/drivers/aufs/aufs.go
+++ b/drivers/aufs/aufs.go
@@ -56,9 +56,9 @@ import (
 
 var (
 	// ErrAufsNotSupported is returned if aufs is not supported by the host.
-	ErrAufsNotSupported = fmt.Errorf("AUFS was not found in /proc/filesystems")
+	ErrAufsNotSupported = fmt.Errorf("aufs was not found in /proc/filesystems")
 	// ErrAufsNested means aufs cannot be used bc we are in a user namespace
-	ErrAufsNested = fmt.Errorf("AUFS cannot be used in non-init user namespace")
+	ErrAufsNested = fmt.Errorf("aufs cannot be used in non-init user namespace")
 	backingFs     = "<unknown>"
 
 	enableDirpermLock sync.Once
@@ -106,7 +106,7 @@ func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) 
 	switch fsMagic {
 	case graphdriver.FsMagicAufs, graphdriver.FsMagicBtrfs, graphdriver.FsMagicEcryptfs:
 		logrus.Errorf("AUFS is not supported over %s", backingFs)
-		return nil, fmt.Errorf("AUFS is not supported over %q: %w", backingFs, graphdriver.ErrIncompatibleFS)
+		return nil, fmt.Errorf("aufs is not supported over %q: %w", backingFs, graphdriver.ErrIncompatibleFS)
 	}
 
 	var mountOptions string
@@ -387,7 +387,7 @@ func (a *Driver) Remove(id string) error {
 
 	// Remove the layers file for the id
 	if err := os.Remove(path.Join(a.rootPath(), "layers", id)); err != nil && !os.IsNotExist(err) {
-		return fmt.Errorf("error removing layers dir for %s: %w", id, err)
+		return fmt.Errorf("removing layers dir for %s: %w", id, err)
 	}
 
 	if err := atomicRemove(a.getDiffPath(id)); err != nil {
@@ -422,7 +422,7 @@ func atomicRemove(source string) error {
 			return fmt.Errorf("target rename dir '%s' exists but should not, this needs to be manually cleaned up: %w", target, err)
 		}
 	default:
-		return fmt.Errorf("error preparing atomic delete: %w", err)
+		return fmt.Errorf("preparing atomic delete: %w", err)
 	}
 
 	return system.EnsureRemoveAll(target)
@@ -626,7 +626,7 @@ func (a *Driver) mount(id string, target string, layers []string, options graphd
 	rw := a.getDiffPath(id)
 
 	if err := a.aufsMount(layers, rw, target, options); err != nil {
-		return fmt.Errorf("error creating aufs mount to %s: %v", target, err)
+		return fmt.Errorf("creating aufs mount to %s: %w", target, err)
 	}
 	return nil
 }

--- a/drivers/btrfs/btrfs.go
+++ b/drivers/btrfs/btrfs.go
@@ -117,7 +117,7 @@ func parseOptions(opt []string) (btrfsOptions, bool, error) {
 		case "btrfs.mountopt":
 			return options, userDiskQuota, fmt.Errorf("btrfs driver does not support mount options")
 		default:
-			return options, userDiskQuota, fmt.Errorf("Unknown option %s", key)
+			return options, userDiskQuota, fmt.Errorf("unknown option %s", key)
 		}
 	}
 	return options, userDiskQuota, nil
@@ -173,7 +173,7 @@ func openDir(path string) (*C.DIR, error) {
 
 	dir := C.opendir(Cpath)
 	if dir == nil {
-		return nil, fmt.Errorf("Can't open dir")
+		return nil, fmt.Errorf("can't open dir %s", path)
 	}
 	return dir, nil
 }
@@ -203,7 +203,7 @@ func subvolCreate(path, name string) error {
 	_, _, errno := unix.Syscall(unix.SYS_IOCTL, getDirFd(dir), C.BTRFS_IOC_SUBVOL_CREATE,
 		uintptr(unsafe.Pointer(&args)))
 	if errno != 0 {
-		return fmt.Errorf("Failed to create btrfs subvolume: %v", errno.Error())
+		return fmt.Errorf("failed to create btrfs subvolume: %w", errno)
 	}
 	return nil
 }
@@ -231,7 +231,7 @@ func subvolSnapshot(src, dest, name string) error {
 	_, _, errno := unix.Syscall(unix.SYS_IOCTL, getDirFd(destDir), C.BTRFS_IOC_SNAP_CREATE_V2,
 		uintptr(unsafe.Pointer(&args)))
 	if errno != 0 {
-		return fmt.Errorf("Failed to create btrfs snapshot: %v", errno.Error())
+		return fmt.Errorf("failed to create btrfs snapshot: %w", errno)
 	}
 	return nil
 }
@@ -264,25 +264,25 @@ func subvolDelete(dirpath, name string, quotaEnabled bool) error {
 				// since it's gone anyway, we don't care
 				return nil
 			}
-			return fmt.Errorf("error walking subvolumes: %v", err)
+			return fmt.Errorf("walking subvolumes: %w", err)
 		}
 		// we want to check children only so skip itself
 		// it will be removed after the filepath walk anyways
 		if d.IsDir() && p != fullPath {
 			sv, err := isSubvolume(p)
 			if err != nil {
-				return fmt.Errorf("Failed to test if %s is a btrfs subvolume: %v", p, err)
+				return fmt.Errorf("failed to test if %s is a btrfs subvolume: %w", p, err)
 			}
 			if sv {
 				if err := subvolDelete(path.Dir(p), d.Name(), quotaEnabled); err != nil {
-					return fmt.Errorf("Failed to destroy btrfs child subvolume (%s) of parent (%s): %v", p, dirpath, err)
+					return fmt.Errorf("failed to destroy btrfs child subvolume (%s) of parent (%s): %w", p, dirpath, err)
 				}
 			}
 		}
 		return nil
 	}
 	if err := filepath.WalkDir(path.Join(dirpath, name), walkSubvolumes); err != nil {
-		return fmt.Errorf("Recursively walking subvolumes for %s failed: %v", dirpath, err)
+		return fmt.Errorf("recursively walking subvolumes for %s failed: %w", dirpath, err)
 	}
 
 	if quotaEnabled {
@@ -308,7 +308,7 @@ func subvolDelete(dirpath, name string, quotaEnabled bool) error {
 	_, _, errno := unix.Syscall(unix.SYS_IOCTL, getDirFd(dir), C.BTRFS_IOC_SNAP_DESTROY,
 		uintptr(unsafe.Pointer(&args)))
 	if errno != 0 {
-		return fmt.Errorf("Failed to destroy btrfs snapshot %s for %s: %v", dirpath, name, errno.Error())
+		return fmt.Errorf("failed to destroy btrfs snapshot %s for %s: %w", dirpath, name, errno)
 	}
 	return nil
 }
@@ -344,7 +344,7 @@ func (d *Driver) enableQuota() error {
 	_, _, errno := unix.Syscall(unix.SYS_IOCTL, getDirFd(dir), C.BTRFS_IOC_QUOTA_CTL,
 		uintptr(unsafe.Pointer(&args)))
 	if errno != 0 {
-		return fmt.Errorf("Failed to enable btrfs quota for %s: %v", dir, errno.Error())
+		return fmt.Errorf("failed to enable btrfs quota for %s: %w", dir, errno)
 	}
 
 	d.quotaEnabled = true
@@ -369,7 +369,7 @@ func (d *Driver) subvolRescanQuota() error {
 	_, _, errno := unix.Syscall(unix.SYS_IOCTL, getDirFd(dir), C.BTRFS_IOC_QUOTA_RESCAN_WAIT,
 		uintptr(unsafe.Pointer(&args)))
 	if errno != 0 {
-		return fmt.Errorf("Failed to rescan btrfs quota for %s: %v", dir, errno.Error())
+		return fmt.Errorf("failed to rescan btrfs quota for %s: %w", dir, errno)
 	}
 
 	return nil
@@ -388,7 +388,7 @@ func subvolLimitQgroup(path string, size uint64) error {
 	_, _, errno := unix.Syscall(unix.SYS_IOCTL, getDirFd(dir), C.BTRFS_IOC_QGROUP_LIMIT,
 		uintptr(unsafe.Pointer(&args)))
 	if errno != 0 {
-		return fmt.Errorf("Failed to limit qgroup for %s: %v", dir, errno.Error())
+		return fmt.Errorf("failed to limit qgroup for %s: %w", dir, errno)
 	}
 
 	return nil
@@ -417,11 +417,11 @@ func qgroupStatus(path string) error {
 	_, _, errno := unix.Syscall(unix.SYS_IOCTL, getDirFd(dir), C.BTRFS_IOC_TREE_SEARCH,
 		uintptr(unsafe.Pointer(&args)))
 	if errno != 0 {
-		return fmt.Errorf("Failed to search qgroup for %s: %v", path, errno.Error())
+		return fmt.Errorf("failed to search qgroup for %s: %w", path, errno)
 	}
 	sh := (*C.struct_btrfs_ioctl_search_header)(unsafe.Pointer(&args.buf))
 	if sh._type != C.BTRFS_QGROUP_STATUS_KEY {
-		return fmt.Errorf("Invalid qgroup search header type for %s: %v", path, sh._type)
+		return fmt.Errorf("invalid qgroup search header type for %s: %v", path, sh._type)
 	}
 	return nil
 }
@@ -439,10 +439,10 @@ func subvolLookupQgroup(path string) (uint64, error) {
 	_, _, errno := unix.Syscall(unix.SYS_IOCTL, getDirFd(dir), C.BTRFS_IOC_INO_LOOKUP,
 		uintptr(unsafe.Pointer(&args)))
 	if errno != 0 {
-		return 0, fmt.Errorf("Failed to lookup qgroup for %s: %v", dir, errno.Error())
+		return 0, fmt.Errorf("failed to lookup qgroup for %s: %w", dir, errno)
 	}
 	if args.treeid == 0 {
-		return 0, fmt.Errorf("Invalid qgroup id for %s: 0", dir)
+		return 0, fmt.Errorf("invalid qgroup id for %s: 0", dir)
 	}
 
 	return uint64(args.treeid), nil
@@ -558,7 +558,7 @@ func (d *Driver) parseStorageOpt(storageOpt map[string]string, driver *Driver) e
 			}
 			driver.options.size = uint64(size)
 		default:
-			return fmt.Errorf("Unknown option %s", key)
+			return fmt.Errorf("unknown option %s", key)
 		}
 	}
 

--- a/drivers/chown.go
+++ b/drivers/chown.go
@@ -87,13 +87,13 @@ func ChownPathByMaps(path string, toContainer, toHost *idtools.IDMappings) error
 	cmd.Stdin = bytes.NewReader(config)
 	output, err := cmd.CombinedOutput()
 	if len(output) > 0 && err != nil {
-		return fmt.Errorf("%v: %s", err, string(output))
+		return fmt.Errorf("%s: %w", string(output), err)
 	}
 	if err != nil {
 		return err
 	}
 	if len(output) > 0 {
-		return fmt.Errorf("%s", string(output))
+		return fmt.Errorf(string(output))
 	}
 
 	return nil

--- a/drivers/chown_unix.go
+++ b/drivers/chown_unix.go
@@ -83,7 +83,7 @@ func (c *platformChowner) LChown(path string, info os.FileInfo, toHost, toContai
 		mappedUID, mappedGID, err := toContainer.ToContainer(pair)
 		if err != nil {
 			if (uid != 0) || (gid != 0) {
-				return fmt.Errorf("error mapping host ID pair %#v for %q to container: %v", pair, path, err)
+				return fmt.Errorf("mapping host ID pair %#v for %q to container: %w", pair, path, err)
 			}
 			mappedUID, mappedGID = uid, gid
 		}
@@ -96,29 +96,29 @@ func (c *platformChowner) LChown(path string, info os.FileInfo, toHost, toContai
 		}
 		mappedPair, err := toHost.ToHostOverflow(pair)
 		if err != nil {
-			return fmt.Errorf("error mapping container ID pair %#v for %q to host: %v", pair, path, err)
+			return fmt.Errorf("mapping container ID pair %#v for %q to host: %w", pair, path, err)
 		}
 		uid, gid = mappedPair.UID, mappedPair.GID
 	}
 	if uid != int(st.Uid) || gid != int(st.Gid) {
 		cap, err := system.Lgetxattr(path, "security.capability")
 		if err != nil && !errors.Is(err, system.EOPNOTSUPP) && !errors.Is(err, system.EOVERFLOW) && err != system.ErrNotSupportedPlatform {
-			return fmt.Errorf("%s: %v", os.Args[0], err)
+			return fmt.Errorf("%s: %w", os.Args[0], err)
 		}
 
 		// Make the change.
 		if err := system.Lchown(path, uid, gid); err != nil {
-			return fmt.Errorf("%s: %v", os.Args[0], err)
+			return fmt.Errorf("%s: %w", os.Args[0], err)
 		}
 		// Restore the SUID and SGID bits if they were originally set.
 		if (info.Mode()&os.ModeSymlink == 0) && info.Mode()&(os.ModeSetuid|os.ModeSetgid) != 0 {
 			if err := system.Chmod(path, info.Mode()); err != nil {
-				return fmt.Errorf("%s: %v", os.Args[0], err)
+				return fmt.Errorf("%s: %w", os.Args[0], err)
 			}
 		}
 		if cap != nil {
 			if err := system.Lsetxattr(path, "security.capability", cap, 0); err != nil {
-				return fmt.Errorf("%s: %v", os.Args[0], err)
+				return fmt.Errorf("%s: %w", os.Args[0], err)
 			}
 		}
 

--- a/drivers/chroot_unix.go
+++ b/drivers/chroot_unix.go
@@ -1,3 +1,4 @@
+//go:build linux || darwin || freebsd || solaris
 // +build linux darwin freebsd solaris
 
 package graphdriver
@@ -12,10 +13,10 @@ import (
 // specified path followed by chdir() to the new root directory
 func chrootOrChdir(path string) error {
 	if err := syscall.Chroot(path); err != nil {
-		return fmt.Errorf("error chrooting to %q: %v", path, err)
+		return fmt.Errorf("chrooting to %q: %w", path, err)
 	}
 	if err := syscall.Chdir(string(os.PathSeparator)); err != nil {
-		return fmt.Errorf("error changing to %q: %v", path, err)
+		return fmt.Errorf("changing to %q: %w", path, err)
 	}
 	return nil
 }

--- a/drivers/chroot_windows.go
+++ b/drivers/chroot_windows.go
@@ -9,7 +9,7 @@ import (
 // specified path followed by chdir() to the new root directory
 func chrootOrChdir(path string) error {
 	if err := syscall.Chdir(path); err != nil {
-		return fmt.Errorf("error changing to %q: %v", path, err)
+		return fmt.Errorf("changing to %q: %w", path, err)
 	}
 	return nil
 }

--- a/drivers/copy/copy_linux.go
+++ b/drivers/copy/copy_linux.go
@@ -1,3 +1,4 @@
+//go:build cgo
 // +build cgo
 
 package copy
@@ -154,7 +155,7 @@ func DirCopy(srcDir, dstDir string, copyMode Mode, copyXattrs bool) error {
 		dstPath := filepath.Join(dstDir, relPath)
 		stat, ok := f.Sys().(*syscall.Stat_t)
 		if !ok {
-			return fmt.Errorf("Unable to get raw syscall.Stat_t data for %s", srcPath)
+			return fmt.Errorf("unable to get raw syscall.Stat_t data for %s", srcPath)
 		}
 
 		isHardlink := false

--- a/drivers/devmapper/device_setup.go
+++ b/drivers/devmapper/device_setup.go
@@ -159,7 +159,7 @@ func readLVMConfig(root string) (directLVMConfig, error) {
 		if os.IsNotExist(err) {
 			return cfg, nil
 		}
-		return cfg, fmt.Errorf("error reading existing setup config: %w", err)
+		return cfg, fmt.Errorf("reading existing setup config: %w", err)
 	}
 
 	// check if this is just an empty file, no need to produce a json error later if so
@@ -168,17 +168,17 @@ func readLVMConfig(root string) (directLVMConfig, error) {
 	}
 
 	err = json.Unmarshal(b, &cfg)
-	return cfg, fmt.Errorf("error unmarshaling previous device setup config: %w", err)
+	return cfg, fmt.Errorf("unmarshaling previous device setup config: %w", err)
 }
 
 func writeLVMConfig(root string, cfg directLVMConfig) error {
 	p := filepath.Join(root, "setup-config.json")
 	b, err := json.Marshal(cfg)
 	if err != nil {
-		return fmt.Errorf("error marshalling direct lvm config: %w", err)
+		return fmt.Errorf("marshalling direct lvm config: %w", err)
 	}
 	err = ioutil.WriteFile(p, b, 0600)
-	return fmt.Errorf("error writing direct lvm config to file: %w", err)
+	return fmt.Errorf("writing direct lvm config to file: %w", err)
 }
 
 func setupDirectLVM(cfg directLVMConfig) error {
@@ -187,13 +187,13 @@ func setupDirectLVM(cfg directLVMConfig) error {
 
 	for _, bin := range binaries {
 		if _, err := exec.LookPath(bin); err != nil {
-			return fmt.Errorf("error looking up command `"+bin+"` while setting up direct lvm: %w", err)
+			return fmt.Errorf("looking up command `"+bin+"` while setting up direct lvm: %w", err)
 		}
 	}
 
 	err := os.MkdirAll(lvmProfileDir, 0755)
 	if err != nil {
-		return fmt.Errorf("error creating lvm profile directory: %w", err)
+		return fmt.Errorf("creating lvm profile directory: %w", err)
 	}
 
 	if cfg.AutoExtendPercent == 0 {
@@ -241,7 +241,7 @@ func setupDirectLVM(cfg directLVMConfig) error {
 	profile := fmt.Sprintf("activation{\nthin_pool_autoextend_threshold=%d\nthin_pool_autoextend_percent=%d\n}", cfg.AutoExtendThreshold, cfg.AutoExtendPercent)
 	err = ioutil.WriteFile(lvmProfileDir+"/storage-thinpool.profile", []byte(profile), 0600)
 	if err != nil {
-		return fmt.Errorf("error writing storage thinp autoextend profile: %w", err)
+		return fmt.Errorf("writing storage thinp autoextend profile: %w", err)
 	}
 
 	out, err = exec.Command("lvchange", "--metadataprofile", "storage-thinpool", "storage/thinpool").CombinedOutput()

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -282,7 +282,7 @@ func init() {
 // Register registers an InitFunc for the driver.
 func Register(name string, initFunc InitFunc) error {
 	if _, exists := drivers[name]; exists {
-		return fmt.Errorf("Name already registered %s", name)
+		return fmt.Errorf("name already registered %s", name)
 	}
 	drivers[name] = initFunc
 
@@ -384,7 +384,7 @@ func New(name string, config Options) (Driver, error) {
 		}
 		return driver, nil
 	}
-	return nil, fmt.Errorf("No supported storage backend found")
+	return nil, fmt.Errorf("no supported storage backend found")
 }
 
 // isDriverNotSupported returns true if the error initializing

--- a/drivers/overlay/check.go
+++ b/drivers/overlay/check.go
@@ -171,7 +171,7 @@ func doesMetacopy(d, mountOpts string) (bool, error) {
 	// Make a change that only impacts the inode, and check if the pulled-up copy is marked
 	// as a metadata-only copy
 	if err := os.Chmod(filepath.Join(td, "merged", "f"), 0600); err != nil {
-		return false, fmt.Errorf("error changing permissions on file for metacopy check: %w", err)
+		return false, fmt.Errorf("changing permissions on file for metacopy check: %w", err)
 	}
 	metacopy, err := system.Lgetxattr(filepath.Join(td, "l2", "f"), archive.GetOverlayXattrName("metacopy"))
 	if err != nil {

--- a/drivers/overlay/mount.go
+++ b/drivers/overlay/mount.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package overlay
@@ -42,7 +43,7 @@ func mountFrom(dir, device, target, mType string, flags uintptr, label string) e
 	cmd := reexec.Command("storage-mountfrom", dir)
 	w, err := cmd.StdinPipe()
 	if err != nil {
-		return fmt.Errorf("mountfrom error on pipe creation: %v", err)
+		return fmt.Errorf("mountfrom error on pipe creation: %w", err)
 	}
 
 	output := bytes.NewBuffer(nil)
@@ -50,17 +51,17 @@ func mountFrom(dir, device, target, mType string, flags uintptr, label string) e
 	cmd.Stderr = output
 	if err := cmd.Start(); err != nil {
 		w.Close()
-		return fmt.Errorf("mountfrom error on re-exec cmd: %v", err)
+		return fmt.Errorf("mountfrom error on re-exec cmd: %w", err)
 	}
 	//write the options to the pipe for the untar exec to read
 	if err := json.NewEncoder(w).Encode(options); err != nil {
 		w.Close()
-		return fmt.Errorf("mountfrom json encode to pipe failed: %v", err)
+		return fmt.Errorf("mountfrom json encode to pipe failed: %w", err)
 	}
 	w.Close()
 
 	if err := cmd.Wait(); err != nil {
-		return fmt.Errorf("mountfrom re-exec error: %v: output: %v", err, output)
+		return fmt.Errorf("mountfrom re-exec output: %s: error: %w", output, err)
 	}
 	return nil
 }

--- a/drivers/overlay/randomid.go
+++ b/drivers/overlay/randomid.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package overlay
@@ -53,7 +54,7 @@ func generateID(l int) string {
 
 			// Any other errors represent a system problem. What did someone
 			// do to /dev/urandom?
-			panic(fmt.Errorf("error reading random number generator, retried for %v: %v", totalBackoff.String(), err))
+			panic(fmt.Errorf("reading random number generator, retried for %v: %w", totalBackoff.String(), err))
 		}
 
 		break

--- a/drivers/quota/projectquota.go
+++ b/drivers/quota/projectquota.go
@@ -92,7 +92,7 @@ func generateUniqueProjectID(path string) (uint32, error) {
 	}
 	stat, ok := fileinfo.Sys().(*syscall.Stat_t)
 	if !ok {
-		return 0, fmt.Errorf("Not a syscall.Stat_t %s", path)
+		return 0, fmt.Errorf("not a syscall.Stat_t %s", path)
 
 	}
 	projectID := projectIDsAllocatedPerQuotaHome + (stat.Ino*projectIDsAllocatedPerQuotaHome)%(math.MaxUint32-projectIDsAllocatedPerQuotaHome)
@@ -235,8 +235,8 @@ func setProjectQuota(backingFsBlockDev string, projectID uint32, quota Quota) er
 		uintptr(unsafe.Pointer(cs)), uintptr(d.d_id),
 		uintptr(unsafe.Pointer(&d)), 0, 0)
 	if errno != 0 {
-		return fmt.Errorf("Failed to set quota limit for projid %d on %s: %v",
-			projectID, backingFsBlockDev, errno.Error())
+		return fmt.Errorf("failed to set quota limit for projid %d on %s: %w",
+			projectID, backingFsBlockDev, errno)
 	}
 
 	return nil
@@ -283,8 +283,8 @@ func (q *Control) fsDiskQuotaFromPath(targetPath string) (C.fs_disk_quota_t, err
 		uintptr(unsafe.Pointer(cs)), uintptr(C.__u32(projectID)),
 		uintptr(unsafe.Pointer(&d)), 0, 0)
 	if errno != 0 {
-		return d, fmt.Errorf("Failed to get quota limit for projid %d on %s: %v",
-			projectID, q.backingFsBlockDev, errno.Error())
+		return d, fmt.Errorf("failed to get quota limit for projid %d on %s: %w",
+			projectID, q.backingFsBlockDev, errno)
 	}
 
 	return d, nil
@@ -302,7 +302,7 @@ func getProjectID(targetPath string) (uint32, error) {
 	_, _, errno := unix.Syscall(unix.SYS_IOCTL, getDirFd(dir), C.FS_IOC_FSGETXATTR,
 		uintptr(unsafe.Pointer(&fsx)))
 	if errno != 0 {
-		return 0, fmt.Errorf("Failed to get projid for %s: %v", targetPath, errno.Error())
+		return 0, fmt.Errorf("failed to get projid for %s: %w", targetPath, errno)
 	}
 
 	return uint32(fsx.fsx_projid), nil
@@ -320,14 +320,14 @@ func setProjectID(targetPath string, projectID uint32) error {
 	_, _, errno := unix.Syscall(unix.SYS_IOCTL, getDirFd(dir), C.FS_IOC_FSGETXATTR,
 		uintptr(unsafe.Pointer(&fsx)))
 	if errno != 0 {
-		return fmt.Errorf("Failed to get projid for %s: %v", targetPath, errno.Error())
+		return fmt.Errorf("failed to get projid for %s: %w", targetPath, errno)
 	}
 	fsx.fsx_projid = C.__u32(projectID)
 	fsx.fsx_xflags |= C.FS_XFLAG_PROJINHERIT
 	_, _, errno = unix.Syscall(unix.SYS_IOCTL, getDirFd(dir), C.FS_IOC_FSSETXATTR,
 		uintptr(unsafe.Pointer(&fsx)))
 	if errno != 0 {
-		return fmt.Errorf("Failed to set projid for %s: %v", targetPath, errno.Error())
+		return fmt.Errorf("failed to set projid for %s: %w", targetPath, errno)
 	}
 
 	return nil
@@ -370,7 +370,7 @@ func openDir(path string) (*C.DIR, error) {
 
 	dir := C.opendir(Cpath)
 	if dir == nil {
-		return nil, fmt.Errorf("Can't open dir")
+		return nil, fmt.Errorf("can't open dir %v", Cpath)
 	}
 	return dir, nil
 }
@@ -398,10 +398,10 @@ func makeBackingFsDev(home string) (string, error) {
 	backingFsBlockDevTmp := backingFsBlockDev + ".tmp"
 	// Re-create just in case someone copied the home directory over to a new device
 	if err := unix.Mknod(backingFsBlockDevTmp, unix.S_IFBLK|0600, int(stat.Dev)); err != nil {
-		return "", fmt.Errorf("Failed to mknod %s: %v", backingFsBlockDevTmp, err)
+		return "", fmt.Errorf("failed to mknod %s: %w", backingFsBlockDevTmp, err)
 	}
 	if err := unix.Rename(backingFsBlockDevTmp, backingFsBlockDev); err != nil {
-		return "", fmt.Errorf("Failed to rename %s to %s: %v", backingFsBlockDevTmp, backingFsBlockDev, err)
+		return "", fmt.Errorf("failed to rename %s to %s: %w", backingFsBlockDevTmp, backingFsBlockDev, err)
 	}
 
 	return backingFsBlockDev, nil

--- a/drivers/windows/windows.go
+++ b/drivers/windows/windows.go
@@ -1,4 +1,5 @@
-//+build windows
+//go:build windows
+// +build windows
 
 package windows
 
@@ -103,7 +104,7 @@ func InitFilter(home string, options graphdriver.Options) (graphdriver.Driver, e
 	}
 
 	if err := idtools.MkdirAllAs(home, 0700, 0, 0); err != nil {
-		return nil, fmt.Errorf("windowsfilter failed to create '%s': %v", home, err)
+		return nil, fmt.Errorf("windowsfilter failed to create '%s': %w", home, err)
 	}
 
 	d := &Driver{
@@ -252,7 +253,7 @@ func (d *Driver) create(id, parent, mountLabel string, readOnly bool, storageOpt
 
 		storageOptions, err := parseStorageOpt(storageOpt)
 		if err != nil {
-			return fmt.Errorf("Failed to parse storage options - %s", err)
+			return fmt.Errorf("failed to parse storage options - %s", err)
 		}
 
 		if storageOptions.size != 0 {
@@ -266,7 +267,7 @@ func (d *Driver) create(id, parent, mountLabel string, readOnly bool, storageOpt
 		if err2 := hcsshim.DestroyLayer(d.info, id); err2 != nil {
 			logrus.Warnf("Failed to DestroyLayer %s: %s", id, err2)
 		}
-		return fmt.Errorf("Cannot create layer with missing parent %s: %s", parent, err)
+		return fmt.Errorf("cannot create layer with missing parent %s: %s", parent, err)
 	}
 
 	if err := d.setLayerChain(id, layerChain); err != nil {
@@ -810,7 +811,7 @@ func (d *Driver) importLayer(id string, layerData io.Reader, parentLayerPaths []
 		}
 
 		if err = cmd.Wait(); err != nil {
-			return 0, fmt.Errorf("re-exec error: %v: output: %s", err, output)
+			return 0, fmt.Errorf("re-exec output: %s: error: %w", output, err)
 		}
 
 		return strconv.ParseInt(output.String(), 10, 64)
@@ -890,13 +891,13 @@ func (d *Driver) getLayerChain(id string) ([]string, error) {
 	if os.IsNotExist(err) {
 		return nil, nil
 	} else if err != nil {
-		return nil, fmt.Errorf("Unable to read layerchain file - %s", err)
+		return nil, fmt.Errorf("unable to read layerchain file - %s", err)
 	}
 
 	var layerChain []string
 	err = json.Unmarshal(content, &layerChain)
 	if err != nil {
-		return nil, fmt.Errorf("Failed to unmarshall layerchain json - %s", err)
+		return nil, fmt.Errorf("failed to unmarshall layerchain json - %s", err)
 	}
 
 	return layerChain, nil
@@ -906,13 +907,13 @@ func (d *Driver) getLayerChain(id string) ([]string, error) {
 func (d *Driver) setLayerChain(id string, chain []string) error {
 	content, err := json.Marshal(&chain)
 	if err != nil {
-		return fmt.Errorf("Failed to marshall layerchain json - %s", err)
+		return fmt.Errorf("failed to marshall layerchain json - %s", err)
 	}
 
 	jPath := filepath.Join(d.dir(id), "layerchain.json")
 	err = ioutil.WriteFile(jPath, content, 0600)
 	if err != nil {
-		return fmt.Errorf("Unable to write layerchain file - %s", err)
+		return fmt.Errorf("unable to write layerchain file - %s", err)
 	}
 
 	return nil
@@ -999,7 +1000,7 @@ func parseStorageOpt(storageOpt map[string]string) (*storageOptions, error) {
 			}
 			options.size = uint64(size)
 		default:
-			return nil, fmt.Errorf("Unknown storage option: %s", key)
+			return nil, fmt.Errorf("unknown storage option: %s", key)
 		}
 	}
 	return &options, nil

--- a/drivers/zfs/zfs_freebsd.go
+++ b/drivers/zfs/zfs_freebsd.go
@@ -11,7 +11,7 @@ import (
 func checkRootdirFs(rootdir string) error {
 	var buf unix.Statfs_t
 	if err := unix.Statfs(rootdir, &buf); err != nil {
-		return fmt.Errorf("Failed to access '%s': %s", rootdir, err)
+		return fmt.Errorf("failed to access '%s': %s", rootdir, err)
 	}
 
 	// on FreeBSD buf.Fstypename contains ['z', 'f', 's', 0 ... ]

--- a/images.go
+++ b/images.go
@@ -233,7 +233,7 @@ func (i *Image) recomputeDigests() error {
 	digests := make(map[digest.Digest]struct{})
 	if i.Digest != "" {
 		if err := i.Digest.Validate(); err != nil {
-			return fmt.Errorf("error validating image digest %q: %w", string(i.Digest), err)
+			return fmt.Errorf("validating image digest %q: %w", string(i.Digest), err)
 		}
 		digests[i.Digest] = struct{}{}
 		validDigests = append(validDigests, i.Digest)
@@ -243,7 +243,7 @@ func (i *Image) recomputeDigests() error {
 			continue
 		}
 		if digest.Validate() != nil {
-			return fmt.Errorf("error validating digest %q for big data item %q: %w", string(digest), name, digest.Validate())
+			return fmt.Errorf("validating digest %q for big data item %q: %w", string(digest), name, digest.Validate())
 		}
 		// Deduplicate the digest values.
 		if _, known := digests[digest]; !known {
@@ -284,7 +284,7 @@ func (r *imageStore) Load() error {
 			// Compute the digest list.
 			err = image.recomputeDigests()
 			if err != nil {
-				return fmt.Errorf("error computing digests for image with ID %q (%v): %w", image.ID, image.Names, err)
+				return fmt.Errorf("computing digests for image with ID %q (%v): %w", image.ID, image.Names, err)
 			}
 			for _, name := range image.Names {
 				names[name] = image
@@ -392,7 +392,7 @@ func (r *imageStore) ClearFlag(id string, flag string) error {
 	}
 	image, ok := r.lookup(id)
 	if !ok {
-		return fmt.Errorf("error locating image with ID %q: %w", id, ErrImageUnknown)
+		return fmt.Errorf("locating image with ID %q: %w", id, ErrImageUnknown)
 	}
 	delete(image.Flags, flag)
 	return r.Save()
@@ -404,7 +404,7 @@ func (r *imageStore) SetFlag(id string, flag string, value interface{}) error {
 	}
 	image, ok := r.lookup(id)
 	if !ok {
-		return fmt.Errorf("error locating image with ID %q: %w", id, ErrImageUnknown)
+		return fmt.Errorf("locating image with ID %q: %w", id, ErrImageUnknown)
 	}
 	if image.Flags == nil {
 		image.Flags = make(map[string]interface{})
@@ -453,7 +453,7 @@ func (r *imageStore) Create(id string, names []string, layer, metadata string, c
 	}
 	err = image.recomputeDigests()
 	if err != nil {
-		return nil, fmt.Errorf("error validating digests for new image: %w", err)
+		return nil, fmt.Errorf("validating digests for new image: %w", err)
 	}
 	r.images = append(r.images, image)
 	r.idindex.Add(id)
@@ -475,7 +475,7 @@ func (r *imageStore) addMappedTopLayer(id, layer string) error {
 		image.MappedTopLayers = append(image.MappedTopLayers, layer)
 		return r.Save()
 	}
-	return fmt.Errorf("error locating image with ID %q: %w", id, ErrImageUnknown)
+	return fmt.Errorf("locating image with ID %q: %w", id, ErrImageUnknown)
 }
 
 func (r *imageStore) removeMappedTopLayer(id, layer string) error {
@@ -488,14 +488,14 @@ func (r *imageStore) removeMappedTopLayer(id, layer string) error {
 		}
 		return r.Save()
 	}
-	return fmt.Errorf("error locating image with ID %q: %w", id, ErrImageUnknown)
+	return fmt.Errorf("locating image with ID %q: %w", id, ErrImageUnknown)
 }
 
 func (r *imageStore) Metadata(id string) (string, error) {
 	if image, ok := r.lookup(id); ok {
 		return image.Metadata, nil
 	}
-	return "", fmt.Errorf("error locating image with ID %q: %w", id, ErrImageUnknown)
+	return "", fmt.Errorf("locating image with ID %q: %w", id, ErrImageUnknown)
 }
 
 func (r *imageStore) SetMetadata(id, metadata string) error {
@@ -506,7 +506,7 @@ func (r *imageStore) SetMetadata(id, metadata string) error {
 		image.Metadata = metadata
 		return r.Save()
 	}
-	return fmt.Errorf("error locating image with ID %q: %w", id, ErrImageUnknown)
+	return fmt.Errorf("locating image with ID %q: %w", id, ErrImageUnknown)
 }
 
 func (r *imageStore) removeName(image *Image, name string) {
@@ -536,7 +536,7 @@ func (r *imageStore) updateNames(id string, names []string, op updateNameOperati
 	}
 	image, ok := r.lookup(id)
 	if !ok {
-		return fmt.Errorf("error locating image with ID %q: %w", id, ErrImageUnknown)
+		return fmt.Errorf("locating image with ID %q: %w", id, ErrImageUnknown)
 	}
 	oldNames := image.Names
 	names, err := applyNameOperation(oldNames, names, op)
@@ -563,7 +563,7 @@ func (r *imageStore) Delete(id string) error {
 	}
 	image, ok := r.lookup(id)
 	if !ok {
-		return fmt.Errorf("error locating image with ID %q: %w", id, ErrImageUnknown)
+		return fmt.Errorf("locating image with ID %q: %w", id, ErrImageUnknown)
 	}
 	id = image.ID
 	toDeleteIndex := -1
@@ -606,14 +606,14 @@ func (r *imageStore) Get(id string) (*Image, error) {
 	if image, ok := r.lookup(id); ok {
 		return copyImage(image), nil
 	}
-	return nil, fmt.Errorf("error locating image with ID %q: %w", id, ErrImageUnknown)
+	return nil, fmt.Errorf("locating image with ID %q: %w", id, ErrImageUnknown)
 }
 
 func (r *imageStore) Lookup(name string) (id string, err error) {
 	if image, ok := r.lookup(name); ok {
 		return image.ID, nil
 	}
-	return "", fmt.Errorf("error locating image with ID %q: %w", id, ErrImageUnknown)
+	return "", fmt.Errorf("locating image with ID %q: %w", id, ErrImageUnknown)
 }
 
 func (r *imageStore) Exists(id string) bool {
@@ -625,7 +625,7 @@ func (r *imageStore) ByDigest(d digest.Digest) ([]*Image, error) {
 	if images, ok := r.bydigest[d]; ok {
 		return copyImageSlice(images), nil
 	}
-	return nil, fmt.Errorf("error locating image with digest %q: %w", d, ErrImageUnknown)
+	return nil, fmt.Errorf("locating image with digest %q: %w", d, ErrImageUnknown)
 }
 
 func (r *imageStore) BigData(id, key string) ([]byte, error) {
@@ -634,7 +634,7 @@ func (r *imageStore) BigData(id, key string) ([]byte, error) {
 	}
 	image, ok := r.lookup(id)
 	if !ok {
-		return nil, fmt.Errorf("error locating image with ID %q: %w", id, ErrImageUnknown)
+		return nil, fmt.Errorf("locating image with ID %q: %w", id, ErrImageUnknown)
 	}
 	return ioutil.ReadFile(r.datapath(image.ID, key))
 }
@@ -645,7 +645,7 @@ func (r *imageStore) BigDataSize(id, key string) (int64, error) {
 	}
 	image, ok := r.lookup(id)
 	if !ok {
-		return -1, fmt.Errorf("error locating image with ID %q: %w", id, ErrImageUnknown)
+		return -1, fmt.Errorf("locating image with ID %q: %w", id, ErrImageUnknown)
 	}
 	if image.BigDataSizes == nil {
 		image.BigDataSizes = make(map[string]int64)
@@ -665,7 +665,7 @@ func (r *imageStore) BigDataDigest(id, key string) (digest.Digest, error) {
 	}
 	image, ok := r.lookup(id)
 	if !ok {
-		return "", fmt.Errorf("error locating image with ID %q: %w", id, ErrImageUnknown)
+		return "", fmt.Errorf("locating image with ID %q: %w", id, ErrImageUnknown)
 	}
 	if image.BigDataDigests == nil {
 		image.BigDataDigests = make(map[string]digest.Digest)
@@ -679,7 +679,7 @@ func (r *imageStore) BigDataDigest(id, key string) (digest.Digest, error) {
 func (r *imageStore) BigDataNames(id string) ([]string, error) {
 	image, ok := r.lookup(id)
 	if !ok {
-		return nil, fmt.Errorf("error locating image with ID %q: %w", id, ErrImageUnknown)
+		return nil, fmt.Errorf("locating image with ID %q: %w", id, ErrImageUnknown)
 	}
 	return copyStringSlice(image.BigDataNames), nil
 }
@@ -704,7 +704,7 @@ func (r *imageStore) SetBigData(id, key string, data []byte, digestManifest func
 	}
 	image, ok := r.lookup(id)
 	if !ok {
-		return fmt.Errorf("error locating image with ID %q: %w", id, ErrImageUnknown)
+		return fmt.Errorf("locating image with ID %q: %w", id, ErrImageUnknown)
 	}
 	err := os.MkdirAll(r.datadir(image.ID), 0700)
 	if err != nil {
@@ -713,10 +713,10 @@ func (r *imageStore) SetBigData(id, key string, data []byte, digestManifest func
 	var newDigest digest.Digest
 	if bigDataNameIsManifest(key) {
 		if digestManifest == nil {
-			return fmt.Errorf("error digesting manifest: no manifest digest callback provided: %w", ErrDigestUnknown)
+			return fmt.Errorf("digesting manifest: no manifest digest callback provided: %w", ErrDigestUnknown)
 		}
 		if newDigest, err = digestManifest(data); err != nil {
-			return fmt.Errorf("error digesting manifest: %w", err)
+			return fmt.Errorf("digesting manifest: %w", err)
 		}
 	} else {
 		newDigest = digest.Canonical.FromBytes(data)
@@ -760,7 +760,7 @@ func (r *imageStore) SetBigData(id, key string, data []byte, digestManifest func
 			}
 		}
 		if err = image.recomputeDigests(); err != nil {
-			return fmt.Errorf("error loading recomputing image digest information for %s: %w", image.ID, err)
+			return fmt.Errorf("loading recomputing image digest information for %s: %w", image.ID, err)
 		}
 		for _, newDigest := range image.Digests {
 			// add the image to the list of images in the digest-based index which

--- a/layers.go
+++ b/layers.go
@@ -824,19 +824,19 @@ func (r *layerStore) Put(id string, parentLayer *Layer, names []string, mountLab
 	if moreOptions.TemplateLayer != "" {
 		if err := r.driver.CreateFromTemplate(id, moreOptions.TemplateLayer, templateIDMappings, parent, parentMappings, &opts, writeable); err != nil {
 			cleanupFailureContext = "creating a layer from template"
-			return nil, -1, fmt.Errorf("error creating copy of template layer %q with ID %q: %w", moreOptions.TemplateLayer, id, err)
+			return nil, -1, fmt.Errorf("creating copy of template layer %q with ID %q: %w", moreOptions.TemplateLayer, id, err)
 		}
 		oldMappings = templateIDMappings
 	} else {
 		if writeable {
 			if err := r.driver.CreateReadWrite(id, parent, &opts); err != nil {
 				cleanupFailureContext = "creating a read-write layer"
-				return nil, -1, fmt.Errorf("error creating read-write layer with ID %q: %w", id, err)
+				return nil, -1, fmt.Errorf("creating read-write layer with ID %q: %w", id, err)
 			}
 		} else {
 			if err := r.driver.Create(id, parent, &opts); err != nil {
 				cleanupFailureContext = "creating a read-only layer"
-				return nil, -1, fmt.Errorf("error creating layer with ID %q: %w", id, err)
+				return nil, -1, fmt.Errorf("creating layer with ID %q: %w", id, err)
 			}
 		}
 		oldMappings = parentMappings
@@ -1040,7 +1040,7 @@ func (r *layerStore) ParentOwners(id string) (uids, gids []int, err error) {
 	}
 	rootuid, rootgid, err := idtools.GetRootUIDGID(layer.UIDMap, layer.GIDMap)
 	if err != nil {
-		return nil, nil, fmt.Errorf("error reading root ID values for layer %q: %w", layer.ID, err)
+		return nil, nil, fmt.Errorf("reading root ID values for layer %q: %w", layer.ID, err)
 	}
 	m := idtools.NewIDMappingsFromMaps(layer.UIDMap, layer.GIDMap)
 	fsuids := make(map[int]struct{})
@@ -1143,7 +1143,7 @@ func (r *layerStore) BigData(id, key string) (io.ReadCloser, error) {
 	}
 	layer, ok := r.lookup(id)
 	if !ok {
-		return nil, fmt.Errorf("error locating layer with ID %q: %w", id, ErrLayerUnknown)
+		return nil, fmt.Errorf("locating layer with ID %q: %w", id, ErrLayerUnknown)
 	}
 	return os.Open(r.datapath(layer.ID, key))
 }
@@ -1157,7 +1157,7 @@ func (r *layerStore) SetBigData(id, key string, data io.Reader) error {
 	}
 	layer, ok := r.lookup(id)
 	if !ok {
-		return fmt.Errorf("error locating layer with ID %q to write bigdata: %w", id, ErrLayerUnknown)
+		return fmt.Errorf("locating layer with ID %q to write bigdata: %w", id, ErrLayerUnknown)
 	}
 	err := os.MkdirAll(r.datadir(layer.ID), 0700)
 	if err != nil {
@@ -1169,16 +1169,16 @@ func (r *layerStore) SetBigData(id, key string, data io.Reader) error {
 	// so that it is either accessing the old data or the new one.
 	writer, err := ioutils.NewAtomicFileWriter(r.datapath(layer.ID, key), 0600)
 	if err != nil {
-		return fmt.Errorf("error opening bigdata file: %w", err)
+		return fmt.Errorf("opening bigdata file: %w", err)
 	}
 
 	if _, err := io.Copy(writer, data); err != nil {
 		writer.Close()
-		return fmt.Errorf("error copying bigdata for the layer: %w", err)
+		return fmt.Errorf("copying bigdata for the layer: %w", err)
 
 	}
 	if err := writer.Close(); err != nil {
-		return fmt.Errorf("error closing bigdata file for the layer: %w", err)
+		return fmt.Errorf("closing bigdata file for the layer: %w", err)
 	}
 
 	addName := true
@@ -1198,7 +1198,7 @@ func (r *layerStore) SetBigData(id, key string, data io.Reader) error {
 func (r *layerStore) BigDataNames(id string) ([]string, error) {
 	layer, ok := r.lookup(id)
 	if !ok {
-		return nil, fmt.Errorf("error locating layer with ID %q to retrieve bigdata names: %w", id, ErrImageUnknown)
+		return nil, fmt.Errorf("locating layer with ID %q to retrieve bigdata names: %w", id, ErrImageUnknown)
 	}
 	return copyStringSlice(layer.BigDataNames), nil
 }
@@ -1337,7 +1337,7 @@ func (r *layerStore) Delete(id string) error {
 	// driver level.
 	mountCount, err := r.Mounted(id)
 	if err != nil {
-		return fmt.Errorf("error checking if layer %q is still mounted: %w", id, err)
+		return fmt.Errorf("checking if layer %q is still mounted: %w", id, err)
 	}
 	for mountCount > 0 {
 		if _, err := r.Unmount(id, false); err != nil {
@@ -1345,7 +1345,7 @@ func (r *layerStore) Delete(id string) error {
 		}
 		mountCount, err = r.Mounted(id)
 		if err != nil {
-			return fmt.Errorf("error checking if layer %q is still mounted: %w", id, err)
+			return fmt.Errorf("checking if layer %q is still mounted: %w", id, err)
 		}
 	}
 	if err := r.deleteInternal(id); err != nil {
@@ -1671,7 +1671,7 @@ func (r *layerStore) applyDiffWithOptions(to string, layerOptions *LayerOptions,
 		compressor = pgzip.NewWriter(&tsdata)
 	}
 	if err := compressor.SetConcurrency(1024*1024, 1); err != nil { // 1024*1024 is the hard-coded default; we're not changing that
-		logrus.Infof("Error setting compression concurrency threads to 1: %v; ignoring", err)
+		logrus.Infof("setting compression concurrency threads to 1: %v; ignoring", err)
 	}
 	metadata := storage.NewJSONPacker(compressor)
 	uncompressed, err := archive.DecompressStream(defragmented)

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -220,7 +220,7 @@ func DecompressStream(archive io.Reader) (io.ReadCloser, error) {
 	case Zstd:
 		return zstdReader(buf)
 	default:
-		return nil, fmt.Errorf("Unsupported compression format %s", (&compression).Extension())
+		return nil, fmt.Errorf("unsupported compression format %s", (&compression).Extension())
 	}
 }
 
@@ -241,9 +241,9 @@ func CompressStream(dest io.Writer, compression Compression) (io.WriteCloser, er
 	case Bzip2, Xz:
 		// archive/bzip2 does not support writing, and there is no xz support at all
 		// However, this is not a problem as docker only currently generates gzipped tars
-		return nil, fmt.Errorf("Unsupported compression format %s", (&compression).Extension())
+		return nil, fmt.Errorf("unsupported compression format %s", (&compression).Extension())
 	default:
-		return nil, fmt.Errorf("Unsupported compression format %s", (&compression).Extension())
+		return nil, fmt.Errorf("unsupported compression format %s", (&compression).Extension())
 	}
 }
 
@@ -363,7 +363,7 @@ func FileInfoHeader(name string, fi os.FileInfo, link string) (*tar.Header, erro
 	hdr.Mode = fillGo18FileTypeBits(int64(chmodTarEntry(os.FileMode(hdr.Mode))), fi)
 	name, err = canonicalTarName(name, fi.IsDir())
 	if err != nil {
-		return nil, fmt.Errorf("tar: cannot canonicalize path: %v", err)
+		return nil, fmt.Errorf("tar: cannot canonicalize path: %w", err)
 	}
 	hdr.Name = name
 	if err := setHeaderForSpecialDevice(hdr, name, fi.Sys()); err != nil {
@@ -1123,7 +1123,7 @@ func UntarUncompressed(tarArchive io.Reader, dest string, options *TarOptions) e
 // Handler for teasing out the automatic decompression
 func untarHandler(tarArchive io.Reader, dest string, options *TarOptions, decompress bool) error {
 	if tarArchive == nil {
-		return fmt.Errorf("Empty archive")
+		return fmt.Errorf("empty archive")
 	}
 	dest = filepath.Clean(dest)
 	if options == nil {
@@ -1239,7 +1239,7 @@ func (archiver *Archiver) CopyFileWithTar(src, dst string) (err error) {
 	}
 
 	if srcSt.IsDir() {
-		return fmt.Errorf("Can't copy a directory")
+		return fmt.Errorf("can't copy a directory")
 	}
 
 	// Clean up the trailing slash. This must be done in an operating
@@ -1450,7 +1450,7 @@ func CopyFileWithTarAndChown(chownOpts *idtools.IDPair, hasher io.Writer, uidmap
 		archiver.Untar = func(tarArchive io.Reader, dest string, options *TarOptions) error {
 			contentReader, contentWriter, err := os.Pipe()
 			if err != nil {
-				return fmt.Errorf("error creating pipe extract data to %q: %w", dest, err)
+				return fmt.Errorf("creating pipe extract data to %q: %w", dest, err)
 			}
 			defer contentReader.Close()
 			defer contentWriter.Close()
@@ -1469,11 +1469,11 @@ func CopyFileWithTarAndChown(chownOpts *idtools.IDPair, hasher io.Writer, uidmap
 				hashWorker.Done()
 			}()
 			if err = originalUntar(io.TeeReader(tarArchive, contentWriter), dest, options); err != nil {
-				err = fmt.Errorf("error extracting data to %q while copying: %w", dest, err)
+				err = fmt.Errorf("extracting data to %q while copying: %w", dest, err)
 			}
 			hashWorker.Wait()
 			if err == nil {
-				err = fmt.Errorf("error calculating digest of data for %q while copying: %w", dest, hashError)
+				err = fmt.Errorf("calculating digest of data for %q while copying: %w", dest, hashError)
 			}
 			return err
 		}

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -684,7 +684,7 @@ func tarUntar(t *testing.T, origin string, options *TarOptions) ([]Change, error
 	detectedCompression := DetectCompression(buf)
 	compression := options.Compression
 	if detectedCompression.Extension() != compression.Extension() {
-		return nil, fmt.Errorf("Wrong compression detected. Actual compression: %s, found %s", compression.Extension(), detectedCompression.Extension())
+		return nil, fmt.Errorf("wrong compression detected. Actual compression: %s, found %s", compression.Extension(), detectedCompression.Extension())
 	}
 
 	tmp, err := ioutil.TempDir("", "storage-test-untar")

--- a/pkg/archive/archive_windows.go
+++ b/pkg/archive/archive_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package archive
@@ -34,7 +35,7 @@ func CanonicalTarNameForPath(p string) (string, error) {
 	// in file names, it is mostly safe to replace however we must
 	// check just in case
 	if strings.Contains(p, "/") {
-		return "", fmt.Errorf("Windows path contains forward slash: %s", p)
+		return "", fmt.Errorf("windows path contains forward slash: %s", p)
 	}
 	return strings.Replace(p, string(os.PathSeparator), "/", -1), nil
 

--- a/pkg/archive/diff.go
+++ b/pkg/archive/diff.go
@@ -184,7 +184,7 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 				linkBasename := filepath.Base(hdr.Linkname)
 				srcHdr = aufsHardlinks[linkBasename]
 				if srcHdr == nil {
-					return 0, fmt.Errorf("Invalid aufs hardlink")
+					return 0, fmt.Errorf("invalid aufs hardlink")
 				}
 				tmpFile, err := os.Open(filepath.Join(aufsTempdir, linkBasename))
 				if err != nil {

--- a/pkg/archive/utils_test.go
+++ b/pkg/archive/utils_test.go
@@ -91,7 +91,7 @@ func testBreakout(untarFn string, tmpdir string, headers []*tar.Header) error {
 	f, err := os.Open(victim)
 	if err != nil {
 		// codepath taken if victim folder was removed
-		return fmt.Errorf("archive breakout: error reading %q: %v", victim, err)
+		return fmt.Errorf("archive breakout: error reading %q: %w", victim, err)
 	}
 	defer f.Close()
 
@@ -104,7 +104,7 @@ func testBreakout(untarFn string, tmpdir string, headers []*tar.Header) error {
 	names, err := f.Readdirnames(2)
 	if err != nil {
 		// codepath taken if victim is not a folder
-		return fmt.Errorf("archive breakout: error reading directory content of %q: %v", victim, err)
+		return fmt.Errorf("archive breakout: error reading directory content of %q: %w", victim, err)
 	}
 	for _, name := range names {
 		if name != "hello" {
@@ -117,7 +117,7 @@ func testBreakout(untarFn string, tmpdir string, headers []*tar.Header) error {
 	f, err = os.Open(hello)
 	if err != nil {
 		// codepath taken if read permissions were removed
-		return fmt.Errorf("archive breakout: could not lstat %q: %v", hello, err)
+		return fmt.Errorf("archive breakout: could not lstat %q: %w", hello, err)
 	}
 	defer f.Close()
 	b, err := ioutil.ReadAll(f)

--- a/pkg/chrootarchive/archive.go
+++ b/pkg/chrootarchive/archive.go
@@ -62,7 +62,7 @@ func UntarUncompressed(tarArchive io.Reader, dest string, options *archive.TarOp
 // Handler for teasing out the automatic decompression
 func untarHandler(tarArchive io.Reader, dest string, options *archive.TarOptions, decompress bool, root string) error {
 	if tarArchive == nil {
-		return fmt.Errorf("Empty archive")
+		return fmt.Errorf("empty archive")
 	}
 	if options == nil {
 		options = &archive.TarOptions{}
@@ -114,7 +114,7 @@ func CopyFileWithTarAndChown(chownOpts *idtools.IDPair, hasher io.Writer, uidmap
 		archiver.Untar = func(tarArchive io.Reader, dest string, options *archive.TarOptions) error {
 			contentReader, contentWriter, err := os.Pipe()
 			if err != nil {
-				return fmt.Errorf("error creating pipe extract data to %q: %w", dest, err)
+				return fmt.Errorf("creating pipe extract data to %q: %w", dest, err)
 			}
 			defer contentReader.Close()
 			defer contentWriter.Close()
@@ -133,11 +133,11 @@ func CopyFileWithTarAndChown(chownOpts *idtools.IDPair, hasher io.Writer, uidmap
 				hashWorker.Done()
 			}()
 			if err = originalUntar(io.TeeReader(tarArchive, contentWriter), dest, options); err != nil {
-				err = fmt.Errorf("error extracting data to %q while copying: %w", dest, err)
+				err = fmt.Errorf("extracting data to %q while copying: %w", dest, err)
 			}
 			hashWorker.Wait()
 			if err == nil {
-				err = fmt.Errorf("error calculating digest of data for %q while copying: %w", dest, hashError)
+				err = fmt.Errorf("calculating digest of data for %q while copying: %w", dest, hashError)
 			}
 			return err
 		}

--- a/pkg/chrootarchive/archive_test.go
+++ b/pkg/chrootarchive/archive_test.go
@@ -155,7 +155,7 @@ func compareDirectories(src string, dest string) error {
 		return err
 	}
 	if len(changes) > 0 {
-		return fmt.Errorf("Unexpected differences after untar: %v", changes)
+		return fmt.Errorf("unexpected differences after untar: %v", changes)
 	}
 	return nil
 }
@@ -169,7 +169,7 @@ func compareDirectoriesChown(src string, dest string, uid, gid int) error {
 		return err
 	}
 	if len(changes) > 0 {
-		return fmt.Errorf("Unexpected differences after untar: %v", changes)
+		return fmt.Errorf("unexpected differences after untar: %v", changes)
 	}
 	return nil
 }

--- a/pkg/chrootarchive/archive_unix.go
+++ b/pkg/chrootarchive/archive_unix.go
@@ -70,7 +70,7 @@ func invokeUnpack(decompressedArchive io.Reader, dest string, options *archive.T
 	// child
 	r, w, err := os.Pipe()
 	if err != nil {
-		return fmt.Errorf("Untar pipe failure: %v", err)
+		return fmt.Errorf("untar pipe failure: %w", err)
 	}
 
 	if root != "" {
@@ -97,13 +97,13 @@ func invokeUnpack(decompressedArchive io.Reader, dest string, options *archive.T
 
 	if err := cmd.Start(); err != nil {
 		w.Close()
-		return fmt.Errorf("Untar error on re-exec cmd: %v", err)
+		return fmt.Errorf("untar error on re-exec cmd: %w", err)
 	}
 
 	//write the options to the pipe for the untar exec to read
 	if err := json.NewEncoder(w).Encode(options); err != nil {
 		w.Close()
-		return fmt.Errorf("Untar json encode to pipe failed: %v", err)
+		return fmt.Errorf("untar json encode to pipe failed: %w", err)
 	}
 	w.Close()
 
@@ -113,7 +113,7 @@ func invokeUnpack(decompressedArchive io.Reader, dest string, options *archive.T
 		// pending on write pipe forever
 		io.Copy(ioutil.Discard, decompressedArchive)
 
-		return fmt.Errorf("Error processing tar file(%v): %s", err, output)
+		return fmt.Errorf("processing tar file(%w): %s", err, output)
 	}
 	return nil
 }
@@ -185,7 +185,7 @@ func invokePack(srcPath string, options *archive.TarOptions, root string) (io.Re
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
-		return nil, fmt.Errorf("error getting options pipe for tar process: %w", err)
+		return nil, fmt.Errorf("getting options pipe for tar process: %w", err)
 	}
 
 	if err := cmd.Start(); err != nil {
@@ -194,7 +194,7 @@ func invokePack(srcPath string, options *archive.TarOptions, root string) (io.Re
 
 	go func() {
 		err := cmd.Wait()
-		err = fmt.Errorf("error processing tar file: %s: %w", errBuff, err)
+		err = fmt.Errorf("processing tar file: %s: %w", errBuff, err)
 		tarW.CloseWithError(err)
 	}()
 

--- a/pkg/chrootarchive/chroot_linux.go
+++ b/pkg/chrootarchive/chroot_linux.go
@@ -36,7 +36,7 @@ func chroot(path string) (err error) {
 	}
 
 	if err := unix.Unshare(unix.CLONE_NEWNS); err != nil {
-		return fmt.Errorf("Error creating mount namespace before pivot: %v", err)
+		return fmt.Errorf("creating mount namespace before pivot: %w", err)
 	}
 
 	// make everything in new ns private
@@ -53,7 +53,7 @@ func chroot(path string) (err error) {
 	// setup oldRoot for pivot_root
 	pivotDir, err := ioutil.TempDir(path, ".pivot_root")
 	if err != nil {
-		return fmt.Errorf("Error setting up pivot dir: %v", err)
+		return fmt.Errorf("setting up pivot dir: %w", err)
 	}
 
 	var mounted bool
@@ -72,7 +72,7 @@ func chroot(path string) (err error) {
 		// pivotDir doesn't exist if pivot_root failed and chroot+chdir was successful
 		// because we already cleaned it up on failed pivot_root
 		if errCleanup != nil && !os.IsNotExist(errCleanup) {
-			errCleanup = fmt.Errorf("Error cleaning up after pivot: %v", errCleanup)
+			errCleanup = fmt.Errorf("cleaning up after pivot: %w", errCleanup)
 			if err == nil {
 				err = errCleanup
 			}
@@ -82,7 +82,7 @@ func chroot(path string) (err error) {
 	if err := unix.PivotRoot(path, pivotDir); err != nil {
 		// If pivot fails, fall back to the normal chroot after cleaning up temp dir
 		if err := os.Remove(pivotDir); err != nil {
-			return fmt.Errorf("Error cleaning up after failed pivot: %v", err)
+			return fmt.Errorf("cleaning up after failed pivot: %w", err)
 		}
 		return realChroot(path)
 	}
@@ -93,17 +93,17 @@ func chroot(path string) (err error) {
 	pivotDir = filepath.Join("/", filepath.Base(pivotDir))
 
 	if err := unix.Chdir("/"); err != nil {
-		return fmt.Errorf("Error changing to new root: %v", err)
+		return fmt.Errorf("changing to new root: %w", err)
 	}
 
 	// Make the pivotDir (where the old root lives) private so it can be unmounted without propagating to the host
 	if err := unix.Mount("", pivotDir, "", unix.MS_PRIVATE|unix.MS_REC, ""); err != nil {
-		return fmt.Errorf("Error making old root private after pivot: %v", err)
+		return fmt.Errorf("making old root private after pivot: %w", err)
 	}
 
 	// Now unmount the old root so it's no longer visible from the new root
 	if err := unix.Unmount(pivotDir, unix.MNT_DETACH); err != nil {
-		return fmt.Errorf("Error while unmounting old root after pivot: %v", err)
+		return fmt.Errorf("while unmounting old root after pivot: %w", err)
 	}
 	mounted = false
 
@@ -112,10 +112,10 @@ func chroot(path string) (err error) {
 
 func realChroot(path string) error {
 	if err := unix.Chroot(path); err != nil {
-		return fmt.Errorf("Error after fallback to chroot: %v", err)
+		return fmt.Errorf("after fallback to chroot: %w", err)
 	}
 	if err := unix.Chdir("/"); err != nil {
-		return fmt.Errorf("Error changing to new root after chroot: %v", err)
+		return fmt.Errorf("changing to new root after chroot: %w", err)
 	}
 	return nil
 }

--- a/pkg/chrootarchive/diff_unix.go
+++ b/pkg/chrootarchive/diff_unix.go
@@ -1,4 +1,5 @@
-//+build !windows,!darwin
+//go:build !windows && !darwin
+// +build !windows,!darwin
 
 package chrootarchive
 
@@ -68,7 +69,7 @@ func applyLayer() {
 
 	encoder := json.NewEncoder(os.Stdout)
 	if err := encoder.Encode(applyLayerResponse{size}); err != nil {
-		fatal(fmt.Errorf("unable to encode layerSize JSON: %s", err))
+		fatal(fmt.Errorf("unable to encode layerSize JSON: %w", err))
 	}
 
 	if _, err := flush(os.Stdin); err != nil {
@@ -104,7 +105,7 @@ func applyLayerHandler(dest string, layer io.Reader, options *archive.TarOptions
 
 	data, err := json.Marshal(options)
 	if err != nil {
-		return 0, fmt.Errorf("ApplyLayer json encode: %v", err)
+		return 0, fmt.Errorf("ApplyLayer json encode: %w", err)
 	}
 
 	cmd := reexec.Command("storage-applyLayer", dest)
@@ -115,14 +116,14 @@ func applyLayerHandler(dest string, layer io.Reader, options *archive.TarOptions
 	cmd.Stdout, cmd.Stderr = outBuf, errBuf
 
 	if err = cmd.Run(); err != nil {
-		return 0, fmt.Errorf("ApplyLayer %s stdout: %s stderr: %s", err, outBuf, errBuf)
+		return 0, fmt.Errorf("ApplyLayer stdout: %s stderr: %s %w", outBuf, errBuf, err)
 	}
 
 	// Stdout should be a valid JSON struct representing an applyLayerResponse.
 	response := applyLayerResponse{}
 	decoder := json.NewDecoder(outBuf)
 	if err = decoder.Decode(&response); err != nil {
-		return 0, fmt.Errorf("unable to decode ApplyLayer JSON response: %s", err)
+		return 0, fmt.Errorf("unable to decode ApplyLayer JSON response: %w", err)
 	}
 
 	return response.LayerSize, nil

--- a/pkg/chunked/storage_linux.go
+++ b/pkg/chunked/storage_linux.go
@@ -547,7 +547,7 @@ func openFileUnderRootFallback(dirfd int, name string, flags uint64, mode os.Fil
 	// Add an additional check to make sure the opened fd is inside the rootfs
 	if !strings.HasPrefix(target, targetRoot) {
 		unix.Close(fd)
-		return -1, fmt.Errorf("error while resolving %q.  It resolves outside the root directory", name)
+		return -1, fmt.Errorf("while resolving %q.  It resolves outside the root directory", name)
 	}
 
 	return fd, err

--- a/pkg/devicemapper/devmapper.go
+++ b/pkg/devicemapper/devmapper.go
@@ -1,3 +1,4 @@
+//go:build linux && cgo
 // +build linux,cgo
 
 package devicemapper
@@ -805,7 +806,7 @@ func CreateSnapDevice(poolName string, deviceID int, baseName string, baseDevice
 	if err := CreateSnapDeviceRaw(poolName, deviceID, baseDeviceID); err != nil {
 		if doSuspend {
 			if err2 := ResumeDevice(baseName); err2 != nil {
-				return fmt.Errorf("CreateSnapDeviceRaw Error: (%v): ResumeDevice Error: (%v)", err, err2)
+				return fmt.Errorf("CreateSnapDeviceRaw Error: (%v): ResumeDevice Error: %w", err, err2)
 			}
 		}
 		return err

--- a/pkg/idtools/idtools.go
+++ b/pkg/idtools/idtools.go
@@ -119,7 +119,7 @@ func RawToContainer(hostID int, idMap []IDMap) (int, error) {
 			return contID, nil
 		}
 	}
-	return -1, fmt.Errorf("Host ID %d cannot be mapped to a container ID", hostID)
+	return -1, fmt.Errorf("host ID %d cannot be mapped to a container ID", hostID)
 }
 
 // RawToHost takes an id mapping and a remapped ID, and translates the ID to
@@ -139,7 +139,7 @@ func RawToHost(contID int, idMap []IDMap) (int, error) {
 			return hostID, nil
 		}
 	}
-	return -1, fmt.Errorf("Container ID %d cannot be mapped to a host ID", contID)
+	return -1, fmt.Errorf("container ID %d cannot be mapped to a host ID", contID)
 }
 
 // IDPair is a UID and GID pair
@@ -167,10 +167,10 @@ func NewIDMappings(username, groupname string) (*IDMappings, error) {
 		return nil, err
 	}
 	if len(subuidRanges) == 0 {
-		return nil, fmt.Errorf("No subuid ranges found for user %q in %s", username, subuidFileName)
+		return nil, fmt.Errorf("no subuid ranges found for user %q in %s", username, subuidFileName)
 	}
 	if len(subgidRanges) == 0 {
-		return nil, fmt.Errorf("No subgid ranges found for group %q in %s", groupname, subgidFileName)
+		return nil, fmt.Errorf("no subgid ranges found for group %q in %s", groupname, subgidFileName)
 	}
 
 	return &IDMappings{
@@ -342,16 +342,16 @@ func parseSubidFile(path, username string) (ranges, error) {
 		}
 		parts := strings.Split(text, ":")
 		if len(parts) != 3 {
-			return rangeList, fmt.Errorf("Cannot parse subuid/gid information: Format not correct for %s file", path)
+			return rangeList, fmt.Errorf("cannot parse subuid/gid information: Format not correct for %s file", path)
 		}
 		if parts[0] == username || username == "ALL" || (parts[0] == uidstr && parts[0] != "") {
 			startid, err := strconv.Atoi(parts[1])
 			if err != nil {
-				return rangeList, fmt.Errorf("String to int conversion failed during subuid/gid parsing of %s: %v", path, err)
+				return rangeList, fmt.Errorf("string to int conversion failed during subuid/gid parsing of %s: %w", path, err)
 			}
 			length, err := strconv.Atoi(parts[2])
 			if err != nil {
-				return rangeList, fmt.Errorf("String to int conversion failed during subuid/gid parsing of %s: %v", path, err)
+				return rangeList, fmt.Errorf("string to int conversion failed during subuid/gid parsing of %s: %w", path, err)
 			}
 			rangeList = append(rangeList, subIDRange{startid, length})
 		}

--- a/pkg/idtools/idtools_unix.go
+++ b/pkg/idtools/idtools_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package idtools

--- a/pkg/idtools/idtools_unix_test.go
+++ b/pkg/idtools/idtools_unix_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package idtools
@@ -174,10 +175,10 @@ func buildTree(base string, tree map[string]node) error {
 	for path, node := range tree {
 		fullPath := filepath.Join(base, path)
 		if err := os.MkdirAll(fullPath, 0755); err != nil {
-			return fmt.Errorf("Couldn't create path: %s; error: %v", fullPath, err)
+			return fmt.Errorf("couldn't create path: %s; error: %w", fullPath, err)
 		}
 		if err := os.Chown(fullPath, node.uid, node.gid); err != nil {
-			return fmt.Errorf("Couldn't chown path: %s; error: %v", fullPath, err)
+			return fmt.Errorf("couldn't chown path: %s; error: %w", fullPath, err)
 		}
 	}
 	return nil
@@ -188,13 +189,13 @@ func readTree(base, root string) (map[string]node, error) {
 
 	dirInfos, err := ioutil.ReadDir(base)
 	if err != nil {
-		return nil, fmt.Errorf("Couldn't read directory entries for %q: %v", base, err)
+		return nil, fmt.Errorf("couldn't read directory entries for %q: %w", base, err)
 	}
 
 	for _, info := range dirInfos {
 		s := &unix.Stat_t{}
 		if err := unix.Stat(filepath.Join(base, info.Name()), s); err != nil {
-			return nil, fmt.Errorf("Can't stat file %q: %v", filepath.Join(base, info.Name()), err)
+			return nil, fmt.Errorf("can't stat file %q: %w", filepath.Join(base, info.Name()), err)
 		}
 		tree[filepath.Join(root, info.Name())] = node{int(s.Uid), int(s.Gid)}
 		if info.IsDir() {
@@ -213,7 +214,7 @@ func readTree(base, root string) (map[string]node, error) {
 
 func compareTrees(left, right map[string]node) error {
 	if len(left) != len(right) {
-		return fmt.Errorf("Trees aren't the same size")
+		return fmt.Errorf("trees aren't the same size")
 	}
 	for path, nodeLeft := range left {
 		if nodeRight, ok := right[path]; ok {

--- a/pkg/idtools/parser.go
+++ b/pkg/idtools/parser.go
@@ -11,22 +11,22 @@ import (
 func parseTriple(spec []string) (container, host, size uint32, err error) {
 	cid, err := strconv.ParseUint(spec[0], 10, 32)
 	if err != nil {
-		return 0, 0, 0, fmt.Errorf("error parsing id map value %q: %v", spec[0], err)
+		return 0, 0, 0, fmt.Errorf("parsing id map value %q: %w", spec[0], err)
 	}
 	hid, err := strconv.ParseUint(spec[1], 10, 32)
 	if err != nil {
-		return 0, 0, 0, fmt.Errorf("error parsing id map value %q: %v", spec[1], err)
+		return 0, 0, 0, fmt.Errorf("parsing id map value %q: %w", spec[1], err)
 	}
 	sz, err := strconv.ParseUint(spec[2], 10, 32)
 	if err != nil {
-		return 0, 0, 0, fmt.Errorf("error parsing id map value %q: %v", spec[2], err)
+		return 0, 0, 0, fmt.Errorf("parsing id map value %q: %w", spec[2], err)
 	}
 	return uint32(cid), uint32(hid), uint32(sz), nil
 }
 
 // ParseIDMap parses idmap triples from string.
 func ParseIDMap(mapSpec []string, mapSetting string) (idmap []IDMap, err error) {
-	stdErr := fmt.Errorf("error initializing ID mappings: %s setting is malformed expected [\"uint32:uint32:uint32\"]: %q", mapSetting, mapSpec)
+	stdErr := fmt.Errorf("initializing ID mappings: %s setting is malformed expected [\"uint32:uint32:uint32\"]: %q", mapSetting, mapSpec)
 	for _, idMapSpec := range mapSpec {
 		if idMapSpec == "" {
 			continue

--- a/pkg/idtools/usergroupadd_unsupported.go
+++ b/pkg/idtools/usergroupadd_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package idtools
@@ -8,5 +9,5 @@ import "fmt"
 // and calls the appropriate helper function to add the group and then
 // the user to the group in /etc/group and /etc/passwd respectively.
 func AddNamespaceRangesUser(name string) (int, int, error) {
-	return -1, -1, fmt.Errorf("No support for adding users or groups on this OS")
+	return -1, -1, fmt.Errorf("no support for adding users or groups on this OS")
 }

--- a/pkg/idtools/utils_unix.go
+++ b/pkg/idtools/utils_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package idtools
@@ -23,7 +24,7 @@ func resolveBinary(binname string) (string, error) {
 	if filepath.Base(resolvedPath) == binname {
 		return resolvedPath, nil
 	}
-	return "", fmt.Errorf("Binary %q does not resolve to a binary of that name in $PATH (%q)", binname, resolvedPath)
+	return "", fmt.Errorf("binary %q does not resolve to a binary of that name in $PATH (%q)", binname, resolvedPath)
 }
 
 func execCmd(cmd, args string) ([]byte, error) {

--- a/pkg/ioutils/readers_test.go
+++ b/pkg/ioutils/readers_test.go
@@ -15,16 +15,16 @@ import (
 type errorReader struct{}
 
 func (r *errorReader) Read(p []byte) (int, error) {
-	return 0, fmt.Errorf("error reader always fail")
+	return 0, fmt.Errorf("reader always fail")
 }
 
 func TestReadCloserWrapperClose(t *testing.T) {
 	reader := strings.NewReader("A string reader")
 	wrapper := NewReadCloserWrapper(reader, func() error {
-		return fmt.Errorf("This will be called when closing")
+		return fmt.Errorf("this will be called when closing")
 	})
 	err := wrapper.Close()
-	if err == nil || !strings.Contains(err.Error(), "This will be called when closing") {
+	if err == nil || !strings.Contains(err.Error(), "this will be called when closing") {
 		t.Fatalf("readCloserWrapper should have call the anonymous func and thus, fail.")
 	}
 }
@@ -36,7 +36,7 @@ func TestReaderErrWrapperReadOnError(t *testing.T) {
 		called = true
 	})
 	_, err := wrapper.Read([]byte{})
-	assert.EqualError(t, err, "error reader always fail")
+	assert.EqualError(t, err, "reader always fail")
 	if !called {
 		t.Fatalf("readErrWrapper should have call the anonymous function on failure")
 	}

--- a/pkg/lockfile/lockfile.go
+++ b/pkg/lockfile/lockfile.go
@@ -86,7 +86,7 @@ func getLockfile(path string, ro bool) (Locker, error) {
 	}
 	cleanPath, err := filepath.Abs(path)
 	if err != nil {
-		return nil, fmt.Errorf("error ensuring that path %q is an absolute path: %w", path, err)
+		return nil, fmt.Errorf("ensuring that path %q is an absolute path: %w", path, err)
 	}
 	if locker, ok := lockfiles[cleanPath]; ok {
 		if ro && locker.IsReadWrite() {

--- a/pkg/lockfile/lockfile_unix.go
+++ b/pkg/lockfile/lockfile_unix.go
@@ -111,7 +111,7 @@ func createLockerForPath(path string, ro bool) (Locker, error) {
 	// Check if we can open the lock.
 	fd, err := openLock(path, ro)
 	if err != nil {
-		return nil, fmt.Errorf("error opening %q: %w", path, err)
+		return nil, err
 	}
 	unix.Close(fd)
 

--- a/pkg/mount/flags.go
+++ b/pkg/mount/flags.go
@@ -99,7 +99,7 @@ func MergeTmpfsOptions(options []string) ([]string, error) {
 		}
 		opt := strings.SplitN(option, "=", 2)
 		if len(opt) != 2 || !validFlags[opt[0]] {
-			return nil, fmt.Errorf("Invalid tmpfs option %q", opt)
+			return nil, fmt.Errorf("invalid tmpfs option %q", opt)
 		}
 		if !dataCollisions[opt[0]] {
 			// We prepend the option and add to collision map
@@ -142,7 +142,7 @@ func ParseTmpfsOptions(options string) (int, string, error) {
 	for _, o := range strings.Split(data, ",") {
 		opt := strings.SplitN(o, "=", 2)
 		if !validFlags[opt[0]] {
-			return 0, "", fmt.Errorf("Invalid tmpfs option %q", opt)
+			return 0, "", fmt.Errorf("invalid tmpfs option %q", opt)
 		}
 	}
 	return flags, data, nil

--- a/pkg/mount/mounter_freebsd.go
+++ b/pkg/mount/mounter_freebsd.go
@@ -62,7 +62,7 @@ func mount(device, target, mType string, flag uintptr, data string) error {
 
 	if errno := C.nmount(&rawOptions[0], C.uint(len(options)), C.int(flag)); errno != 0 {
 		reason := C.GoString(C.strerror(*C.__error()))
-		return fmt.Errorf("Failed to call nmount: %s", reason)
+		return fmt.Errorf("failed to call nmount: %s", reason)
 	}
 	return nil
 }

--- a/pkg/parsers/kernel/kernel_darwin.go
+++ b/pkg/parsers/kernel/kernel_darwin.go
@@ -1,3 +1,4 @@
+//go:build darwin
 // +build darwin
 
 // Package kernel provides helper function to get, parse and compare kernel
@@ -37,16 +38,16 @@ func getRelease() (string, error) {
 			// It has the format like '      Kernel Version: Darwin 14.5.0'
 			content := strings.SplitN(line, ":", 2)
 			if len(content) != 2 {
-				return "", fmt.Errorf("Kernel Version is invalid")
+				return "", fmt.Errorf("kernel version is invalid")
 			}
 
 			prettyNames, err := shellwords.Parse(content[1])
 			if err != nil {
-				return "", fmt.Errorf("Kernel Version is invalid: %s", err.Error())
+				return "", fmt.Errorf("kernel version is invalid: %s", err.Error())
 			}
 
 			if len(prettyNames) != 2 {
-				return "", fmt.Errorf("Kernel Version needs to be 'Darwin x.x.x' ")
+				return "", fmt.Errorf("kernel version needs to be 'Darwin x.x.x' ")
 			}
 			release = prettyNames[1]
 		}

--- a/pkg/parsers/operatingsystem/operatingsystem_linux.go
+++ b/pkg/parsers/operatingsystem/operatingsystem_linux.go
@@ -29,11 +29,11 @@ func GetOperatingSystem() (string, error) {
 	osReleaseFile, err := os.Open(etcOsRelease)
 	if err != nil {
 		if !os.IsNotExist(err) {
-			return "", fmt.Errorf("Error opening %s: %v", etcOsRelease, err)
+			return "", err
 		}
 		osReleaseFile, err = os.Open(altOsRelease)
 		if err != nil {
-			return "", fmt.Errorf("Error opening %s: %v", altOsRelease, err)
+			return "", err
 		}
 	}
 	defer osReleaseFile.Close()

--- a/pkg/parsers/parsers.go
+++ b/pkg/parsers/parsers.go
@@ -13,7 +13,7 @@ import (
 func ParseKeyValueOpt(opt string) (string, string, error) {
 	parts := strings.SplitN(opt, "=", 2)
 	if len(parts) != 2 {
-		return "", "", fmt.Errorf("Unable to parse key/value option: %s", opt)
+		return "", "", fmt.Errorf("unable to parse key/value option: %s", opt)
 	}
 	return strings.TrimSpace(parts[0]), strings.TrimSpace(parts[1]), nil
 }

--- a/pkg/parsers/parsers_test.go
+++ b/pkg/parsers/parsers_test.go
@@ -7,8 +7,8 @@ import (
 
 func TestParseKeyValueOpt(t *testing.T) {
 	invalids := map[string]string{
-		"":    "Unable to parse key/value option: ",
-		"key": "Unable to parse key/value option: key",
+		"":    "unable to parse key/value option: ",
+		"key": "unable to parse key/value option: key",
 	}
 	for invalid, expectedError := range invalids {
 		if _, _, err := ParseKeyValueOpt(invalid); err == nil || err.Error() != expectedError {

--- a/pkg/system/meminfo_freebsd.go
+++ b/pkg/system/meminfo_freebsd.go
@@ -19,7 +19,7 @@ import "C"
 func getMemInfo() (int64, int64, error) {
 	data, err := unix.SysctlRaw("vm.vmtotal")
 	if err != nil {
-		return -1, -1, fmt.Errorf("Can't get kernel info: %v", err)
+		return -1, -1, fmt.Errorf("can't get kernel info: %w", err)
 	}
 	if len(data) != C.sizeof_struct_vmtotal {
 		return -1, -1, fmt.Errorf("unexpected vmtotal size %d", len(data))
@@ -39,12 +39,12 @@ func getSwapInfo() (int64, int64, error) {
 	)
 	swapCount, err := unix.SysctlUint32("vm.nswapdev")
 	if err != nil {
-		return -1, -1, fmt.Errorf("error reading vm.nswapdev: %v", err)
+		return -1, -1, fmt.Errorf("reading vm.nswapdev: %w", err)
 	}
 	for i := 0; i < int(swapCount); i++ {
 		data, err := unix.SysctlRaw("vm.swap_info", i)
 		if err != nil {
-			return -1, -1, fmt.Errorf("error reading vm.swap_info.%d: %v", i, err)
+			return -1, -1, fmt.Errorf("reading vm.swap_info.%d: %w", i, err)
 		}
 		if len(data) != C.sizeof_struct_xswdev {
 			return -1, -1, fmt.Errorf("unexpected swap_info size %d", len(data))
@@ -62,15 +62,15 @@ func getSwapInfo() (int64, int64, error) {
 func ReadMemInfo() (*MemInfo, error) {
 	MemTotal, MemFree, err := getMemInfo()
 	if err != nil {
-		return nil, fmt.Errorf("error getting memory totals %v\n", err)
+		return nil, fmt.Errorf("getting memory totals %w", err)
 	}
 	SwapTotal, SwapFree, err := getSwapInfo()
 	if err != nil {
-		return nil, fmt.Errorf("error getting swap totals %v\n", err)
+		return nil, fmt.Errorf("getting swap totals %w", err)
 	}
 
 	if MemTotal < 0 || MemFree < 0 || SwapTotal < 0 || SwapFree < 0 {
-		return nil, fmt.Errorf("error getting system memory info %v\n", err)
+		return nil, fmt.Errorf("getting system memory info %w", err)
 	}
 
 	meminfo := &MemInfo{}

--- a/pkg/system/meminfo_solaris.go
+++ b/pkg/system/meminfo_solaris.go
@@ -1,3 +1,4 @@
+//go:build solaris && cgo
 // +build solaris,cgo
 
 package system
@@ -90,7 +91,7 @@ func ReadMemInfo() (*MemInfo, error) {
 
 	if ppKernel < 0 || MemTotal < 0 || MemFree < 0 || SwapTotal < 0 ||
 		SwapFree < 0 {
-		return nil, fmt.Errorf("error getting system memory info %v\n", err)
+		return nil, fmt.Errorf("getting system memory info %w", err)
 	}
 
 	meminfo := &MemInfo{}

--- a/pkg/system/path_windows.go
+++ b/pkg/system/path_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package system
@@ -21,13 +22,13 @@ import (
 // d:\			--> Fail
 func CheckSystemDriveAndRemoveDriveLetter(path string) (string, error) {
 	if len(path) == 2 && string(path[1]) == ":" {
-		return "", fmt.Errorf("No relative path specified in %q", path)
+		return "", fmt.Errorf("relative path not specified in %q", path)
 	}
 	if !filepath.IsAbs(path) || len(path) < 2 {
 		return filepath.FromSlash(path), nil
 	}
 	if string(path[1]) == ":" && !strings.EqualFold(string(path[0]), "c") {
-		return "", fmt.Errorf("The specified path is not on the system drive (C:)")
+		return "", fmt.Errorf("specified path is not on the system drive (C:)")
 	}
 	return filepath.FromSlash(path[2:]), nil
 }

--- a/pkg/system/rm.go
+++ b/pkg/system/rm.go
@@ -67,7 +67,7 @@ func EnsureRemoveAll(dir string) error {
 		}
 
 		if e := mount.Unmount(pe.Path); e != nil {
-			return fmt.Errorf("error while removing %s: %w", dir, e)
+			return fmt.Errorf("while removing %s: %w", dir, e)
 		}
 
 		if exitOnErr[pe.Path] == maxRetry {

--- a/pkg/unshare/unshare_freebsd.go
+++ b/pkg/unshare/unshare_freebsd.go
@@ -49,7 +49,7 @@ func (c *Cmd) Start() error {
 	// Create the pipe for reading the child's PID.
 	pidRead, pidWrite, err := os.Pipe()
 	if err != nil {
-		return fmt.Errorf("error creating pid pipe: %w", err)
+		return fmt.Errorf("creating pid pipe: %w", err)
 	}
 	c.Env = append(c.Env, fmt.Sprintf("_Containers-pid-pipe=%d", len(c.ExtraFiles)+3))
 	c.ExtraFiles = append(c.ExtraFiles, pidWrite)
@@ -59,7 +59,7 @@ func (c *Cmd) Start() error {
 	if err != nil {
 		pidRead.Close()
 		pidWrite.Close()
-		return fmt.Errorf("error creating pid pipe: %w", err)
+		return fmt.Errorf("creating pid pipe: %w", err)
 	}
 	c.Env = append(c.Env, fmt.Sprintf("_Containers-continue-pipe=%d", len(c.ExtraFiles)+3))
 	c.ExtraFiles = append(c.ExtraFiles, continueRead)
@@ -108,13 +108,13 @@ func (c *Cmd) Start() error {
 	pidString := ""
 	b := new(bytes.Buffer)
 	if _, err := io.Copy(b, pidRead); err != nil {
-		return fmt.Errorf("Reading child PID: %w", err)
+		return fmt.Errorf("reading child PID: %w", err)
 	}
 	pidString = b.String()
 	pid, err := strconv.Atoi(pidString)
 	if err != nil {
 		fmt.Fprintf(continueWrite, "error parsing PID %q: %v", pidString, err)
-		return fmt.Errorf("error parsing PID %q: %w", pidString, err)
+		return fmt.Errorf("parsing PID %q: %w", pidString, err)
 	}
 
 	// Run any additional setup that we want to do before the child starts running proper.

--- a/store.go
+++ b/store.go
@@ -1248,13 +1248,13 @@ func (s *store) imageTopLayerForMapping(image *Image, ristore ROImageStore, crea
 		layerOptions.TemplateLayer = layer.ID
 		mappedLayer, _, err := rlstore.Put("", parentLayer, nil, layer.MountLabel, nil, &layerOptions, false, nil, nil)
 		if err != nil {
-			return nil, fmt.Errorf("error creating an ID-mapped copy of layer %q: %w", layer.ID, err)
+			return nil, fmt.Errorf("creating an ID-mapped copy of layer %q: %w", layer.ID, err)
 		}
 		if err = istore.addMappedTopLayer(image.ID, mappedLayer.ID); err != nil {
 			if err2 := rlstore.Delete(mappedLayer.ID); err2 != nil {
-				err = fmt.Errorf("error deleting layer %q: %v: %w", mappedLayer.ID, err2, err)
+				err = fmt.Errorf("deleting layer %q: %v: %w", mappedLayer.ID, err2, err)
 			}
-			return nil, fmt.Errorf("error registering ID-mapped layer with image %q: %w", image.ID, err)
+			return nil, fmt.Errorf("registering ID-mapped layer with image %q: %w", image.ID, err)
 		}
 		layer = mappedLayer
 	}
@@ -1330,7 +1330,7 @@ func (s *store) CreateContainer(id string, names []string, image, layer, metadat
 			}
 		}
 		if cimage == nil {
-			return nil, fmt.Errorf("error locating image with ID %q: %w", image, ErrImageUnknown)
+			return nil, fmt.Errorf("locating image with ID %q: %w", image, ErrImageUnknown)
 		}
 		imageID = cimage.ID
 	}
@@ -1561,7 +1561,7 @@ func (s *store) ListImageBigData(id string) ([]string, error) {
 			return bigDataNames, err
 		}
 	}
-	return nil, fmt.Errorf("error locating image with ID %q: %w", id, ErrImageUnknown)
+	return nil, fmt.Errorf("locating image with ID %q: %w", id, ErrImageUnknown)
 }
 
 func (s *store) ImageBigDataSize(id, key string) (int64, error) {
@@ -1639,9 +1639,9 @@ func (s *store) ImageBigData(id, key string) ([]byte, error) {
 		}
 	}
 	if foundImage {
-		return nil, fmt.Errorf("error locating item named %q for image with ID %q (consider removing the image to resolve the issue): %w", key, id, os.ErrNotExist)
+		return nil, fmt.Errorf("locating item named %q for image with ID %q (consider removing the image to resolve the issue): %w", key, id, os.ErrNotExist)
 	}
-	return nil, fmt.Errorf("error locating image with ID %q: %w", id, ErrImageUnknown)
+	return nil, fmt.Errorf("locating image with ID %q: %w", id, ErrImageUnknown)
 }
 
 // ListLayerBigData retrieves a list of the (possibly large) chunks of
@@ -1672,9 +1672,9 @@ func (s *store) ListLayerBigData(id string) ([]string, error) {
 		}
 	}
 	if foundLayer {
-		return nil, fmt.Errorf("error locating big data for layer with ID %q: %w", id, os.ErrNotExist)
+		return nil, fmt.Errorf("locating big data for layer with ID %q: %w", id, os.ErrNotExist)
 	}
-	return nil, fmt.Errorf("error locating layer with ID %q: %w", id, ErrLayerUnknown)
+	return nil, fmt.Errorf("locating layer with ID %q: %w", id, ErrLayerUnknown)
 }
 
 // LayerBigData retrieves a (possibly large) chunk of named data
@@ -1705,9 +1705,9 @@ func (s *store) LayerBigData(id, key string) (io.ReadCloser, error) {
 		}
 	}
 	if foundLayer {
-		return nil, fmt.Errorf("error locating item named %q for layer with ID %q: %w", key, id, os.ErrNotExist)
+		return nil, fmt.Errorf("locating item named %q for layer with ID %q: %w", key, id, os.ErrNotExist)
 	}
-	return nil, fmt.Errorf("error locating layer with ID %q: %w", id, ErrLayerUnknown)
+	return nil, fmt.Errorf("locating layer with ID %q: %w", id, ErrLayerUnknown)
 }
 
 // SetLayerBigData stores a (possibly large) chunk of named data
@@ -1746,11 +1746,11 @@ func (s *store) ImageSize(id string) (int64, error) {
 
 	lstore, err := s.LayerStore()
 	if err != nil {
-		return -1, fmt.Errorf("error loading primary layer store data: %w", err)
+		return -1, fmt.Errorf("loading primary layer store data: %w", err)
 	}
 	lstores, err := s.ROLayerStores()
 	if err != nil {
-		return -1, fmt.Errorf("error loading additional layer stores: %w", err)
+		return -1, fmt.Errorf("loading additional layer stores: %w", err)
 	}
 	for _, s := range append([]ROLayerStore{lstore}, lstores...) {
 		store := s
@@ -1764,11 +1764,11 @@ func (s *store) ImageSize(id string) (int64, error) {
 	var imageStore ROBigDataStore
 	istore, err := s.ImageStore()
 	if err != nil {
-		return -1, fmt.Errorf("error loading primary image store data: %w", err)
+		return -1, fmt.Errorf("loading primary image store data: %w", err)
 	}
 	istores, err := s.ROImageStores()
 	if err != nil {
-		return -1, fmt.Errorf("error loading additional image stores: %w", err)
+		return -1, fmt.Errorf("loading additional image stores: %w", err)
 	}
 
 	// Look for the image's record.
@@ -1785,7 +1785,7 @@ func (s *store) ImageSize(id string) (int64, error) {
 		}
 	}
 	if image == nil {
-		return -1, fmt.Errorf("error locating image with ID %q: %w", id, ErrImageUnknown)
+		return -1, fmt.Errorf("locating image with ID %q: %w", id, ErrImageUnknown)
 	}
 
 	// Start with a list of the image's top layers, if it has any.
@@ -1815,7 +1815,7 @@ func (s *store) ImageSize(id string) (int64, error) {
 				}
 			}
 			if layer == nil {
-				return -1, fmt.Errorf("error locating layer with ID %q: %w", layerID, ErrLayerUnknown)
+				return -1, fmt.Errorf("locating layer with ID %q: %w", layerID, ErrLayerUnknown)
 			}
 			// The UncompressedSize is only valid if there's a digest to go with it.
 			n := layer.UncompressedSize
@@ -1838,12 +1838,12 @@ func (s *store) ImageSize(id string) (int64, error) {
 	// Count big data items.
 	names, err := imageStore.BigDataNames(id)
 	if err != nil {
-		return -1, fmt.Errorf("error reading list of big data items for image %q: %w", id, err)
+		return -1, fmt.Errorf("reading list of big data items for image %q: %w", id, err)
 	}
 	for _, name := range names {
 		n, err := imageStore.BigDataSize(id, name)
 		if err != nil {
-			return -1, fmt.Errorf("error reading size of big data item %q for image %q: %w", name, id, err)
+			return -1, fmt.Errorf("reading size of big data item %q for image %q: %w", name, id, err)
 		}
 		size += n
 	}
@@ -1903,24 +1903,24 @@ func (s *store) ContainerSize(id string) (int64, error) {
 		if layer, err = store.Get(container.LayerID); err == nil {
 			size, err = store.DiffSize("", layer.ID)
 			if err != nil {
-				return -1, fmt.Errorf("error determining size of layer with ID %q: %w", layer.ID, err)
+				return -1, fmt.Errorf("determining size of layer with ID %q: %w", layer.ID, err)
 			}
 			break
 		}
 	}
 	if layer == nil {
-		return -1, fmt.Errorf("error locating layer with ID %q: %w", container.LayerID, ErrLayerUnknown)
+		return -1, fmt.Errorf("locating layer with ID %q: %w", container.LayerID, ErrLayerUnknown)
 	}
 
 	// Count big data items.
 	names, err := rcstore.BigDataNames(id)
 	if err != nil {
-		return -1, fmt.Errorf("error reading list of big data items for container %q: %w", container.ID, err)
+		return -1, fmt.Errorf("reading list of big data items for container %q: %w", container.ID, err)
 	}
 	for _, name := range names {
 		n, err := rcstore.BigDataSize(id, name)
 		if err != nil {
-			return -1, fmt.Errorf("error reading size of big data item %q for container %q: %w", name, id, err)
+			return -1, fmt.Errorf("reading size of big data item %q for container %q: %w", name, id, err)
 		}
 		size += n
 	}
@@ -3064,14 +3064,14 @@ func (s *store) layersByMappedDigest(m func(ROLayerStore, digest.Digest) ([]Laye
 
 func (s *store) LayersByCompressedDigest(d digest.Digest) ([]Layer, error) {
 	if err := d.Validate(); err != nil {
-		return nil, fmt.Errorf("error looking for compressed layers matching digest %q: %w", d, err)
+		return nil, fmt.Errorf("looking for compressed layers matching digest %q: %w", d, err)
 	}
 	return s.layersByMappedDigest(func(r ROLayerStore, d digest.Digest) ([]Layer, error) { return r.LayersByCompressedDigest(d) }, d)
 }
 
 func (s *store) LayersByUncompressedDigest(d digest.Digest) ([]Layer, error) {
 	if err := d.Validate(); err != nil {
-		return nil, fmt.Errorf("error looking for layers matching digest %q: %w", d, err)
+		return nil, fmt.Errorf("looking for layers matching digest %q: %w", d, err)
 	}
 	return s.layersByMappedDigest(func(r ROLayerStore, d digest.Digest) ([]Layer, error) { return r.LayersByUncompressedDigest(d) }, d)
 }
@@ -3351,7 +3351,7 @@ func (s *store) Image(id string) (*Image, error) {
 			return image, nil
 		}
 	}
-	return nil, fmt.Errorf("error locating image with ID %q: %w", id, ErrImageUnknown)
+	return nil, fmt.Errorf("locating image with ID %q: %w", id, ErrImageUnknown)
 }
 
 func (s *store) ImagesByTopLayer(id string) ([]*Image, error) {


### PR DESCRIPTION
Also returned errors should not begine with a capatalized errors.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>