### PR TITLE
Do not error if no storage.conf exists

### DIFF
--- a/types/options.go
+++ b/types/options.go
@@ -1,6 +1,7 @@
 package types
 
 import (
+	"errors"
 	"fmt"
 	"os"
 	"path/filepath"
@@ -60,7 +61,7 @@ func loadDefaultStoreOptions() {
 		if !os.IsNotExist(err) {
 			logrus.Warningf("Attempting to use %s, %v", defaultConfigFile, err)
 		}
-		if err := ReloadConfigurationFileIfNeeded(defaultConfigFile, &defaultStoreOptions); err != nil {
+		if err := ReloadConfigurationFileIfNeeded(defaultConfigFile, &defaultStoreOptions); err != nil && !errors.Is(err, os.ErrNotExist) {
 			loadDefaultStoreOptionsErr = err
 			return
 		}


### PR DESCRIPTION
This allows consumers of this library to rely on the in-memory default rather than requiring a storage.conf.

Refers to https://github.com/containers/storage/pull/1279 (1f647d954f0ba1d185baa23dc4b94b56ea4fb24e) and https://github.com/containers/storage/pull/1279/commits/1f647d954f0ba1d185baa23dc4b94b56ea4fb24e#r920899670
