### PR TITLE
diff: create missing layers dirs with 0755

### DIFF
--- a/pkg/archive/diff.go
+++ b/pkg/archive/diff.go
@@ -86,7 +86,7 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 			parentPath := filepath.Join(dest, parent)
 
 			if _, err := os.Lstat(parentPath); err != nil && os.IsNotExist(err) {
-				err = os.MkdirAll(parentPath, 0600)
+				err = os.MkdirAll(parentPath, 0755)
 				if err != nil {
 					return 0, err
 				}


### PR DESCRIPTION
if the parent directory is missing when creating a directory or
extracting a file from the tarball, then create the missing parent
directories with mode 0755 instead of 0600 so that a container can run
with uid != 0.

Closes: https://github.com/containers/storage/issues/1288

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>