### PR TITLE
Fix missing error check in device mapper

### DIFF
--- a/drivers/devmapper/device_setup.go
+++ b/drivers/devmapper/device_setup.go
@@ -177,8 +177,10 @@ func writeLVMConfig(root string, cfg directLVMConfig) error {
 	if err != nil {
 		return fmt.Errorf("marshalling direct lvm config: %w", err)
 	}
-	err = ioutil.WriteFile(p, b, 0600)
-	return fmt.Errorf("writing direct lvm config to file: %w", err)
+	if err := ioutil.WriteFile(p, b, 0600); err != nil {
+		return fmt.Errorf("writing direct lvm config to file: %w", err)
+	}
+	return nil
 }
 
 func setupDirectLVM(cfg directLVMConfig) error {


### PR DESCRIPTION
We missed that error check during the conversion, which is now fixed.
