### PR TITLE
fix return error in device mapper

### DIFF
--- a/drivers/devmapper/device_setup.go
+++ b/drivers/devmapper/device_setup.go
@@ -166,9 +166,10 @@ func readLVMConfig(root string) (directLVMConfig, error) {
 	if len(b) == 0 {
 		return cfg, nil
 	}
-
-	err = json.Unmarshal(b, &cfg)
-	return cfg, fmt.Errorf("unmarshaling previous device setup config: %w", err)
+	if err := json.Unmarshal(b, &cfg); err != nil {
+		return cfg, fmt.Errorf("unmarshaling previous device setup config: %w", err)
+	}
+	return cfg, nil
 }
 
 func writeLVMConfig(root string, cfg directLVMConfig) error {


### PR DESCRIPTION
The function readLVMConfig always returns an error.

Signed-off-by: Alice Frosi <afrosi@redhat.com>