### PR TITLE
Remove a couple of cases of possibly wrapping `nil` as errors

### DIFF
--- a/images.go
+++ b/images.go
@@ -242,8 +242,8 @@ func (i *Image) recomputeDigests() error {
 		if !bigDataNameIsManifest(name) {
 			continue
 		}
-		if digest.Validate() != nil {
-			return fmt.Errorf("validating digest %q for big data item %q: %w", string(digest), name, digest.Validate())
+		if err := digest.Validate(); err != nil {
+			return fmt.Errorf("validating digest %q for big data item %q: %w", string(digest), name, err)
 		}
 		// Deduplicate the digest values.
 		if _, known := digests[digest]; !known {

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -1472,7 +1472,7 @@ func CopyFileWithTarAndChown(chownOpts *idtools.IDPair, hasher io.Writer, uidmap
 				err = fmt.Errorf("extracting data to %q while copying: %w", dest, err)
 			}
 			hashWorker.Wait()
-			if err == nil {
+			if err == nil && hashError != nil {
 				err = fmt.Errorf("calculating digest of data for %q while copying: %w", dest, hashError)
 			}
 			return err

--- a/pkg/chrootarchive/archive.go
+++ b/pkg/chrootarchive/archive.go
@@ -136,7 +136,7 @@ func CopyFileWithTarAndChown(chownOpts *idtools.IDPair, hasher io.Writer, uidmap
 				err = fmt.Errorf("extracting data to %q while copying: %w", dest, err)
 			}
 			hashWorker.Wait()
-			if err == nil {
+			if err == nil && hashError != nil {
 				err = fmt.Errorf("calculating digest of data for %q while copying: %w", dest, hashError)
 			}
 			return err

--- a/pkg/system/meminfo_freebsd.go
+++ b/pkg/system/meminfo_freebsd.go
@@ -70,7 +70,7 @@ func ReadMemInfo() (*MemInfo, error) {
 	}
 
 	if MemTotal < 0 || MemFree < 0 || SwapTotal < 0 || SwapFree < 0 {
-		return nil, fmt.Errorf("getting system memory info %w", err)
+		return nil, errors.New("getting system memory info")
 	}
 
 	meminfo := &MemInfo{}


### PR DESCRIPTION
There are a few places that look like we could end up passing a `nil` value to `fmt.Errorf()`'s "%w" specifier, and one where we were calling `Validate()` on a `Digest` a second time to wrap an error result instead of just reusing it.