### PR TITLE
[release-1.40] [CI:DOCS] Cirrus: Use the latest imgts container

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -132,7 +132,7 @@ lint_task:
 meta_task:
 
     container:
-        image: "quay.io/libpod/imgts:${IMAGE_SUFFIX}"
+        image: "quay.io/libpod/imgts:latest"
         cpu: 1
         memory: 1
 


### PR DESCRIPTION
Contains important updates re: preserving release-branch CI VM images.
Ref: https://github.com/containers/automation_images/pull/157

Signed-off-by: Chris Evich <cevich@redhat.com>