### PR TITLE
pkg/unshare: declare init() as static

### DIFF
--- a/pkg/unshare/unshare_cgo.go
+++ b/pkg/unshare/unshare_cgo.go
@@ -5,7 +5,7 @@ package unshare
 
 // #cgo CFLAGS: -Wall
 // extern void _containers_unshare(void);
-// void __attribute__((constructor)) init(void) {
+// static void __attribute__((constructor)) init(void) {
 //   _containers_unshare();
 // }
 import "C"

--- a/pkg/unshare/unshare_gccgo.go
+++ b/pkg/unshare/unshare_gccgo.go
@@ -4,7 +4,7 @@ package unshare
 
 // #cgo CFLAGS: -Wall -Wextra
 // extern void _containers_unshare(void);
-// void __attribute__((constructor)) init(void) {
+// static void __attribute__((constructor)) init(void) {
 //   _containers_unshare();
 // }
 import "C"


### PR DESCRIPTION
This commit declare C init() function as static, since this is a constructor there is no need to export this symbol, avoiding errors like 'multiple definitions error' when linking the binary.

Fixes: #1304