### PR TITLE
replace syscall.Pause with <-time.After(math.MaxInt) for arm64 platform

### DIFF
--- a/drivers/overlay/idmapped_utils.go
+++ b/drivers/overlay/idmapped_utils.go
@@ -6,8 +6,10 @@ package overlay
 import (
 	"fmt"
 	"io/ioutil"
+	"math"
 	"os"
 	"syscall"
+	"time"
 	"unsafe"
 
 	"github.com/containers/storage/pkg/idtools"
@@ -132,7 +134,7 @@ func createUsernsProcess(uidMaps []idtools.IDMap, gidMaps []idtools.IDMap) (int,
 		_ = unix.Prctl(unix.PR_SET_PDEATHSIG, uintptr(unix.SIGKILL), 0, 0, 0)
 		// just wait for the SIGKILL
 		for {
-			syscall.Pause()
+			<-time.After(math.MaxInt)
 		}
 	}
 	cleanupFunc := func() {


### PR DESCRIPTION
function `syscall.Pause` is not available for linux/arm64 platform, using `<-time.After(math.MaxInt)` instead