### PR TITLE
overlay: do not clone source recursively

### DIFF
--- a/drivers/overlay/idmapped_utils.go
+++ b/drivers/overlay/idmapped_utils.go
@@ -105,7 +105,7 @@ func createIDMappedMount(source, target string, pid int) error {
 
 	defer userNsFile.Close()
 
-	targetDirFd, err := openTree(source, _OPEN_TREE_CLONE|unix.AT_RECURSIVE)
+	targetDirFd, err := openTree(source, _OPEN_TREE_CLONE)
 	if err != nil {
 		return err
 	}

--- a/drivers/overlay/idmapped_utils.go
+++ b/drivers/overlay/idmapped_utils.go
@@ -21,17 +21,6 @@ type attr struct {
 	userNs      uint64
 }
 
-const (
-	// _MOUNT_ATTR_IDMAP - Idmap mount to @userns_fd in struct mount_attr
-	_MOUNT_ATTR_IDMAP = 0x00100000 //nolint:golint
-
-	// _OPEN_TREE_CLONE - Clone the source path mount
-	_OPEN_TREE_CLONE = 0x00000001 //nolint:golint
-
-	// _MOVE_MOUNT_F_EMPTY_PATH - Move the path referenced by the fd
-	_MOVE_MOUNT_F_EMPTY_PATH = 0x00000004 //nolint:golint
-)
-
 // openTree is a wrapper for the open_tree syscall
 func openTree(path string, flags int) (fd int, err error) {
 	var _p0 *byte
@@ -61,7 +50,7 @@ func moveMount(fdTree int, target string) (err error) {
 		return err
 	}
 
-	flags := _MOVE_MOUNT_F_EMPTY_PATH
+	flags := unix.MOVE_MOUNT_F_EMPTY_PATH
 
 	_, _, e1 := syscall.Syscall6(uintptr(unix.SYS_MOVE_MOUNT),
 		uintptr(fdTree), uintptr(unsafe.Pointer(_p1)),
@@ -98,14 +87,14 @@ func createIDMappedMount(source, target string, pid int) error {
 	}
 
 	var attr attr
-	attr.attrSet = _MOUNT_ATTR_IDMAP
+	attr.attrSet = unix.MOUNT_ATTR_IDMAP
 	attr.attrClr = 0
 	attr.propagation = 0
 	attr.userNs = uint64(userNsFile.Fd())
 
 	defer userNsFile.Close()
 
-	targetDirFd, err := openTree(source, _OPEN_TREE_CLONE)
+	targetDirFd, err := openTree(source, unix.OPEN_TREE_CLONE)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
do not clone the source directory in recursive mode (the equivalent of
MS_BIND|MS_RECURSIVE) but use only a regular bind mount.  If
not recursive bind mount is used then the existing overlay mounts are
not replicated.  In this way a new idmapped mount won't need to map
the overlay mount as well, causing the mount_settattr(2) syscall to
fail with EINVAL since it is not possible to idmap an overlay mount
yet.

Closes: https://github.com/containers/storage/issues/1308

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>