### PR TITLE
test: use `T.TempDir` to create temporary test directory

### DIFF
--- a/drivers/copy/copy_test.go
+++ b/drivers/copy/copy_test.go
@@ -32,13 +32,10 @@ func TestCopyWithoutRange(t *testing.T) {
 }
 
 func TestCopyDir(t *testing.T) {
-	srcDir, err := ioutil.TempDir("", "srcDir")
-	assert.NilError(t, err)
+	srcDir := t.TempDir()
 	populateSrcDir(t, srcDir, 3)
 
-	dstDir, err := ioutil.TempDir("", "testdst")
-	assert.NilError(t, err)
-	defer os.RemoveAll(dstDir)
+	dstDir := t.TempDir()
 
 	assert.Check(t, DirCopy(srcDir, dstDir, Content, false))
 	assert.NilError(t, filepath.Walk(srcDir, func(srcPath string, f os.FileInfo, err error) error {
@@ -110,15 +107,13 @@ func populateSrcDir(t *testing.T, srcDir string, remainingDepth int) {
 }
 
 func doCopyTest(t *testing.T, copyWithFileRange, copyWithFileClone *bool) {
-	dir, err := ioutil.TempDir("", "storage-copy-check")
-	assert.NilError(t, err)
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	srcFilename := filepath.Join(dir, "srcFilename")
 	dstFilename := filepath.Join(dir, "dstilename")
 
 	r := rand.New(rand.NewSource(0))
 	buf := make([]byte, 1024)
-	_, err = r.Read(buf)
+	_, err := r.Read(buf)
 	assert.NilError(t, err)
 	assert.NilError(t, ioutil.WriteFile(srcFilename, buf, 0777))
 	fileinfo, err := os.Stat(srcFilename)
@@ -133,13 +128,8 @@ func doCopyTest(t *testing.T, copyWithFileRange, copyWithFileClone *bool) {
 func TestCopyHardlink(t *testing.T) {
 	var srcFile1FileInfo, srcFile2FileInfo, dstFile1FileInfo, dstFile2FileInfo unix.Stat_t
 
-	srcDir, err := ioutil.TempDir("", "srcDir")
-	assert.NilError(t, err)
-	defer os.RemoveAll(srcDir)
-
-	dstDir, err := ioutil.TempDir("", "dstDir")
-	assert.NilError(t, err)
-	defer os.RemoveAll(dstDir)
+	srcDir := t.TempDir()
+	dstDir := t.TempDir()
 
 	srcFile1 := filepath.Join(srcDir, "file1")
 	srcFile2 := filepath.Join(srcDir, "file2")

--- a/drivers/overlay/overlay_test.go
+++ b/drivers/overlay/overlay_test.go
@@ -1,10 +1,9 @@
+//go:build linux
 // +build linux
 
 package overlay
 
 import (
-	"io/ioutil"
-	"os"
 	"testing"
 
 	graphdriver "github.com/containers/storage/drivers"
@@ -25,11 +24,7 @@ func init() {
 }
 
 func skipIfNaive(t *testing.T) {
-	td, err := ioutil.TempDir("", "naive-check-")
-	if err != nil {
-		t.Fatalf("Failed to create temp dir: %v", err)
-	}
-	defer os.RemoveAll(td)
+	td := t.TempDir()
 
 	if err := doesSupportNativeDiff(td, ""); err != nil {
 		t.Skipf("Cannot run test with naive diff")

--- a/images_test.go
+++ b/images_test.go
@@ -1,7 +1,6 @@
 package storage
 
 import (
-	"io/ioutil"
 	"testing"
 	"time"
 
@@ -10,9 +9,7 @@ import (
 )
 
 func newTestImageStore(t *testing.T) ImageStore {
-	dir, err := ioutil.TempDir("", "storage")
-	require.Nil(t, err)
-	store, err := newImageStore(dir)
+	store, err := newImageStore(t.TempDir())
 	require.Nil(t, err)
 	return store
 }

--- a/pkg/archive/archive_linux_test.go
+++ b/pkg/archive/archive_linux_test.go
@@ -22,7 +22,8 @@ import (
 // ├── d2     # opaque, 0750
 // │   └── f1 # empty file, 0660
 // └── d3     # 0700
-//     └── f1 # whiteout, 0000
+//
+//	└── f1 # whiteout, 0000
 func setupOverlayTestDir(t *testing.T, src string) {
 	// Create opaque directory containing single file and permission 0700
 	err := os.Mkdir(filepath.Join(src, "d1"), 0700)
@@ -98,21 +99,13 @@ func TestOverlayTarUntar(t *testing.T) {
 	require.NoError(t, err)
 	defer system.Umask(oldmask)
 
-	src, err := ioutil.TempDir("", "storage-test-overlay-tar-src")
-	require.NoError(t, err)
-	defer os.RemoveAll(src)
-
+	src := t.TempDir()
 	setupOverlayTestDir(t, src)
 
-	lower, err := ioutil.TempDir("", "storage-test-overlay-tar-lower")
-	require.NoError(t, err)
-	defer os.RemoveAll(lower)
-
+	lower := t.TempDir()
 	setupOverlayLowerDir(t, lower)
 
-	dst, err := ioutil.TempDir("", "storage-test-overlay-tar-dst")
-	require.NoError(t, err)
-	defer os.RemoveAll(dst)
+	dst := t.TempDir()
 
 	options := &TarOptions{
 		Compression:    Uncompressed,
@@ -144,21 +137,13 @@ func TestOverlayTarAUFSUntar(t *testing.T) {
 	require.NoError(t, err)
 	defer system.Umask(oldmask)
 
-	src, err := ioutil.TempDir("", "storage-test-overlay-tar-src")
-	require.NoError(t, err)
-	defer os.RemoveAll(src)
-
+	src := t.TempDir()
 	setupOverlayTestDir(t, src)
 
-	lower, err := ioutil.TempDir("", "storage-test-overlay-tar-lower")
-	require.NoError(t, err)
-	defer os.RemoveAll(lower)
-
+	lower := t.TempDir()
 	setupOverlayLowerDir(t, lower)
 
-	dst, err := ioutil.TempDir("", "storage-test-overlay-tar-dst")
-	require.NoError(t, err)
-	defer os.RemoveAll(dst)
+	dst := t.TempDir()
 
 	archive, err := TarWithOptions(src, &TarOptions{
 		Compression:    Uncompressed,
@@ -205,11 +190,9 @@ func TestNestedOverlayWhiteouts(t *testing.T) {
 		require.NoError(t, tw.Close())
 	}()
 
-	dst, err := ioutil.TempDir("", "storage-test-overlay-tar-dst")
-	require.NoError(t, err)
-	defer os.RemoveAll(dst)
+	dst := t.TempDir()
 
-	err = Untar(reader, dst, &TarOptions{
+	err := Untar(reader, dst, &TarOptions{
 		Compression:    Uncompressed,
 		WhiteoutFormat: OverlayWhiteoutFormat,
 	})

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -210,9 +210,7 @@ func TestExtensionXz(t *testing.T) {
 }
 
 func TestUntarPathWithInvalidDest(t *testing.T) {
-	tempFolder, err := ioutil.TempDir("", "storage-archive-test")
-	require.NoError(t, err)
-	defer os.RemoveAll(tempFolder)
+	tempFolder := t.TempDir()
 	invalidDestFolder := filepath.Join(tempFolder, "invalidDest")
 	// Create a src file
 	srcFile := filepath.Join(tempFolder, "src")
@@ -229,7 +227,7 @@ func TestUntarPathWithInvalidDest(t *testing.T) {
 	}
 
 	cmd := exec.Command("sh", "-c", "tar cf "+tarFileU+" "+srcFileU)
-	_, err = cmd.CombinedOutput()
+	_, err := cmd.CombinedOutput()
 	require.NoError(t, err)
 
 	err = defaultUntarPath(tarFile, invalidDestFolder)
@@ -239,27 +237,21 @@ func TestUntarPathWithInvalidDest(t *testing.T) {
 }
 
 func TestUntarPathWithInvalidSrc(t *testing.T) {
-	dest, err := ioutil.TempDir("", "storage-archive-test")
-	if err != nil {
-		t.Fatalf("Fail to create the destination file")
-	}
-	defer os.RemoveAll(dest)
-	err = defaultUntarPath("/invalid/path", dest)
+	dest := t.TempDir()
+	err := defaultUntarPath("/invalid/path", dest)
 	if err == nil {
 		t.Fatalf("UntarPath with invalid src path should throw an error.")
 	}
 }
 
 func TestUntarPath(t *testing.T) {
-	tmpFolder, err := ioutil.TempDir("", "storage-archive-test")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpFolder)
+	tmpFolder := t.TempDir()
 	srcFile := filepath.Join(tmpFolder, "src")
 	tarFile := filepath.Join(tmpFolder, "src.tar")
 	os.Create(filepath.Join(tmpFolder, "src"))
 
 	destFolder := filepath.Join(tmpFolder, "dest")
-	err = os.MkdirAll(destFolder, 0740)
+	err := os.MkdirAll(destFolder, 0740)
 	if err != nil {
 		t.Fatalf("Fail to create the destination file")
 	}
@@ -288,11 +280,7 @@ func TestUntarPath(t *testing.T) {
 
 // Do the same test as above but with the destination as file, it should fail
 func TestUntarPathWithDestinationFile(t *testing.T) {
-	tmpFolder, err := ioutil.TempDir("", "storage-archive-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpFolder)
+	tmpFolder := t.TempDir()
 	srcFile := filepath.Join(tmpFolder, "src")
 	tarFile := filepath.Join(tmpFolder, "src.tar")
 	os.Create(filepath.Join(tmpFolder, "src"))
@@ -305,7 +293,7 @@ func TestUntarPathWithDestinationFile(t *testing.T) {
 		srcFileU = "/tmp/" + filepath.Base(filepath.Dir(srcFile)) + "/src"
 	}
 	cmd := exec.Command("sh", "-c", "tar cf "+tarFileU+" "+srcFileU)
-	_, err = cmd.CombinedOutput()
+	_, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -324,11 +312,7 @@ func TestUntarPathWithDestinationFile(t *testing.T) {
 // and the destination file is a directory
 // It's working, see https://github.com/docker/docker/issues/10040
 func TestUntarPathWithDestinationSrcFileAsFolder(t *testing.T) {
-	tmpFolder, err := ioutil.TempDir("", "storage-archive-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpFolder)
+	tmpFolder := t.TempDir()
 	srcFile := filepath.Join(tmpFolder, "src")
 	tarFile := filepath.Join(tmpFolder, "src.tar")
 	os.Create(srcFile)
@@ -342,7 +326,7 @@ func TestUntarPathWithDestinationSrcFileAsFolder(t *testing.T) {
 	}
 
 	cmd := exec.Command("sh", "-c", "tar cf "+tarFileU+" "+srcFileU)
-	_, err = cmd.CombinedOutput()
+	_, err := cmd.CombinedOutput()
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -364,13 +348,10 @@ func TestUntarPathWithDestinationSrcFileAsFolder(t *testing.T) {
 }
 
 func TestCopyWithTarInvalidSrc(t *testing.T) {
-	tempFolder, err := ioutil.TempDir("", "storage-archive-test")
-	if err != nil {
-		t.Fatal(nil)
-	}
+	tempFolder := t.TempDir()
 	destFolder := filepath.Join(tempFolder, "dest")
 	invalidSrc := filepath.Join(tempFolder, "doesnotexists")
-	err = os.MkdirAll(destFolder, 0740)
+	err := os.MkdirAll(destFolder, 0740)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -381,13 +362,10 @@ func TestCopyWithTarInvalidSrc(t *testing.T) {
 }
 
 func TestCopyWithTarInexistentDestWillCreateIt(t *testing.T) {
-	tempFolder, err := ioutil.TempDir("", "storage-archive-test")
-	if err != nil {
-		t.Fatal(nil)
-	}
+	tempFolder := t.TempDir()
 	srcFolder := filepath.Join(tempFolder, "src")
 	inexistentDestFolder := filepath.Join(tempFolder, "doesnotexists")
-	err = os.MkdirAll(srcFolder, 0740)
+	err := os.MkdirAll(srcFolder, 0740)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -403,15 +381,11 @@ func TestCopyWithTarInexistentDestWillCreateIt(t *testing.T) {
 
 // Test CopyWithTar with a file as src
 func TestCopyWithTarSrcFile(t *testing.T) {
-	folder, err := ioutil.TempDir("", "storage-archive-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(folder)
+	folder := t.TempDir()
 	dest := filepath.Join(folder, "dest")
 	srcFolder := filepath.Join(folder, "src")
 	src := filepath.Join(folder, filepath.Join("src", "src"))
-	err = os.MkdirAll(srcFolder, 0740)
+	err := os.MkdirAll(srcFolder, 0740)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -469,14 +443,10 @@ func TestCopyWithTarSrcFile(t *testing.T) {
 
 // Test CopyWithTar with a folder as src
 func TestCopyWithTarSrcFolder(t *testing.T) {
-	folder, err := ioutil.TempDir("", "storage-archive-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(folder)
+	folder := t.TempDir()
 	dest := filepath.Join(folder, "dest")
 	src := filepath.Join(folder, filepath.Join("src", "folder"))
-	err = os.MkdirAll(src, 0740)
+	err := os.MkdirAll(src, 0740)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -497,13 +467,9 @@ func TestCopyWithTarSrcFolder(t *testing.T) {
 }
 
 func TestCopyFileWithTarInvalidSrc(t *testing.T) {
-	tempFolder, err := ioutil.TempDir("", "storage-archive-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tempFolder)
+	tempFolder := t.TempDir()
 	destFolder := filepath.Join(tempFolder, "dest")
-	err = os.MkdirAll(destFolder, 0740)
+	err := os.MkdirAll(destFolder, 0740)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -515,14 +481,10 @@ func TestCopyFileWithTarInvalidSrc(t *testing.T) {
 }
 
 func TestCopyFileWithTarInexistentDestWillCreateIt(t *testing.T) {
-	tempFolder, err := ioutil.TempDir("", "storage-archive-test")
-	if err != nil {
-		t.Fatal(nil)
-	}
-	defer os.RemoveAll(tempFolder)
+	tempFolder := t.TempDir()
 	srcFile := filepath.Join(tempFolder, "src")
 	inexistentDestFolder := filepath.Join(tempFolder, "doesnotexists")
-	_, err = os.Create(srcFile)
+	_, err := os.Create(srcFile)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -538,14 +500,10 @@ func TestCopyFileWithTarInexistentDestWillCreateIt(t *testing.T) {
 }
 
 func TestCopyFileWithTarSrcFolder(t *testing.T) {
-	folder, err := ioutil.TempDir("", "storage-archive-copyfilewithtar-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(folder)
+	folder := t.TempDir()
 	dest := filepath.Join(folder, "dest")
 	src := filepath.Join(folder, "srcfolder")
-	err = os.MkdirAll(src, 0740)
+	err := os.MkdirAll(src, 0740)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -560,15 +518,11 @@ func TestCopyFileWithTarSrcFolder(t *testing.T) {
 }
 
 func TestCopyFileWithTarSrcFile(t *testing.T) {
-	folder, err := ioutil.TempDir("", "storage-archive-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(folder)
+	folder := t.TempDir()
 	dest := filepath.Join(folder, "dest")
 	srcFolder := filepath.Join(folder, "src")
 	src := filepath.Join(folder, filepath.Join("src", "src"))
-	err = os.MkdirAll(srcFolder, 0740)
+	err := os.MkdirAll(srcFolder, 0740)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -588,14 +542,10 @@ func TestCopyFileWithTarSrcFile(t *testing.T) {
 }
 
 func TestCopySocket(t *testing.T) {
-	folder, err := ioutil.TempDir("", "storage-archive-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(folder)
+	folder := t.TempDir()
 	dest := filepath.Join(folder, "dest")
 	src := filepath.Join(folder, "src")
-	err = os.MkdirAll(src, 0740)
+	err := os.MkdirAll(src, 0740)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -626,29 +576,20 @@ func TestTarFiles(t *testing.T) {
 		t.Skip("Failing on Windows")
 	}
 	// try without hardlinks
-	if err := checkNoChanges(1000, false); err != nil {
+	if err := checkNoChanges(t, 1000, false); err != nil {
 		t.Fatal(err)
 	}
 	// try with hardlinks
-	if err := checkNoChanges(1000, true); err != nil {
+	if err := checkNoChanges(t, 1000, true); err != nil {
 		t.Fatal(err)
 	}
 }
 
-func checkNoChanges(fileNum int, hardlinks bool) error {
-	srcDir, err := ioutil.TempDir("", "storage-test-srcDir")
-	if err != nil {
-		return err
-	}
-	defer os.RemoveAll(srcDir)
+func checkNoChanges(t *testing.T, fileNum int, hardlinks bool) error {
+	srcDir := t.TempDir()
+	destDir := t.TempDir()
 
-	destDir, err := ioutil.TempDir("", "storage-test-destDir")
-	if err != nil {
-		return err
-	}
-	defer os.RemoveAll(destDir)
-
-	_, err = prepareUntarSourceDirectory(fileNum, srcDir, hardlinks)
+	_, err := prepareUntarSourceDirectory(fileNum, srcDir, hardlinks)
 	if err != nil {
 		return err
 	}
@@ -687,11 +628,7 @@ func tarUntar(t *testing.T, origin string, options *TarOptions) ([]Change, error
 		return nil, fmt.Errorf("wrong compression detected. Actual compression: %s, found %s", compression.Extension(), detectedCompression.Extension())
 	}
 
-	tmp, err := ioutil.TempDir("", "storage-test-untar")
-	if err != nil {
-		return nil, err
-	}
-	defer os.RemoveAll(tmp)
+	tmp := t.TempDir()
 	if err := Untar(wrap, tmp, nil); err != nil {
 		return nil, err
 	}
@@ -707,11 +644,7 @@ func TestTarUntar(t *testing.T) {
 	if runtime.GOOS == windows {
 		t.Skip("Failing on Windows")
 	}
-	origin, err := ioutil.TempDir("", "storage-test-untar-origin")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(origin)
+	origin := t.TempDir()
 	if err := ioutil.WriteFile(filepath.Join(origin, "1"), []byte("hello world"), 0700); err != nil {
 		t.Fatal(err)
 	}
@@ -742,12 +675,9 @@ func TestTarUntar(t *testing.T) {
 }
 
 func TestTarWithOptionsChownOptsAlwaysOverridesIdPair(t *testing.T) {
-	origin, err := ioutil.TempDir("", "storage-test-tar-chown-opt")
-	require.NoError(t, err)
-
-	defer os.RemoveAll(origin)
+	origin := t.TempDir()
 	filePath := filepath.Join(origin, "1")
-	err = ioutil.WriteFile(filePath, []byte("hello world"), 0700)
+	err := ioutil.WriteFile(filePath, []byte("hello world"), 0700)
 	require.NoError(t, err)
 
 	idMaps := []idtools.IDMap{
@@ -797,14 +727,10 @@ func TestTarWithOptions(t *testing.T) {
 	if runtime.GOOS == windows {
 		t.Skip("Failing on Windows")
 	}
-	origin, err := ioutil.TempDir("", "storage-test-untar-origin")
-	if err != nil {
-		t.Fatal(err)
-	}
+	origin := t.TempDir()
 	if _, err := ioutil.TempDir(origin, "folder"); err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(origin)
 	if err := ioutil.WriteFile(filepath.Join(origin, "1"), []byte("hello world"), 0700); err != nil {
 		t.Fatal(err)
 	}
@@ -839,13 +765,9 @@ func TestTarWithOptions(t *testing.T) {
 // Failing prevents the archives from being uncompressed during ADD
 func TestTypeXGlobalHeaderDoesNotFail(t *testing.T) {
 	hdr := tar.Header{Typeflag: tar.TypeXGlobalHeader}
-	tmpDir, err := ioutil.TempDir("", "storage-test-archive-pax-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 	buffer := make([]byte, 1<<20)
-	err = createTarFile(filepath.Join(tmpDir, "pax_global_header"), tmpDir, &hdr, nil, true, nil, false, false, nil, buffer)
+	err := createTarFile(filepath.Join(tmpDir, "pax_global_header"), tmpDir, &hdr, nil, true, nil, false, false, nil, buffer)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -900,21 +822,13 @@ func prepareUntarSourceDirectory(numberOfFiles int, targetPath string, makeLinks
 }
 
 func BenchmarkTarUntar(b *testing.B) {
-	origin, err := ioutil.TempDir("", "storage-test-untar-origin")
-	if err != nil {
-		b.Fatal(err)
-	}
-	tempDir, err := ioutil.TempDir("", "storage-test-untar-destination")
-	if err != nil {
-		b.Fatal(err)
-	}
+	origin := b.TempDir()
+	tempDir := b.TempDir()
 	target := filepath.Join(tempDir, "dest")
 	n, err := prepareUntarSourceDirectory(100, origin, false)
 	if err != nil {
 		b.Fatal(err)
 	}
-	defer os.RemoveAll(origin)
-	defer os.RemoveAll(tempDir)
 
 	b.ResetTimer()
 	b.SetBytes(int64(n))
@@ -928,21 +842,13 @@ func BenchmarkTarUntar(b *testing.B) {
 }
 
 func BenchmarkTarUntarWithLinks(b *testing.B) {
-	origin, err := ioutil.TempDir("", "storage-test-untar-origin")
-	if err != nil {
-		b.Fatal(err)
-	}
-	tempDir, err := ioutil.TempDir("", "storage-test-untar-destination")
-	if err != nil {
-		b.Fatal(err)
-	}
+	origin := b.TempDir()
+	tempDir := b.TempDir()
 	target := filepath.Join(tempDir, "dest")
 	n, err := prepareUntarSourceDirectory(100, origin, true)
 	if err != nil {
 		b.Fatal(err)
 	}
-	defer os.RemoveAll(origin)
-	defer os.RemoveAll(tempDir)
 
 	b.ResetTimer()
 	b.SetBytes(int64(n))
@@ -969,7 +875,7 @@ func TestUntarSelinuxLabel(t *testing.T) {
 			},
 		},
 	} {
-		if err := testBreakout("untar", "storage-TestUntarInvalidFilenames", headers); err != nil {
+		if err := testBreakout(t, "untar", headers); err != nil {
 			t.Fatalf("i=%d. %v", i, err)
 		}
 	}
@@ -997,7 +903,7 @@ func TestUntarInvalidFilenames(t *testing.T) {
 			},
 		},
 	} {
-		if err := testBreakout("untar", "storage-TestUntarInvalidFilenames", headers); err != nil {
+		if err := testBreakout(t, "untar", headers); err != nil {
 			t.Fatalf("i=%d. %v", i, err)
 		}
 	}
@@ -1029,7 +935,7 @@ func TestUntarHardlinkToSymlink(t *testing.T) {
 			},
 		},
 	} {
-		if err := testBreakout("untar", "storage-TestUntarHardlinkToSymlink", headers); err != nil {
+		if err := testBreakout(t, "untar", headers); err != nil {
 			t.Fatalf("i=%d. %v", i, err)
 		}
 	}
@@ -1113,7 +1019,7 @@ func TestUntarInvalidHardlink(t *testing.T) {
 			},
 		},
 	} {
-		if err := testBreakout("untar", "storage-TestUntarInvalidHardlink", headers); err != nil {
+		if err := testBreakout(t, "untar", headers); err != nil {
 			t.Fatalf("i=%d. %v", i, err)
 		}
 	}
@@ -1211,7 +1117,7 @@ func TestUntarInvalidSymlink(t *testing.T) {
 			},
 		},
 	} {
-		if err := testBreakout("untar", "storage-TestUntarInvalidSymlink", headers); err != nil {
+		if err := testBreakout(t, "untar", headers); err != nil {
 			t.Fatalf("i=%d. %v", i, err)
 		}
 	}
@@ -1285,16 +1191,14 @@ func TestReplaceFileTarWrapper(t *testing.T) {
 }
 
 func buildSourceArchive(t *testing.T, numberOfFiles int) (io.ReadCloser, func()) {
-	srcDir, err := ioutil.TempDir("", "storage-test-srcDir")
-	require.NoError(t, err)
+	srcDir := t.TempDir()
 
-	_, err = prepareUntarSourceDirectory(numberOfFiles, srcDir, false)
+	_, err := prepareUntarSourceDirectory(numberOfFiles, srcDir, false)
 	require.NoError(t, err)
 
 	sourceArchive, err := TarWithOptions(srcDir, &TarOptions{})
 	require.NoError(t, err)
 	return sourceArchive, func() {
-		os.RemoveAll(srcDir)
 		sourceArchive.Close()
 	}
 }
@@ -1325,11 +1229,9 @@ func appendModifier(path string, header *tar.Header, content io.Reader) (*tar.He
 }
 
 func readFileFromArchive(t *testing.T, archive io.ReadCloser, name string, expectedCount int, doc string) string {
-	destDir, err := ioutil.TempDir("", "storage-test-destDir")
-	require.NoError(t, err)
-	defer os.RemoveAll(destDir)
+	destDir := t.TempDir()
 
-	err = Untar(archive, destDir, nil)
+	err := Untar(archive, destDir, nil)
 	require.NoError(t, err)
 
 	files, _ := ioutil.ReadDir(destDir)

--- a/pkg/archive/archive_unix_test.go
+++ b/pkg/archive/archive_unix_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package archive
@@ -72,11 +73,9 @@ func TestChmodTarEntry(t *testing.T) {
 }
 
 func TestTarWithHardLink(t *testing.T) {
-	origin, err := ioutil.TempDir("", "storage-test-tar-hardlink")
-	require.NoError(t, err)
-	defer os.RemoveAll(origin)
+	origin := t.TempDir()
 
-	err = ioutil.WriteFile(filepath.Join(origin, "1"), []byte("hello world"), 0700)
+	err := ioutil.WriteFile(filepath.Join(origin, "1"), []byte("hello world"), 0700)
 	require.NoError(t, err)
 
 	err = os.Link(filepath.Join(origin, "1"), filepath.Join(origin, "2"))
@@ -91,9 +90,7 @@ func TestTarWithHardLink(t *testing.T) {
 		t.Skipf("skipping since hardlinks don't work here; expected 2 links, got %d", i1)
 	}
 
-	dest, err := ioutil.TempDir("", "storage-test-tar-hardlink-dest")
-	require.NoError(t, err)
-	defer os.RemoveAll(dest)
+	dest := t.TempDir()
 
 	// we'll do this in two steps to separate failure
 	fh, err := Tar(origin, Uncompressed)
@@ -117,12 +114,10 @@ func TestTarWithHardLink(t *testing.T) {
 }
 
 func TestTarWithHardLinkAndRebase(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "storage-test-tar-hardlink-rebase")
-	require.NoError(t, err)
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	origin := filepath.Join(tmpDir, "origin")
-	err = os.Mkdir(origin, 0700)
+	err := os.Mkdir(origin, 0700)
 	require.NoError(t, err)
 
 	err = ioutil.WriteFile(filepath.Join(origin, "1"), []byte("hello world"), 0700)
@@ -184,11 +179,9 @@ func getInode(path string) (uint64, error) {
 }
 
 func TestTarWithBlockCharFifo(t *testing.T) {
-	origin, err := ioutil.TempDir("", "storage-test-tar-hardlink")
-	require.NoError(t, err)
+	origin := t.TempDir()
 
-	defer os.RemoveAll(origin)
-	err = ioutil.WriteFile(filepath.Join(origin, "1"), []byte("hello world"), 0700)
+	err := ioutil.WriteFile(filepath.Join(origin, "1"), []byte("hello world"), 0700)
 	require.NoError(t, err)
 
 	err = system.Mknod(filepath.Join(origin, "2"), unix.S_IFBLK, int(system.Mkdev(int64(12), int64(5))))
@@ -198,9 +191,7 @@ func TestTarWithBlockCharFifo(t *testing.T) {
 	err = system.Mknod(filepath.Join(origin, "4"), unix.S_IFIFO, int(system.Mkdev(int64(12), int64(5))))
 	require.NoError(t, err)
 
-	dest, err := ioutil.TempDir("", "storage-test-tar-hardlink-dest")
-	require.NoError(t, err)
-	defer os.RemoveAll(dest)
+	dest := t.TempDir()
 
 	// we'll do this in two steps to separate failure
 	fh, err := Tar(origin, Uncompressed)
@@ -227,10 +218,8 @@ func TestTarUntarWithXattr(t *testing.T) {
 	if runtime.GOOS == solaris {
 		t.Skip()
 	}
-	origin, err := ioutil.TempDir("", "storage-test-untar-origin")
-	require.NoError(t, err)
-	defer os.RemoveAll(origin)
-	err = ioutil.WriteFile(filepath.Join(origin, "1"), []byte("hello world"), 0700)
+	origin := t.TempDir()
+	err := ioutil.WriteFile(filepath.Join(origin, "1"), []byte("hello world"), 0700)
 	require.NoError(t, err)
 
 	err = ioutil.WriteFile(filepath.Join(origin, "2"), []byte("welcome!"), 0700)

--- a/pkg/archive/archive_windows_test.go
+++ b/pkg/archive/archive_windows_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package archive
@@ -14,15 +15,11 @@ func TestCopyFileWithInvalidDest(t *testing.T) {
 	// recently changed in CopyWithTar as used to pass. Further investigation
 	// is required.
 	t.Skip("Currently fails")
-	folder, err := ioutil.TempDir("", "storage-archive-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(folder)
+	folder := t.TempDir()
 	dest := "c:dest"
 	srcFolder := filepath.Join(folder, "src")
 	src := filepath.Join(folder, "src", "src")
-	err = os.MkdirAll(srcFolder, 0740)
+	err := os.MkdirAll(srcFolder, 0740)
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/archive/changes_posix_test.go
+++ b/pkg/archive/changes_posix_test.go
@@ -4,7 +4,6 @@ import (
 	"archive/tar"
 	"fmt"
 	"io"
-	"io/ioutil"
 	"os"
 	"path"
 	"runtime"
@@ -23,11 +22,7 @@ func TestHardLinkOrder(t *testing.T) {
 	msg := []byte("Hey y'all")
 
 	// Create dir
-	src, err := ioutil.TempDir("", "storage-hardlink-test-src-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(src)
+	src := t.TempDir()
 	for _, name := range names {
 		func() {
 			fh, err := os.Create(path.Join(src, name))
@@ -41,15 +36,11 @@ func TestHardLinkOrder(t *testing.T) {
 		}()
 	}
 	// Create dest, with changes that includes hardlinks
-	dest, err := ioutil.TempDir("", "storage-hardlink-test-dest-")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dest := t.TempDir()
 	os.RemoveAll(dest) // we just want the name, at first
 	if err := copyDir(src, dest); err != nil {
 		t.Fatal(err)
 	}
-	defer os.RemoveAll(dest)
 	for _, name := range names {
 		for i := 0; i < 5; i++ {
 			if err := os.Link(path.Join(dest, name), path.Join(dest, fmt.Sprintf("%s.link%d", name, i))); err != nil {

--- a/pkg/archive/copy_unix_test.go
+++ b/pkg/archive/copy_unix_test.go
@@ -12,7 +12,6 @@ import (
 	"fmt"
 	"io"
 	"io/fs"
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"strings"
@@ -22,22 +21,8 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func removeAllPaths(paths ...string) {
-	for _, path := range paths {
-		os.RemoveAll(path)
-	}
-}
-
 func getTestTempDirs(t *testing.T) (tmpDirA, tmpDirB string) {
-	var err error
-
-	tmpDirA, err = ioutil.TempDir("", "archive-copy-test")
-	require.NoError(t, err)
-
-	tmpDirB, err = ioutil.TempDir("", "archive-copy-test")
-	require.NoError(t, err)
-
-	return
+	return t.TempDir(), t.TempDir()
 }
 
 func isNotDir(err error) bool {
@@ -145,8 +130,7 @@ func testCopyHelperFSym(t *testing.T, srcPath, dstPath string) (err error) {
 
 // Test for error when SRC does not exist.
 func TestCopyErrSrcNotExists(t *testing.T) {
-	tmpDirA, tmpDirB := getTestTempDirs(t)
-	defer removeAllPaths(tmpDirA, tmpDirB)
+	tmpDirA, _ := getTestTempDirs(t)
 
 	if _, err := CopyInfoSourcePath(filepath.Join(tmpDirA, "file1"), false); !os.IsNotExist(err) {
 		t.Fatalf("expected IsNotExist error, but got %T: %s", err, err)
@@ -156,8 +140,7 @@ func TestCopyErrSrcNotExists(t *testing.T) {
 // Test for error when SRC ends in a trailing
 // path separator but it exists as a file.
 func TestCopyErrSrcNotDir(t *testing.T) {
-	tmpDirA, tmpDirB := getTestTempDirs(t)
-	defer removeAllPaths(tmpDirA, tmpDirB)
+	tmpDirA, _ := getTestTempDirs(t)
 
 	// Load A with some sample files and directories.
 	createSampleDir(t, tmpDirA)
@@ -171,7 +154,6 @@ func TestCopyErrSrcNotDir(t *testing.T) {
 // but the DST parent directory does not exist.
 func TestCopyErrDstParentNotExists(t *testing.T) {
 	tmpDirA, tmpDirB := getTestTempDirs(t)
-	defer removeAllPaths(tmpDirA, tmpDirB)
 
 	// Load A with some sample files and directories.
 	createSampleDir(t, tmpDirA)
@@ -217,7 +199,6 @@ func TestCopyErrDstParentNotExists(t *testing.T) {
 // path separator but exists as a file.
 func TestCopyErrDstNotDir(t *testing.T) {
 	tmpDirA, tmpDirB := getTestTempDirs(t)
-	defer removeAllPaths(tmpDirA, tmpDirB)
 
 	// Load A and B with some sample files and directories.
 	createSampleDir(t, tmpDirA)
@@ -275,11 +256,11 @@ func TestCopyErrDstNotDir(t *testing.T) {
 //
 
 // A. SRC specifies a file and DST (no trailing path separator) doesn't
-//    exist. This should create a file with the name DST and copy the
-//    contents of the source file into it.
+//
+//	exist. This should create a file with the name DST and copy the
+//	contents of the source file into it.
 func TestCopyCaseA(t *testing.T) {
 	tmpDirA, tmpDirB := getTestTempDirs(t)
-	defer removeAllPaths(tmpDirA, tmpDirB)
 
 	// Load A with some sample files and directories.
 	createSampleDir(t, tmpDirA)
@@ -317,11 +298,11 @@ func TestCopyCaseA(t *testing.T) {
 }
 
 // B. SRC specifies a file and DST (with trailing path separator) doesn't
-//    exist. This should cause an error because the copy operation cannot
-//    create a directory when copying a single file.
+//
+//	exist. This should cause an error because the copy operation cannot
+//	create a directory when copying a single file.
 func TestCopyCaseB(t *testing.T) {
 	tmpDirA, tmpDirB := getTestTempDirs(t)
-	defer removeAllPaths(tmpDirA, tmpDirB)
 
 	// Load A with some sample files and directories.
 	createSampleDir(t, tmpDirA)
@@ -351,10 +332,10 @@ func TestCopyCaseB(t *testing.T) {
 }
 
 // C. SRC specifies a file and DST exists as a file. This should overwrite
-//    the file at DST with the contents of the source file.
+//
+//	the file at DST with the contents of the source file.
 func TestCopyCaseC(t *testing.T) {
 	tmpDirA, tmpDirB := getTestTempDirs(t)
-	defer removeAllPaths(tmpDirA, tmpDirB)
 
 	// Load A and B with some sample files and directories.
 	createSampleDir(t, tmpDirA)
@@ -379,11 +360,11 @@ func TestCopyCaseC(t *testing.T) {
 }
 
 // C. Symbol link following version:
-//    SRC specifies a file and DST exists as a file. This should overwrite
-//    the file at DST with the contents of the source file.
+//
+//	SRC specifies a file and DST exists as a file. This should overwrite
+//	the file at DST with the contents of the source file.
 func TestCopyCaseCFSym(t *testing.T) {
 	tmpDirA, tmpDirB := getTestTempDirs(t)
-	defer removeAllPaths(tmpDirA, tmpDirB)
 
 	// Load A and B with some sample files and directories.
 	createSampleDir(t, tmpDirA)
@@ -416,11 +397,11 @@ func TestCopyCaseCFSym(t *testing.T) {
 }
 
 // D. SRC specifies a file and DST exists as a directory. This should place
-//    a copy of the source file inside it using the basename from SRC. Ensure
-//    this works whether DST has a trailing path separator or not.
+//
+//	a copy of the source file inside it using the basename from SRC. Ensure
+//	this works whether DST has a trailing path separator or not.
 func TestCopyCaseD(t *testing.T) {
 	tmpDirA, tmpDirB := getTestTempDirs(t)
-	defer removeAllPaths(tmpDirA, tmpDirB)
 
 	// Load A and B with some sample files and directories.
 	createSampleDir(t, tmpDirA)
@@ -465,12 +446,12 @@ func TestCopyCaseD(t *testing.T) {
 }
 
 // D. Symbol link following version:
-//    SRC specifies a file and DST exists as a directory. This should place
-//    a copy of the source file inside it using the basename from SRC. Ensure
-//    this works whether DST has a trailing path separator or not.
+//
+//	SRC specifies a file and DST exists as a directory. This should place
+//	a copy of the source file inside it using the basename from SRC. Ensure
+//	this works whether DST has a trailing path separator or not.
 func TestCopyCaseDFSym(t *testing.T) {
 	tmpDirA, tmpDirB := getTestTempDirs(t)
-	defer removeAllPaths(tmpDirA, tmpDirB)
 
 	// Load A and B with some sample files and directories.
 	createSampleDir(t, tmpDirA)
@@ -516,12 +497,12 @@ func TestCopyCaseDFSym(t *testing.T) {
 }
 
 // E. SRC specifies a directory and DST does not exist. This should create a
-//    directory at DST and copy the contents of the SRC directory into the DST
-//    directory. Ensure this works whether DST has a trailing path separator or
-//    not.
+//
+//	directory at DST and copy the contents of the SRC directory into the DST
+//	directory. Ensure this works whether DST has a trailing path separator or
+//	not.
 func TestCopyCaseE(t *testing.T) {
 	tmpDirA, tmpDirB := getTestTempDirs(t)
-	defer removeAllPaths(tmpDirA, tmpDirB)
 
 	// Load A with some sample files and directories.
 	createSampleDir(t, tmpDirA)
@@ -559,13 +540,13 @@ func TestCopyCaseE(t *testing.T) {
 }
 
 // E. Symbol link following version:
-//    SRC specifies a directory and DST does not exist. This should create a
-//    directory at DST and copy the contents of the SRC directory into the DST
-//    directory. Ensure this works whether DST has a trailing path separator or
-//    not.
+//
+//	SRC specifies a directory and DST does not exist. This should create a
+//	directory at DST and copy the contents of the SRC directory into the DST
+//	directory. Ensure this works whether DST has a trailing path separator or
+//	not.
 func TestCopyCaseEFSym(t *testing.T) {
 	tmpDirA, tmpDirB := getTestTempDirs(t)
-	defer removeAllPaths(tmpDirA, tmpDirB)
 
 	// Load A with some sample files and directories.
 	createSampleDir(t, tmpDirA)
@@ -604,10 +585,10 @@ func TestCopyCaseEFSym(t *testing.T) {
 }
 
 // F. SRC specifies a directory and DST exists as a file. This should cause an
-//    error as it is not possible to overwrite a file with a directory.
+//
+//	error as it is not possible to overwrite a file with a directory.
 func TestCopyCaseF(t *testing.T) {
 	tmpDirA, tmpDirB := getTestTempDirs(t)
-	defer removeAllPaths(tmpDirA, tmpDirB)
 
 	// Load A and B with some sample files and directories.
 	createSampleDir(t, tmpDirA)
@@ -638,11 +619,11 @@ func TestCopyCaseF(t *testing.T) {
 }
 
 // G. SRC specifies a directory and DST exists as a directory. This should copy
-//    the SRC directory and all its contents to the DST directory. Ensure this
-//    works whether DST has a trailing path separator or not.
+//
+//	the SRC directory and all its contents to the DST directory. Ensure this
+//	works whether DST has a trailing path separator or not.
 func TestCopyCaseG(t *testing.T) {
 	tmpDirA, tmpDirB := getTestTempDirs(t)
-	defer removeAllPaths(tmpDirA, tmpDirB)
 
 	// Load A and B with some sample files and directories.
 	createSampleDir(t, tmpDirA)
@@ -682,12 +663,12 @@ func TestCopyCaseG(t *testing.T) {
 }
 
 // G. Symbol link version:
-//    SRC specifies a directory and DST exists as a directory. This should copy
-//    the SRC directory and all its contents to the DST directory. Ensure this
-//    works whether DST has a trailing path separator or not.
+//
+//	SRC specifies a directory and DST exists as a directory. This should copy
+//	the SRC directory and all its contents to the DST directory. Ensure this
+//	works whether DST has a trailing path separator or not.
 func TestCopyCaseGFSym(t *testing.T) {
 	tmpDirA, tmpDirB := getTestTempDirs(t)
-	defer removeAllPaths(tmpDirA, tmpDirB)
 
 	// Load A and B with some sample files and directories.
 	createSampleDir(t, tmpDirA)
@@ -728,12 +709,12 @@ func TestCopyCaseGFSym(t *testing.T) {
 }
 
 // H. SRC specifies a directory's contents only and DST does not exist. This
-//    should create a directory at DST and copy the contents of the SRC
-//    directory (but not the directory itself) into the DST directory. Ensure
-//    this works whether DST has a trailing path separator or not.
+//
+//	should create a directory at DST and copy the contents of the SRC
+//	directory (but not the directory itself) into the DST directory. Ensure
+//	this works whether DST has a trailing path separator or not.
 func TestCopyCaseH(t *testing.T) {
 	tmpDirA, tmpDirB := getTestTempDirs(t)
-	defer removeAllPaths(tmpDirA, tmpDirB)
 
 	// Load A with some sample files and directories.
 	createSampleDir(t, tmpDirA)
@@ -775,13 +756,13 @@ func TestCopyCaseH(t *testing.T) {
 }
 
 // H. Symbol link following version:
-//    SRC specifies a directory's contents only and DST does not exist. This
-//    should create a directory at DST and copy the contents of the SRC
-//    directory (but not the directory itself) into the DST directory. Ensure
-//    this works whether DST has a trailing path separator or not.
+//
+//	SRC specifies a directory's contents only and DST does not exist. This
+//	should create a directory at DST and copy the contents of the SRC
+//	directory (but not the directory itself) into the DST directory. Ensure
+//	this works whether DST has a trailing path separator or not.
 func TestCopyCaseHFSym(t *testing.T) {
 	tmpDirA, tmpDirB := getTestTempDirs(t)
-	defer removeAllPaths(tmpDirA, tmpDirB)
 
 	// Load A with some sample files and directories.
 	createSampleDir(t, tmpDirA)
@@ -824,11 +805,11 @@ func TestCopyCaseHFSym(t *testing.T) {
 }
 
 // I. SRC specifies a directory's contents only and DST exists as a file. This
-//    should cause an error as it is not possible to overwrite a file with a
-//    directory.
+//
+//	should cause an error as it is not possible to overwrite a file with a
+//	directory.
 func TestCopyCaseI(t *testing.T) {
 	tmpDirA, tmpDirB := getTestTempDirs(t)
-	defer removeAllPaths(tmpDirA, tmpDirB)
 
 	// Load A and B with some sample files and directories.
 	createSampleDir(t, tmpDirA)
@@ -859,12 +840,12 @@ func TestCopyCaseI(t *testing.T) {
 }
 
 // J. SRC specifies a directory's contents only and DST exists as a directory.
-//    This should copy the contents of the SRC directory (but not the directory
-//    itself) into the DST directory. Ensure this works whether DST has a
-//    trailing path separator or not.
+//
+//	This should copy the contents of the SRC directory (but not the directory
+//	itself) into the DST directory. Ensure this works whether DST has a
+//	trailing path separator or not.
 func TestCopyCaseJ(t *testing.T) {
 	tmpDirA, tmpDirB := getTestTempDirs(t)
-	defer removeAllPaths(tmpDirA, tmpDirB)
 
 	// Load A and B with some sample files and directories.
 	createSampleDir(t, tmpDirA)
@@ -908,13 +889,13 @@ func TestCopyCaseJ(t *testing.T) {
 }
 
 // J. Symbol link following version:
-//    SRC specifies a directory's contents only and DST exists as a directory.
-//    This should copy the contents of the SRC directory (but not the directory
-//    itself) into the DST directory. Ensure this works whether DST has a
-//    trailing path separator or not.
+//
+//	SRC specifies a directory's contents only and DST exists as a directory.
+//	This should copy the contents of the SRC directory (but not the directory
+//	itself) into the DST directory. Ensure this works whether DST has a
+//	trailing path separator or not.
 func TestCopyCaseJFSym(t *testing.T) {
 	tmpDirA, tmpDirB := getTestTempDirs(t)
-	defer removeAllPaths(tmpDirA, tmpDirB)
 
 	// Load A and B with some sample files and directories.
 	createSampleDir(t, tmpDirA)

--- a/pkg/archive/diff_test.go
+++ b/pkg/archive/diff_test.go
@@ -36,7 +36,7 @@ func TestApplyLayerInvalidFilenames(t *testing.T) {
 			},
 		},
 	} {
-		if err := testBreakout("applylayer", "storage-TestApplyLayerInvalidFilenames", headers); err != nil {
+		if err := testBreakout(t, "applylayer", headers); err != nil {
 			t.Fatalf("i=%d. %v", i, err)
 		}
 	}
@@ -119,7 +119,7 @@ func TestApplyLayerInvalidHardlink(t *testing.T) {
 			},
 		},
 	} {
-		if err := testBreakout("applylayer", "storage-TestApplyLayerInvalidHardlink", headers); err != nil {
+		if err := testBreakout(t, "applylayer", headers); err != nil {
 			t.Fatalf("i=%d. %v", i, err)
 		}
 	}
@@ -202,7 +202,7 @@ func TestApplyLayerInvalidSymlink(t *testing.T) {
 			},
 		},
 	} {
-		if err := testBreakout("applylayer", "storage-TestApplyLayerInvalidSymlink", headers); err != nil {
+		if err := testBreakout(t, "applylayer", headers); err != nil {
 			t.Fatalf("i=%d. %v", i, err)
 		}
 	}
@@ -214,11 +214,7 @@ func TestApplyLayerWhiteouts(t *testing.T) {
 		t.Skip("Failing on Windows")
 	}
 
-	wd, err := ioutil.TempDir("", "graphdriver-test-whiteouts")
-	if err != nil {
-		return
-	}
-	defer os.RemoveAll(wd)
+	wd := t.TempDir()
 
 	base := []string{
 		".baz",
@@ -303,7 +299,7 @@ func TestApplyLayerWhiteouts(t *testing.T) {
 	}
 
 	for i, tc := range tcases {
-		l, err := makeTestLayer(tc.change)
+		l, err := makeTestLayer(t, tc.change)
 		if err != nil {
 			t.Fatal(err)
 		}
@@ -329,16 +325,8 @@ func TestApplyLayerWhiteouts(t *testing.T) {
 
 }
 
-func makeTestLayer(paths []string) (rc io.ReadCloser, err error) {
-	tmpDir, err := ioutil.TempDir("", "graphdriver-test-mklayer")
-	if err != nil {
-		return
-	}
-	defer func() {
-		if err != nil {
-			os.RemoveAll(tmpDir)
-		}
-	}()
+func makeTestLayer(t *testing.T, paths []string) (rc io.ReadCloser, err error) {
+	tmpDir := t.TempDir()
 	for _, p := range paths {
 		if p[len(p)-1] == filepath.Separator {
 			if err = os.MkdirAll(filepath.Join(tmpDir, p), 0700); err != nil {
@@ -356,7 +344,6 @@ func makeTestLayer(paths []string) (rc io.ReadCloser, err error) {
 	}
 	return ioutils.NewReadCloserWrapper(archive, func() error {
 		err := archive.Close()
-		os.RemoveAll(tmpDir)
 		return err
 	}), nil
 }

--- a/pkg/archive/utils_test.go
+++ b/pkg/archive/utils_test.go
@@ -9,6 +9,7 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
+	"testing"
 	"time"
 )
 
@@ -34,12 +35,8 @@ var testUntarFns = map[string]func(string, io.Reader) error{
 // - file in `dest` with same content as `victim/hello` (read)
 //
 // When using testBreakout make sure you cover one of the scenarios listed above.
-func testBreakout(untarFn string, tmpdir string, headers []*tar.Header) error {
-	tmpdir, err := ioutil.TempDir("", tmpdir)
-	if err != nil {
-		return err
-	}
-	defer os.RemoveAll(tmpdir)
+func testBreakout(t *testing.T, untarFn string, headers []*tar.Header) error {
+	tmpdir := t.TempDir()
 
 	dest := filepath.Join(tmpdir, "dest")
 	if err := os.Mkdir(dest, 0755); err != nil {

--- a/pkg/chrootarchive/archive_test.go
+++ b/pkg/chrootarchive/archive_test.go
@@ -47,11 +47,7 @@ func CopyWithTar(src, dst string) error {
 }
 
 func TestChrootTarUntar(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "storage-TestChrootTarUntar")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 	src := filepath.Join(tmpdir, "src")
 	if err := os.MkdirAll(src, 0700); err != nil {
 		t.Fatal(err)
@@ -78,11 +74,7 @@ func TestChrootTarUntar(t *testing.T) {
 // gh#10426: Verify the fix for having a huge excludes list (like on `docker load` with large # of
 // local images)
 func TestChrootUntarWithHugeExcludesList(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "storage-TestChrootUntarHugeExcludes")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 	src := filepath.Join(tmpdir, "src")
 	if err := os.MkdirAll(src, 0700); err != nil {
 		t.Fatal(err)
@@ -112,11 +104,7 @@ func TestChrootUntarWithHugeExcludesList(t *testing.T) {
 }
 
 func TestChrootUntarEmptyArchive(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "storage-TestChrootUntarEmptyArchive")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 	if err := Untar(nil, tmpdir, nil); err == nil {
 		t.Fatal("expected error on empty archive")
 	}
@@ -210,11 +198,7 @@ func TestChrootTarUntarWithSymlink(t *testing.T) {
 	if runtime.GOOS == windows {
 		t.Skip("Failing on Windows")
 	}
-	tmpdir, err := ioutil.TempDir("", "storage-TestChrootTarUntarWithSymlink")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 	src := filepath.Join(tmpdir, "src")
 	if err := os.MkdirAll(src, 0700); err != nil {
 		t.Fatal(err)
@@ -236,11 +220,7 @@ func TestChrootCopyWithTar(t *testing.T) {
 	if runtime.GOOS == windows || runtime.GOOS == solaris {
 		t.Skip("Failing on Windows and Solaris")
 	}
-	tmpdir, err := ioutil.TempDir("", "storage-TestChrootCopyWithTar")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 	src := filepath.Join(tmpdir, "src")
 	if err := os.MkdirAll(src, 0700); err != nil {
 		t.Fatal(err)
@@ -286,11 +266,7 @@ func TestChrootCopyWithTarAndChown(t *testing.T) {
 	if runtime.GOOS == windows || runtime.GOOS == solaris {
 		t.Skip("Failing on Windows and Solaris")
 	}
-	tmpdir, err := ioutil.TempDir("", "storage-TestChrootCopyWithTar")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 	src := filepath.Join(tmpdir, "src")
 	if err := os.MkdirAll(src, 0700); err != nil {
 		t.Fatal(err)
@@ -338,11 +314,7 @@ func TestChrootCopyWithTarAndChown(t *testing.T) {
 }
 
 func TestChrootCopyFileWithTar(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "storage-TestChrootCopyFileWithTar")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 	src := filepath.Join(tmpdir, "src")
 	if err := os.MkdirAll(src, 0700); err != nil {
 		t.Fatal(err)
@@ -381,11 +353,7 @@ func TestChrootCopyFileWithTar(t *testing.T) {
 }
 
 func TestChrootCopyFileWithTarAndChown(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "storage-TestChrootCopyFileWithTar")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 	src := filepath.Join(tmpdir, "src")
 	if err := os.MkdirAll(src, 0700); err != nil {
 		t.Fatal(err)
@@ -435,11 +403,7 @@ func TestChrootUntarPath(t *testing.T) {
 	if runtime.GOOS == windows {
 		t.Skip("Failing on Windows")
 	}
-	tmpdir, err := ioutil.TempDir("", "storage-TestChrootUntarPath")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 	src := filepath.Join(tmpdir, "src")
 	if err := os.MkdirAll(src, 0700); err != nil {
 		t.Fatal(err)
@@ -478,11 +442,7 @@ func TestChrootUntarPathAndChown(t *testing.T) {
 	if runtime.GOOS == windows {
 		t.Skip("Failing on Windows")
 	}
-	tmpdir, err := ioutil.TempDir("", "storage-TestChrootUntarPath")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 	src := filepath.Join(tmpdir, "src")
 	if err := os.MkdirAll(src, 0700); err != nil {
 		t.Fatal(err)
@@ -550,11 +510,7 @@ func (s *slowEmptyTarReader) Read(p []byte) (int, error) {
 }
 
 func TestChrootUntarEmptyArchiveFromSlowReader(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "storage-TestChrootUntarEmptyArchiveFromSlowReader")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 	dest := filepath.Join(tmpdir, "dest")
 	if err := os.MkdirAll(dest, 0700); err != nil {
 		t.Fatal(err)
@@ -566,11 +522,7 @@ func TestChrootUntarEmptyArchiveFromSlowReader(t *testing.T) {
 }
 
 func TestChrootApplyEmptyArchiveFromSlowReader(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "storage-TestChrootApplyEmptyArchiveFromSlowReader")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 	dest := filepath.Join(tmpdir, "dest")
 	if err := os.MkdirAll(dest, 0700); err != nil {
 		t.Fatal(err)
@@ -582,11 +534,7 @@ func TestChrootApplyEmptyArchiveFromSlowReader(t *testing.T) {
 }
 
 func TestChrootApplyDotDotFile(t *testing.T) {
-	tmpdir, err := ioutil.TempDir("", "storage-TestChrootApplyDotDotFile")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpdir)
+	tmpdir := t.TempDir()
 	src := filepath.Join(tmpdir, "src")
 	if err := os.MkdirAll(src, 0700); err != nil {
 		t.Fatal(err)

--- a/pkg/chrootarchive/archive_unix_test.go
+++ b/pkg/chrootarchive/archive_unix_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package chrootarchive
@@ -23,13 +24,10 @@ import (
 // some path outside of a container's rootfs that we do not copy data to a
 // container path that will actually overwrite data on the host
 func TestUntarWithMaliciousSymlinks(t *testing.T) {
-	dir, err := ioutil.TempDir("", t.Name())
-	assert.NilError(t, err)
-	defer os.RemoveAll(dir)
-
+	dir := t.TempDir()
 	root := filepath.Join(dir, "root")
 
-	err = os.MkdirAll(root, 0755)
+	err := os.MkdirAll(root, 0755)
 	assert.NilError(t, err)
 
 	// Add a file into a directory above root
@@ -84,14 +82,12 @@ func TestUntarWithMaliciousSymlinks(t *testing.T) {
 // some path outside of a container's rootfs that we do not unwittingly leak
 // host data into the archive.
 func TestTarWithMaliciousSymlinks(t *testing.T) {
-	dir, err := ioutil.TempDir("", t.Name())
-	assert.NilError(t, err)
-	// defer os.RemoveAll(dir)
+	dir := t.TempDir()
 	t.Log(dir)
 
 	root := filepath.Join(dir, "root")
 
-	err = os.MkdirAll(root, 0755)
+	err := os.MkdirAll(root, 0755)
 	assert.NilError(t, err)
 
 	hostFileData := []byte("I am a host file")

--- a/pkg/directory/directory_test.go
+++ b/pkg/directory/directory_test.go
@@ -11,14 +11,7 @@ import (
 
 // Usage of an empty directory should be 0
 func TestUsageEmpty(t *testing.T) {
-	var dir string
-	var err error
-	if dir, err = ioutil.TempDir(os.TempDir(), "testUsageEmptyDirectory"); err != nil {
-		t.Fatalf("failed to create directory: %s", err)
-	}
-	defer os.RemoveAll(dir)
-
-	usage, _ := Usage(dir)
+	usage, _ := Usage(t.TempDir())
 	expectSizeAndInodeCount(t, "empty directory", usage, &DiskUsage{
 		Size:       0,
 		InodeCount: 1,
@@ -27,14 +20,10 @@ func TestUsageEmpty(t *testing.T) {
 
 // Usage of one empty file should be 0
 func TestUsageEmptyFile(t *testing.T) {
-	var dir string
-	var err error
-	if dir, err = ioutil.TempDir(os.TempDir(), "testUsageEmptyFile"); err != nil {
-		t.Fatalf("failed to create directory: %s", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	var file *os.File
+	var err error
 	if file, err = ioutil.TempFile(dir, "file"); err != nil {
 		t.Fatalf("failed to create file: %s", err)
 	}
@@ -48,14 +37,10 @@ func TestUsageEmptyFile(t *testing.T) {
 
 // Usage of a directory with one 5-byte file should be 5
 func TestUsageNonemptyFile(t *testing.T) {
-	var dir string
-	var err error
-	if dir, err = ioutil.TempDir(os.TempDir(), "testUsageNonemptyFile"); err != nil {
-		t.Fatalf("failed to create directory: %s", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
 
 	var file *os.File
+	var err error
 	if file, err = ioutil.TempFile(dir, "file"); err != nil {
 		t.Fatalf("failed to create file: %s", err)
 	}
@@ -72,14 +57,7 @@ func TestUsageNonemptyFile(t *testing.T) {
 
 // Usage of an empty directory should be 0
 func TestUsageEmptyDirectory(t *testing.T) {
-	var dir string
-	var err error
-	if dir, err = ioutil.TempDir(os.TempDir(), "testUsageEmptyDirectory"); err != nil {
-		t.Fatalf("failed to create directory: %s", err)
-	}
-	defer os.RemoveAll(dir)
-
-	usage, _ := Usage(dir)
+	usage, _ := Usage(t.TempDir())
 	expectSizeAndInodeCount(t, "one directory", usage, &DiskUsage{
 		Size:       0,
 		InodeCount: 1,
@@ -88,13 +66,8 @@ func TestUsageEmptyDirectory(t *testing.T) {
 
 // Usage of a directory with one empty directory should be 0
 func TestUsageNestedDirectoryEmpty(t *testing.T) {
-	var dir string
-	var err error
-	if dir, err = ioutil.TempDir(os.TempDir(), "testUsageNestedDirectoryEmpty"); err != nil {
-		t.Fatalf("failed to create directory: %s", err)
-	}
-	defer os.RemoveAll(dir)
-	if _, err = ioutil.TempDir(dir, "nested"); err != nil {
+	dir := t.TempDir()
+	if _, err := ioutil.TempDir(dir, "nested"); err != nil {
 		t.Fatalf("failed to create nested directory: %s", err)
 	}
 
@@ -107,12 +80,9 @@ func TestUsageNestedDirectoryEmpty(t *testing.T) {
 
 // Test directory with 1 file and 1 empty directory
 func TestUsageFileAndNestedDirectoryEmpty(t *testing.T) {
-	var dir string
 	var err error
-	if dir, err = ioutil.TempDir(os.TempDir(), "testUsageFileAndNestedDirectoryEmpty"); err != nil {
-		t.Fatalf("failed to create directory: %s", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
+
 	if _, err = ioutil.TempDir(dir, "nested"); err != nil {
 		t.Fatalf("failed to create nested directory: %s", err)
 	}
@@ -134,12 +104,10 @@ func TestUsageFileAndNestedDirectoryEmpty(t *testing.T) {
 
 // Test directory with 1 file and 1 non-empty directory
 func TestUsageFileAndNestedDirectoryNonempty(t *testing.T) {
-	var dir, dirNested string
+	var dirNested string
 	var err error
-	if dir, err = ioutil.TempDir(os.TempDir(), "TestUsageFileAndNestedDirectoryNonempty"); err != nil {
-		t.Fatalf("failed to create directory: %s", err)
-	}
-	defer os.RemoveAll(dir)
+	dir := t.TempDir()
+
 	if dirNested, err = ioutil.TempDir(dir, "nested"); err != nil {
 		t.Fatalf("failed to create nested directory: %s", err)
 	}
@@ -169,13 +137,9 @@ func TestUsageFileAndNestedDirectoryNonempty(t *testing.T) {
 
 // Test migration of directory to a subdir underneath itself
 func TestMoveToSubdir(t *testing.T) {
-	var outerDir, subDir string
+	var subDir string
 	var err error
-
-	if outerDir, err = ioutil.TempDir(os.TempDir(), "TestMoveToSubdir"); err != nil {
-		t.Fatalf("failed to create directory: %v", err)
-	}
-	defer os.RemoveAll(outerDir)
+	outerDir := t.TempDir()
 
 	if subDir, err = ioutil.TempDir(outerDir, "testSub"); err != nil {
 		t.Fatalf("failed to create subdirectory: %v", err)

--- a/pkg/fileutils/fileutils_test.go
+++ b/pkg/fileutils/fileutils_test.go
@@ -18,11 +18,7 @@ const windows = "windows"
 
 // CopyFile with invalid src
 func TestCopyFileWithInvalidSrc(t *testing.T) {
-	tempFolder, err := ioutil.TempDir("", "storage-fileutils-test")
-	defer os.RemoveAll(tempFolder)
-	if err != nil {
-		t.Fatal(err)
-	}
+	tempFolder := t.TempDir()
 	bytes, err := CopyFile("/invalid/file/path", path.Join(tempFolder, "dest"))
 	if err == nil {
 		t.Fatal("Should have fail to copy an invalid src file")
@@ -35,13 +31,9 @@ func TestCopyFileWithInvalidSrc(t *testing.T) {
 
 // CopyFile with invalid dest
 func TestCopyFileWithInvalidDest(t *testing.T) {
-	tempFolder, err := ioutil.TempDir("", "storage-fileutils-test")
-	defer os.RemoveAll(tempFolder)
-	if err != nil {
-		t.Fatal(err)
-	}
+	tempFolder := t.TempDir()
 	src := path.Join(tempFolder, "file")
-	err = ioutil.WriteFile(src, []byte("content"), 0740)
+	err := ioutil.WriteFile(src, []byte("content"), 0740)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -57,13 +49,9 @@ func TestCopyFileWithInvalidDest(t *testing.T) {
 
 // CopyFile with same src and dest
 func TestCopyFileWithSameSrcAndDest(t *testing.T) {
-	tempFolder, err := ioutil.TempDir("", "storage-fileutils-test")
-	defer os.RemoveAll(tempFolder)
-	if err != nil {
-		t.Fatal(err)
-	}
+	tempFolder := t.TempDir()
 	file := path.Join(tempFolder, "file")
-	err = ioutil.WriteFile(file, []byte("content"), 0740)
+	err := ioutil.WriteFile(file, []byte("content"), 0740)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -78,13 +66,9 @@ func TestCopyFileWithSameSrcAndDest(t *testing.T) {
 
 // CopyFile with same src and dest but path is different and not clean
 func TestCopyFileWithSameSrcAndDestWithPathNameDifferent(t *testing.T) {
-	tempFolder, err := ioutil.TempDir("", "storage-fileutils-test")
-	defer os.RemoveAll(tempFolder)
-	if err != nil {
-		t.Fatal(err)
-	}
+	tempFolder := t.TempDir()
 	testFolder := path.Join(tempFolder, "test")
-	err = os.MkdirAll(testFolder, 0740)
+	err := os.MkdirAll(testFolder, 0740)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -104,14 +88,10 @@ func TestCopyFileWithSameSrcAndDestWithPathNameDifferent(t *testing.T) {
 }
 
 func TestCopyFile(t *testing.T) {
-	tempFolder, err := ioutil.TempDir("", "storage-fileutils-test")
-	defer os.RemoveAll(tempFolder)
-	if err != nil {
-		t.Fatal(err)
-	}
+	tempFolder := t.TempDir()
 	src := path.Join(tempFolder, "src")
 	dest := path.Join(tempFolder, "dest")
-	err = ioutil.WriteFile(src, []byte("content"), 0777)
+	err := ioutil.WriteFile(src, []byte("content"), 0777)
 	require.NoError(t, err)
 
 	err = ioutil.WriteFile(dest, []byte("destContent"), 0777)
@@ -486,11 +466,7 @@ func TestCleanPatternsErrorSingleException(t *testing.T) {
 }
 
 func TestCreateIfNotExistsDir(t *testing.T) {
-	tempFolder, err := ioutil.TempDir("", "storage-fileutils-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tempFolder)
+	tempFolder := t.TempDir()
 
 	folderToCreate := filepath.Join(tempFolder, "tocreate")
 
@@ -508,11 +484,7 @@ func TestCreateIfNotExistsDir(t *testing.T) {
 }
 
 func TestCreateIfNotExistsFile(t *testing.T) {
-	tempFolder, err := ioutil.TempDir("", "storage-fileutils-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tempFolder)
+	tempFolder := t.TempDir()
 
 	fileToCreate := filepath.Join(tempFolder, "file/to/create")
 

--- a/pkg/idtools/idtools_unix_test.go
+++ b/pkg/idtools/idtools_unix_test.go
@@ -20,11 +20,7 @@ type node struct {
 }
 
 func TestMkdirAllAs(t *testing.T) {
-	dirName, err := ioutil.TempDir("", "mkdirall")
-	if err != nil {
-		t.Fatalf("Couldn't create temp dir: %v", err)
-	}
-	defer os.RemoveAll(dirName)
+	dirName := t.TempDir()
 
 	testTree := map[string]node{
 		"usr":              {0, 0},
@@ -85,9 +81,7 @@ func TestMkdirAllAs(t *testing.T) {
 }
 
 func TestMkdirAllAndChownNew(t *testing.T) {
-	dirName, err := ioutil.TempDir("", "mkdirnew")
-	require.NoError(t, err)
-	defer os.RemoveAll(dirName)
+	dirName := t.TempDir()
 
 	testTree := map[string]node{
 		"usr":              {0, 0},
@@ -99,7 +93,7 @@ func TestMkdirAllAndChownNew(t *testing.T) {
 	require.NoError(t, buildTree(dirName, testTree))
 
 	// test adding a directory to a pre-existing dir; only the new dir is owned by the uid/gid
-	err = MkdirAllAndChownNew(filepath.Join(dirName, "usr", "share"), 0755, IDPair{99, 99})
+	err := MkdirAllAndChownNew(filepath.Join(dirName, "usr", "share"), 0755, IDPair{99, 99})
 	require.NoError(t, err)
 
 	testTree["usr/share"] = node{99, 99}
@@ -126,11 +120,7 @@ func TestMkdirAllAndChownNew(t *testing.T) {
 
 func TestMkdirAs(t *testing.T) {
 
-	dirName, err := ioutil.TempDir("", "mkdir")
-	if err != nil {
-		t.Fatalf("Couldn't create temp dir: %v", err)
-	}
-	defer os.RemoveAll(dirName)
+	dirName := t.TempDir()
 
 	testTree := map[string]node{
 		"usr": {0, 0},
@@ -231,11 +221,7 @@ func compareTrees(left, right map[string]node) error {
 }
 
 func TestParseSubidFileWithNewlinesAndComments(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "parsesubid")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	fnamePath := filepath.Join(tmpDir, "testsubuid")
 	fcontent := `tss:100000:65536

--- a/pkg/ioutils/fswriters_test.go
+++ b/pkg/ioutils/fswriters_test.go
@@ -21,11 +21,7 @@ func init() {
 }
 
 func TestAtomicWriteToFile(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "atomic-writers-test")
-	if err != nil {
-		t.Fatalf("Error when creating temporary directory: %s", err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	expected := []byte("barbaz")
 	if err := AtomicWriteFile(filepath.Join(tmpDir, "foo"), expected, testMode); err != nil {
@@ -51,11 +47,7 @@ func TestAtomicWriteToFile(t *testing.T) {
 }
 
 func TestAtomicWriteSetCommit(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "atomic-writerset-test")
-	if err != nil {
-		t.Fatalf("Error when creating temporary directory: %s", err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	if err := os.Mkdir(filepath.Join(tmpDir, "tmp"), 0700); err != nil {
 		t.Fatalf("Error creating tmp directory: %s", err)
@@ -100,11 +92,7 @@ func TestAtomicWriteSetCommit(t *testing.T) {
 }
 
 func TestAtomicWriteSetCancel(t *testing.T) {
-	tmpDir, err := ioutil.TempDir("", "atomic-writerset-test")
-	if err != nil {
-		t.Fatalf("Error when creating temporary directory: %s", err)
-	}
-	defer os.RemoveAll(tmpDir)
+	tmpDir := t.TempDir()
 
 	if err := os.Mkdir(filepath.Join(tmpDir, "tmp"), 0700); err != nil {
 		t.Fatalf("Error creating tmp directory: %s", err)

--- a/pkg/mount/mounter_linux_test.go
+++ b/pkg/mount/mounter_linux_test.go
@@ -2,7 +2,6 @@ package mount
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 	"strings"
 	"testing"
@@ -13,11 +12,7 @@ func TestMount(t *testing.T) {
 		t.Skip("not root tests would fail")
 	}
 
-	source, err := ioutil.TempDir("", "mount-test-source-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(source)
+	source := t.TempDir()
 
 	// Ensure we have a known start point by mounting tmpfs with given options
 	if err := Mount("tmpfs", source, "tmpfs", "private"); err != nil {
@@ -29,11 +24,7 @@ func TestMount(t *testing.T) {
 		t.FailNow()
 	}
 
-	target, err := ioutil.TempDir("", "mount-test-target-")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(target)
+	target := t.TempDir()
 
 	tests := []struct {
 		source           string

--- a/pkg/system/chtimes_test.go
+++ b/pkg/system/chtimes_test.go
@@ -9,23 +9,17 @@ import (
 )
 
 // prepareTempFile creates a temporary file in a temporary directory.
-func prepareTempFile(t *testing.T) (string, string) {
-	dir, err := ioutil.TempDir("", "storage-system-test")
-	if err != nil {
-		t.Fatal(err)
-	}
-
-	file := filepath.Join(dir, "exist")
+func prepareTempFile(t *testing.T) string {
+	file := filepath.Join(t.TempDir(), "exist")
 	if err := ioutil.WriteFile(file, []byte("hello"), 0644); err != nil {
 		t.Fatal(err)
 	}
-	return file, dir
+	return file
 }
 
 // TestChtimes tests Chtimes on a tempfile. Test only mTime, because aTime is OS dependent
 func TestChtimes(t *testing.T) {
-	file, dir := prepareTempFile(t)
-	defer os.RemoveAll(dir)
+	file := prepareTempFile(t)
 
 	beforeUnixEpochTime := time.Unix(0, 0).Add(-100 * time.Second)
 	unixEpochTime := time.Unix(0, 0)

--- a/pkg/system/chtimes_unix_test.go
+++ b/pkg/system/chtimes_unix_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package system
@@ -11,8 +12,7 @@ import (
 
 // TestChtimesLinux tests Chtimes access time on a tempfile on Linux
 func TestChtimesLinux(t *testing.T) {
-	file, dir := prepareTempFile(t)
-	defer os.RemoveAll(dir)
+	file := prepareTempFile(t)
 
 	beforeUnixEpochTime := time.Unix(0, 0).Add(-100 * time.Second)
 	unixEpochTime := time.Unix(0, 0)

--- a/pkg/system/chtimes_windows_test.go
+++ b/pkg/system/chtimes_windows_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package system
@@ -11,8 +12,7 @@ import (
 
 // TestChtimesWindows tests Chtimes access time on a tempfile on Windows
 func TestChtimesWindows(t *testing.T) {
-	file, dir := prepareTempFile(t)
-	defer os.RemoveAll(dir)
+	file := prepareTempFile(t)
 
 	beforeUnixEpochTime := time.Unix(0, 0).Add(-100 * time.Second)
 	unixEpochTime := time.Unix(0, 0)

--- a/pkg/system/lstat_unix_test.go
+++ b/pkg/system/lstat_unix_test.go
@@ -1,16 +1,15 @@
+//go:build linux || freebsd
 // +build linux freebsd
 
 package system
 
 import (
-	"os"
 	"testing"
 )
 
 // TestLstat tests Lstat for existing and non existing files
 func TestLstat(t *testing.T) {
-	file, invalid, _, dir := prepareFiles(t)
-	defer os.RemoveAll(dir)
+	file, invalid, _ := prepareFiles(t)
 
 	statFile, err := Lstat(file)
 	if err != nil {

--- a/pkg/system/rm_test.go
+++ b/pkg/system/rm_test.go
@@ -19,10 +19,7 @@ func TestEnsureRemoveAllNotExist(t *testing.T) {
 }
 
 func TestEnsureRemoveAllWithDir(t *testing.T) {
-	dir, err := ioutil.TempDir("", "test-ensure-removeall-with-dir")
-	if err != nil {
-		t.Fatal(err)
-	}
+	dir := t.TempDir()
 	if err := EnsureRemoveAll(dir); err != nil {
 		t.Fatal(err)
 	}
@@ -44,15 +41,8 @@ func TestEnsureRemoveAllWithMount(t *testing.T) {
 		t.Skip("mount not supported on Windows")
 	}
 
-	dir1, err := ioutil.TempDir("", "test-ensure-removeall-with-dir1")
-	if err != nil {
-		t.Fatal(err)
-	}
-	dir2, err := ioutil.TempDir("", "test-ensure-removeall-with-dir2")
-	if err != nil {
-		t.Fatal(err)
-	}
-	defer os.RemoveAll(dir2)
+	dir1 := t.TempDir()
+	dir2 := t.TempDir()
 
 	bindDir := filepath.Join(dir1, "bind")
 	if err := os.MkdirAll(bindDir, 0755); err != nil {
@@ -63,6 +53,7 @@ func TestEnsureRemoveAllWithMount(t *testing.T) {
 		t.Fatal(err)
 	}
 
+	var err error
 	done := make(chan struct{})
 	go func() {
 		err = EnsureRemoveAll(dir1)

--- a/pkg/system/stat_unix_test.go
+++ b/pkg/system/stat_unix_test.go
@@ -1,17 +1,16 @@
+//go:build linux || freebsd
 // +build linux freebsd
 
 package system
 
 import (
-	"os"
 	"syscall"
 	"testing"
 )
 
 // TestFromStatT tests fromStatT for a tempfile
 func TestFromStatT(t *testing.T) {
-	file, _, _, dir := prepareFiles(t)
-	defer os.RemoveAll(dir)
+	file, _, _ := prepareFiles(t)
 
 	stat := &syscall.Stat_t{}
 	if err := syscall.Lstat(file, stat); err != nil {

--- a/pkg/system/utimes_unix_test.go
+++ b/pkg/system/utimes_unix_test.go
@@ -1,3 +1,4 @@
+//go:build linux || freebsd
 // +build linux freebsd
 
 package system
@@ -11,11 +12,8 @@ import (
 )
 
 // prepareFiles creates files for testing in the temp directory
-func prepareFiles(t *testing.T) (string, string, string, string) {
-	dir, err := ioutil.TempDir("", "storage-system-test")
-	if err != nil {
-		t.Fatal(err)
-	}
+func prepareFiles(t *testing.T) (string, string, string) {
+	dir := t.TempDir()
 
 	file := filepath.Join(dir, "exist")
 	if err := ioutil.WriteFile(file, []byte("hello"), 0644); err != nil {
@@ -29,12 +27,11 @@ func prepareFiles(t *testing.T) (string, string, string, string) {
 		t.Fatal(err)
 	}
 
-	return file, invalid, symlink, dir
+	return file, invalid, symlink
 }
 
 func TestLUtimesNano(t *testing.T) {
-	file, invalid, symlink, dir := prepareFiles(t)
-	defer os.RemoveAll(dir)
+	file, invalid, symlink := prepareFiles(t)
 
 	before, err := os.Stat(file)
 	if err != nil {

--- a/store_test.go
+++ b/store_test.go
@@ -1,7 +1,6 @@
 package storage
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 	"testing"
@@ -13,10 +12,7 @@ import (
 )
 
 func TestStore(t *testing.T) {
-	wd, err := ioutil.TempDir("", "testStorageRuntime")
-	require.NoError(t, err)
-	err = os.MkdirAll(wd, 0700)
-	require.NoError(t, err)
+	wd := t.TempDir()
 
 	pullOpts := map[string]string{"Test1": "test1", "Test2": "test2"}
 	store, err := GetStore(StoreOptions{

--- a/types/utils_test.go
+++ b/types/utils_test.go
@@ -47,12 +47,10 @@ func (env rootlessRuntimeDirEnvironmentTest) homedirGet() string {
 }
 
 func TestRootlessRuntimeDir(t *testing.T) {
-	testDir, err := ioutil.TempDir("", "rootless-runtime-dir-test")
-	assert.NilError(t, err)
-	defer os.Remove(testDir)
+	testDir := t.TempDir()
 
 	homeRuntimeDir := filepath.Join(testDir, "home-rundir")
-	err = os.Mkdir(homeRuntimeDir, 0700)
+	err := os.Mkdir(homeRuntimeDir, 0700)
 	assert.NilError(t, err)
 
 	homeRuntimeDisabled := homeRuntimeData{err: errors.New("homedirGetRuntimeDir is disabled")}
@@ -244,12 +242,10 @@ func (rootlessRuntimeDirEnvironmentRace) homedirGet() string {
 }
 
 func TestRootlessRuntimeDirRace(t *testing.T) {
-	raceDir, err := ioutil.TempDir("", "rootless-runtime-dir-race-test")
-	assert.NilError(t, err)
-	defer os.Remove(raceDir)
+	raceDir := t.TempDir()
 
 	procCommandFile := filepath.Join(raceDir, "command")
-	err = ioutil.WriteFile(procCommandFile, []byte("init"), 0644)
+	err := ioutil.WriteFile(procCommandFile, []byte("init"), 0644)
 	assert.NilError(t, err)
 
 	tmpPerUserDir := filepath.Join(raceDir, "tmp")


### PR DESCRIPTION
A testing cleanup. 

This pull request replaces `ioutil.TempDir` with `t.TempDir`. We can use the `T.TempDir` function from the `testing` package to create temporary directory. The directory created by `T.TempDir` is automatically removed when the test and all its subtests complete. 

This saves us at least 2 lines (error check, and cleanup) on every instance, or in some cases adds cleanup that we forgot.

Reference: https://pkg.go.dev/testing#T.TempDir

```go
func TestFoo(t *testing.T) {
	// before
	tmpDir, err := ioutil.TempDir("", "")
	require.NoError(t, err)
	defer os.RemoveAll(tmpDir)

	// now
	tmpDir := t.TempDir()
}
```