### PR TITLE
Don't use subprocess output as a format specifier

### DIFF
--- a/drivers/chown.go
+++ b/drivers/chown.go
@@ -2,6 +2,7 @@ package graphdriver
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
 	"os"
 
@@ -93,7 +94,7 @@ func ChownPathByMaps(path string, toContainer, toHost *idtools.IDMappings) error
 		return err
 	}
 	if len(output) > 0 {
-		return fmt.Errorf(string(output))
+		return errors.New(string(output))
 	}
 
 	return nil


### PR DESCRIPTION
Don't pass the output of a subprocess to `fmt.Errorf()`, which will try to treat it as a format specifier.  Just use `errors.New()` to create an error using the text verbatim.

Fixes #1316.