### PR TITLE
Fix data race between ReloadIfChanged and read-only usage of layerStore

### DIFF
--- a/layers.go
+++ b/layers.go
@@ -423,6 +423,15 @@ func (r *layerStore) Load() error {
 		}
 	}
 
+	info, statErr := os.Stat(r.layerspath())
+	if statErr != nil && !os.IsNotExist(statErr) {
+		return statErr
+	}
+
+	if info != nil {
+		r.layerspathModified = info.ModTime()
+	}
+
 	return err
 }
 
@@ -1924,7 +1933,6 @@ func (r *layerStore) Modified() (bool, error) {
 	}
 	if info != nil {
 		tmodified = info.ModTime() != r.layerspathModified
-		r.layerspathModified = info.ModTime()
 	}
 
 	return tmodified, nil


### PR DESCRIPTION
There was a race condition if a goroutine accessed to layerStore public
methods under RO lock and at the same time ReloadIfChanged was called.
In real life, it can occurr when there are two concurrent PlayKube
requests in Podman.

Signed-off-by: Mikhail Khachayants <tyler92@inbox.ru>