### PR TITLE
Explain why a substring match is sufficient when reading uid_map

### DIFF
--- a/pkg/unshare/unshare_linux.go
+++ b/pkg/unshare/unshare_linux.go
@@ -394,7 +394,9 @@ func hasFullUsersMappings() (bool, error) {
 	if err != nil {
 		return false, err
 	}
-	// if the uid_map contains 4294967295, the entire IDs space is available in the
+	// The kernel rejects attempts to create mappings where either starting
+	// point is (u32)-1: https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/tree/kernel/user_namespace.c?id=af3e9579ecfb#n1006 .
+	// So, if the uid_map contains 4294967295, the entire IDs space is available in the
 	// user namespace, so it is likely the initial user namespace.
 	return bytes.Contains(content, []byte("4294967295")), nil
 }


### PR DESCRIPTION
per https://github.com/containers/storage/pull/1312#discussion_r966242314 .