### PR TITLE
ReadMemInfo: Add missing import of errors

### DIFF
--- a/pkg/system/meminfo_freebsd.go
+++ b/pkg/system/meminfo_freebsd.go
@@ -4,6 +4,7 @@
 package system
 
 import (
+	"errors"
 	"fmt"
 	"unsafe"
 


### PR DESCRIPTION
This wasn't picked up by the freebsd cross build because meminfo_freebsd.go relies on cgo.

Signed-off-by: Doug Rabson <dfr@rabson.org>