### PR TITLE
refactor: use `os.ReadDir` for lightweight directory reading

### DIFF
--- a/drivers/aufs/aufs.go
+++ b/drivers/aufs/aufs.go
@@ -170,7 +170,7 @@ func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) 
 
 	for _, path := range []string{"mnt", "diff"} {
 		p := filepath.Join(home, path)
-		entries, err := ioutil.ReadDir(p)
+		entries, err := os.ReadDir(p)
 		if err != nil {
 			logger.WithError(err).WithField("dir", p).Error("error reading dir entries")
 			continue

--- a/drivers/aufs/aufs_test.go
+++ b/drivers/aufs/aufs_test.go
@@ -8,7 +8,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"os"
 	"path"
 	"path/filepath"
@@ -692,7 +691,7 @@ func testMountMoreThan42Layers(t *testing.T, mountPath string) {
 	// Perform the actual mount for the top most image
 	point, err := driverGet(d, last, "")
 	require.NoError(t, err)
-	files, err := ioutil.ReadDir(point)
+	files, err := os.ReadDir(point)
 	require.NoError(t, err)
 	assert.Len(t, files, expected)
 }

--- a/drivers/aufs/dirs.go
+++ b/drivers/aufs/dirs.go
@@ -1,17 +1,17 @@
+//go:build linux
 // +build linux
 
 package aufs
 
 import (
 	"bufio"
-	"io/ioutil"
 	"os"
 	"path"
 )
 
 // Return all the directories
 func loadIds(root string) ([]string, error) {
-	dirs, err := ioutil.ReadDir(root)
+	dirs, err := os.ReadDir(root)
 	if err != nil {
 		return nil, err
 	}

--- a/drivers/devmapper/deviceset.go
+++ b/drivers/devmapper/deviceset.go
@@ -1276,8 +1276,8 @@ func (devices *DeviceSet) setupBaseImage() error {
 }
 
 func setCloseOnExec(name string) {
-	fileInfos, _ := ioutil.ReadDir("/proc/self/fd")
-	for _, i := range fileInfos {
+	entries, _ := os.ReadDir("/proc/self/fd")
+	for _, i := range entries {
 		link, _ := os.Readlink(filepath.Join("/proc/self/fd", i.Name()))
 		if link == name {
 			fd, err := strconv.Atoi(i.Name())
@@ -2258,7 +2258,7 @@ func (devices *DeviceSet) cancelDeferredRemoval(info *devInfo) error {
 }
 
 func (devices *DeviceSet) unmountAndDeactivateAll(dir string) {
-	files, err := ioutil.ReadDir(dir)
+	files, err := os.ReadDir(dir)
 	if err != nil {
 		logrus.Warnf("devmapper: unmountAndDeactivate: %s", err)
 		return

--- a/drivers/graphtest/testutil.go
+++ b/drivers/graphtest/testutil.go
@@ -328,11 +328,11 @@ func checkManyLayers(drv graphdriver.Driver, layer string, count int) error {
 	return nil
 }
 
-// readDir reads a directory just like ioutil.ReadDir()
+// readDir reads a directory just like os.ReadDir()
 // then hides specific files (currently "lost+found")
 // so the tests don't "see" it
-func readDir(dir string) ([]os.FileInfo, error) {
-	a, err := ioutil.ReadDir(dir)
+func readDir(dir string) ([]os.DirEntry, error) {
+	a, err := os.ReadDir(dir)
 	if err != nil {
 		return nil, err
 	}

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -1209,7 +1209,7 @@ func (d *Driver) recreateSymlinks() error {
 	const maxIterations = 10
 
 	// List all the directories under the home directory
-	dirs, err := ioutil.ReadDir(d.home)
+	dirs, err := os.ReadDir(d.home)
 	if err != nil {
 		return fmt.Errorf("reading driver home directory %q: %w", d.home, err)
 	}
@@ -1228,7 +1228,7 @@ func (d *Driver) recreateSymlinks() error {
 		// the layer's "link" file that points to the layer's "diff" directory.
 		for _, dir := range dirs {
 			// Skip over the linkDir and anything that is not a directory
-			if dir.Name() == linkDir || !dir.Mode().IsDir() {
+			if dir.Name() == linkDir || !dir.IsDir() {
 				continue
 			}
 			// Read the "link" file under each layer to get the name of the symlink
@@ -1257,7 +1257,7 @@ func (d *Driver) recreateSymlinks() error {
 		linkDirFullPath := filepath.Join(d.home, "l")
 		// Now check if we somehow lost a "link" file, by making sure
 		// that each symlink we have corresponds to one.
-		links, err := ioutil.ReadDir(linkDirFullPath)
+		links, err := os.ReadDir(linkDirFullPath)
 		if err != nil {
 			errs = multierror.Append(errs, err)
 			continue
@@ -1661,7 +1661,7 @@ func (d *Driver) Put(id string) error {
 	mappedRoot := filepath.Join(d.home, id, "mapped")
 	// It should not happen, but cleanup any mapped mount if it was leaked.
 	if _, err := os.Stat(mappedRoot); err == nil {
-		mounts, err := ioutil.ReadDir(mappedRoot)
+		mounts, err := os.ReadDir(mappedRoot)
 		if err == nil {
 			// Go through all of the mapped mounts.
 			for _, m := range mounts {

--- a/drivers/quota/projectquota.go
+++ b/drivers/quota/projectquota.go
@@ -52,7 +52,6 @@ struct fsxattr {
 import "C"
 import (
 	"fmt"
-	"io/ioutil"
 	"math"
 	"os"
 	"path"
@@ -109,11 +108,12 @@ func generateUniqueProjectID(path string) (uint32, error) {
 // This test will fail if the backing fs is not xfs.
 //
 // xfs_quota tool can be used to assign a project id to the driver home directory, e.g.:
-//    echo 100000:/var/lib/containers/storage/overlay >> /etc/projects
-//    echo 200000:/var/lib/containers/storage/volumes >> /etc/projects
-//    echo storage:100000 >> /etc/projid
-//    echo volumes:200000 >> /etc/projid
-//    xfs_quota -x -c 'project -s storage volumes' /<xfs mount point>
+//
+//	echo 100000:/var/lib/containers/storage/overlay >> /etc/projects
+//	echo 200000:/var/lib/containers/storage/volumes >> /etc/projects
+//	echo storage:100000 >> /etc/projid
+//	echo volumes:200000 >> /etc/projid
+//	xfs_quota -x -c 'project -s storage volumes' /<xfs mount point>
 //
 // In the example above, the storage directory project id will be used as a
 // "start offset" and all containers will be assigned larger project ids
@@ -122,12 +122,10 @@ func generateUniqueProjectID(path string) (uint32, error) {
 // (e.g. >= 200000).
 // This is a way to prevent xfs_quota management from conflicting with
 // containers/storage.
-
 //
 // Then try to create a test directory with the next project id and set a quota
 // on it. If that works, continue to scan existing containers to map allocated
 // project ids.
-//
 func NewControl(basePath string) (*Control, error) {
 	//
 	// Get project id of parent dir as minimal id to be used by driver
@@ -336,7 +334,7 @@ func setProjectID(targetPath string, projectID uint32) error {
 // findNextProjectID - find the next project id to be used for containers
 // by scanning driver home directory to find used project ids
 func (q *Control) findNextProjectID(home string) error {
-	files, err := ioutil.ReadDir(home)
+	files, err := os.ReadDir(home)
 	if err != nil {
 		return fmt.Errorf("read directory failed : %s", home)
 	}

--- a/drivers/windows/windows.go
+++ b/drivers/windows/windows.go
@@ -475,7 +475,7 @@ func (d *Driver) Put(id string) error {
 // We use this opportunity to cleanup any -removing folders which may be
 // still left if the daemon was killed while it was removing a layer.
 func (d *Driver) Cleanup() error {
-	items, err := ioutil.ReadDir(d.info.HomeDir)
+	items, err := os.ReadDir(d.info.HomeDir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -1234,7 +1234,7 @@ func readFileFromArchive(t *testing.T, archive io.ReadCloser, name string, expec
 	err := Untar(archive, destDir, nil)
 	require.NoError(t, err)
 
-	files, _ := ioutil.ReadDir(destDir)
+	files, _ := os.ReadDir(destDir)
 	assert.Len(t, files, expectedCount, doc)
 
 	content, err := ioutil.ReadFile(filepath.Join(destDir, name))

--- a/pkg/directory/directory.go
+++ b/pkg/directory/directory.go
@@ -1,7 +1,6 @@
 package directory
 
 import (
-	"io/ioutil"
 	"os"
 	"path/filepath"
 )
@@ -15,14 +14,14 @@ type DiskUsage struct {
 
 // MoveToSubdir moves all contents of a directory to a subdirectory underneath the original path
 func MoveToSubdir(oldpath, subdir string) error {
-	infos, err := ioutil.ReadDir(oldpath)
+	entries, err := os.ReadDir(oldpath)
 	if err != nil {
 		return err
 	}
-	for _, info := range infos {
-		if info.Name() != subdir {
-			oldName := filepath.Join(oldpath, info.Name())
-			newName := filepath.Join(oldpath, subdir, info.Name())
+	for _, entry := range entries {
+		if entry.Name() != subdir {
+			oldName := filepath.Join(oldpath, entry.Name())
+			newName := filepath.Join(oldpath, subdir, entry.Name())
 			if err := os.Rename(oldName, newName); err != nil {
 				return err
 			}

--- a/pkg/directory/directory_test.go
+++ b/pkg/directory/directory_test.go
@@ -160,16 +160,16 @@ func TestMoveToSubdir(t *testing.T) {
 		t.Fatalf("Error during migration of content to subdirectory: %v", err)
 	}
 	// validate that the files were moved to the subdirectory
-	infos, err := ioutil.ReadDir(subDir)
+	entries, err := os.ReadDir(subDir)
 	if err != nil {
 		t.Fatal(err)
 	}
-	if len(infos) != 4 {
-		t.Fatalf("Should be four files in the subdir after the migration: actual length: %d", len(infos))
+	if len(entries) != 4 {
+		t.Fatalf("Should be four files in the subdir after the migration: actual length: %d", len(entries))
 	}
 	var results []string
-	for _, info := range infos {
-		results = append(results, info.Name())
+	for _, entry := range entries {
+		results = append(results, entry.Name())
 	}
 	sort.Sort(sort.StringSlice(results))
 	if !reflect.DeepEqual(filesList, results) {

--- a/pkg/fileutils/fileutils_unix.go
+++ b/pkg/fileutils/fileutils_unix.go
@@ -1,10 +1,10 @@
+//go:build linux || freebsd
 // +build linux freebsd
 
 package fileutils
 
 import (
 	"fmt"
-	"io/ioutil"
 	"os"
 
 	"github.com/sirupsen/logrus"
@@ -13,7 +13,7 @@ import (
 // GetTotalUsedFds Returns the number of used File Descriptors by
 // reading it via /proc filesystem.
 func GetTotalUsedFds() int {
-	if fds, err := ioutil.ReadDir(fmt.Sprintf("/proc/%d/fd", os.Getpid())); err != nil {
+	if fds, err := os.ReadDir(fmt.Sprintf("/proc/%d/fd", os.Getpid())); err != nil {
 		logrus.Errorf("%v", err)
 	} else {
 		return len(fds)

--- a/pkg/fsutils/fsutils_linux.go
+++ b/pkg/fsutils/fsutils_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package fsutils
@@ -12,7 +13,7 @@ import (
 )
 
 func locateDummyIfEmpty(path string) (string, error) {
-	children, err := ioutil.ReadDir(path)
+	children, err := os.ReadDir(path)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/idtools/idtools_unix_test.go
+++ b/pkg/idtools/idtools_unix_test.go
@@ -177,20 +177,20 @@ func buildTree(base string, tree map[string]node) error {
 func readTree(base, root string) (map[string]node, error) {
 	tree := make(map[string]node)
 
-	dirInfos, err := ioutil.ReadDir(base)
+	dirEntries, err := os.ReadDir(base)
 	if err != nil {
 		return nil, fmt.Errorf("couldn't read directory entries for %q: %w", base, err)
 	}
 
-	for _, info := range dirInfos {
+	for _, entry := range dirEntries {
 		s := &unix.Stat_t{}
-		if err := unix.Stat(filepath.Join(base, info.Name()), s); err != nil {
-			return nil, fmt.Errorf("can't stat file %q: %w", filepath.Join(base, info.Name()), err)
+		if err := unix.Stat(filepath.Join(base, entry.Name()), s); err != nil {
+			return nil, fmt.Errorf("can't stat file %q: %w", filepath.Join(base, entry.Name()), err)
 		}
-		tree[filepath.Join(root, info.Name())] = node{int(s.Uid), int(s.Gid)}
-		if info.IsDir() {
+		tree[filepath.Join(root, entry.Name())] = node{int(s.Uid), int(s.Gid)}
+		if entry.IsDir() {
 			// read the subdirectory
-			subtree, err := readTree(filepath.Join(base, info.Name()), filepath.Join(root, info.Name()))
+			subtree, err := readTree(filepath.Join(base, entry.Name()), filepath.Join(root, entry.Name()))
 			if err != nil {
 				return nil, err
 			}


### PR DESCRIPTION
This PR replaces all `ioutil.ReadDir` to `os.ReadDir`. `ioutil.ReadDir` has been deprecated in Go 1.16. The new `os.ReadDir` is a more efficient implementation than `ioutil.ReadDir`. 

The full proposal can be read here: https://<!---->github.com<!---->/<!---->golang<!---->/go/issues/41467

Reference: https://pkg.go.dev/io/ioutil#ReadDir