### PR TITLE
Use defined constants for flag names

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -143,26 +143,26 @@ func copyContainer(c *Container) *Container {
 }
 
 func (c *Container) MountLabel() string {
-	if label, ok := c.Flags["MountLabel"].(string); ok {
+	if label, ok := c.Flags[mountLabelFlag].(string); ok {
 		return label
 	}
 	return ""
 }
 
 func (c *Container) ProcessLabel() string {
-	if label, ok := c.Flags["ProcessLabel"].(string); ok {
+	if label, ok := c.Flags[processLabelFlag].(string); ok {
 		return label
 	}
 	return ""
 }
 
 func (c *Container) MountOpts() []string {
-	switch c.Flags["MountOpts"].(type) {
+	switch c.Flags[mountOptsFlag].(type) {
 	case []string:
-		return c.Flags["MountOpts"].([]string)
+		return c.Flags[mountOptsFlag].([]string)
 	case []interface{}:
 		var mountOpts []string
-		for _, v := range c.Flags["MountOpts"].([]interface{}) {
+		for _, v := range c.Flags[mountOptsFlag].([]interface{}) {
 			if flag, ok := v.(string); ok {
 				mountOpts = append(mountOpts, flag)
 			}
@@ -320,10 +320,10 @@ func (r *containerStore) Create(id string, names []string, image, layer, metadat
 		return nil, ErrDuplicateID
 	}
 	if options.MountOpts != nil {
-		options.Flags["MountOpts"] = append([]string{}, options.MountOpts...)
+		options.Flags[mountOptsFlag] = append([]string{}, options.MountOpts...)
 	}
 	if options.Volatile {
-		options.Flags["Volatile"] = true
+		options.Flags[volatileFlag] = true
 	}
 	names = dedupeNames(names)
 	for _, name := range names {

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -48,7 +48,7 @@ type CreateOpts struct {
 	ignoreChownErrors bool
 }
 
-// MountOpts contains optional arguments for LayerStope.Mount() methods.
+// MountOpts contains optional arguments for Driver.Get() methods.
 type MountOpts struct {
 	// Mount label is the MAC Labels to assign to mount point (SELINUX)
 	MountLabel string

--- a/userns.go
+++ b/userns.go
@@ -226,7 +226,7 @@ func (s *store) getAutoUserNS(options *types.AutoUserNsOptions, image *Image) ([
 		return nil, nil, fmt.Errorf("cannot read mappings: %w", err)
 	}
 
-	// Look every container that is using a user namespace and store
+	// Look at every container that is using a user namespace and store
 	// the intervals that are already used.
 	containers, err := s.Containers()
 	if err != nil {

--- a/utils.go
+++ b/utils.go
@@ -16,12 +16,12 @@ func GetRootlessRuntimeDir(rootlessUID int) (string, error) {
 	return types.GetRootlessRuntimeDir(rootlessUID)
 }
 
-// DefaultStoreOptionsAutoDetectUID returns the default storage ops for containers
+// DefaultStoreOptionsAutoDetectUID returns the default storage options for containers
 func DefaultStoreOptionsAutoDetectUID() (types.StoreOptions, error) {
 	return types.DefaultStoreOptionsAutoDetectUID()
 }
 
-// DefaultStoreOptions returns the default storage ops for containers
+// DefaultStoreOptions returns the default storage options for containers
 func DefaultStoreOptions(rootless bool, rootlessUID int) (types.StoreOptions, error) {
 	return types.DefaultStoreOptions(rootless, rootlessUID)
 }


### PR DESCRIPTION
Use constants for the names of flags that we set in `Flags` maps that we store in layer/image/container records, to make it easier to avoid possible breakages due to typos in the future.