### PR TITLE
layers.Wipe(): try to remove layers before their parents

### DIFF
--- a/layers.go
+++ b/layers.go
@@ -1388,6 +1388,9 @@ func (r *layerStore) Wipe() error {
 	for id := range r.byid {
 		ids = append(ids, id)
 	}
+	sort.Slice(ids, func(i, j int) bool {
+		return r.byid[ids[i]].Created.After(r.byid[ids[j]].Created)
+	})
 	for _, id := range ids {
 		if err := r.Delete(id); err != nil {
 			return err


### PR DESCRIPTION
When removing layers, try to remove layers before removing their parents, as the lower-level driver may enforce the dependency beyond what the higher-level logic does or knows.

Do this by sorting by creation time as an attempt at flattening the layer tree into an ordered list.  It won't be correct if a parent layer needed to be recreated, but it's more likely to be correct otherwise.