### PR TITLE
Remove an undocumented assumption that O_RDONLY == 0

### DIFF
--- a/pkg/lockfile/lockfile_unix.go
+++ b/pkg/lockfile/lockfile_unix.go
@@ -71,8 +71,10 @@ func newLastWriterID() []byte {
 // openLock will create the file and its parent directories,
 // if necessary.
 func openLock(path string, ro bool) (fd int, err error) {
-	flags := os.O_RDONLY | unix.O_CLOEXEC | os.O_CREATE
-	if !ro {
+	flags := unix.O_CLOEXEC | os.O_CREATE
+	if ro {
+		flags |= os.O_RDONLY
+	} else {
 		flags |= os.O_RDWR
 	}
 	fd, err = unix.Open(path, flags, 0o644)


### PR DESCRIPTION
There's at least one Go platform where that is not true.

Making that assumption without any warning is just a trap for future readers.

Instead, just do the obviously correct thing, per the API documentation.

On macOS, this compiles to _literally exactly the same binary code_.

So, let the compiler be clever so that we don't have to.