### PR TITLE
Deprecate lockfile.Locker.RecursiveLock (alternative to #1376)

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -617,6 +617,8 @@ func (r *containerStore) Lock() {
 	r.lockfile.Lock()
 }
 
+// Deprecated: This can block indefinitely if the current goroutine owns the lock, and another goroutine is trying to acquire a writer lock.
+// Do not use this.
 func (r *containerStore) RecursiveLock() {
 	r.lockfile.RecursiveLock()
 }

--- a/images.go
+++ b/images.go
@@ -798,6 +798,8 @@ func (r *imageStore) Lock() {
 	r.lockfile.Lock()
 }
 
+// Deprecated: This can block indefinitely if the current goroutine owns the lock, and another goroutine is trying to acquire a writer lock.
+// Do not use this.
 func (r *imageStore) RecursiveLock() {
 	r.lockfile.RecursiveLock()
 }

--- a/layers.go
+++ b/layers.go
@@ -1895,6 +1895,8 @@ func (r *layerStore) Lock() {
 	r.lockfile.Lock()
 }
 
+// Deprecated: This can block indefinitely if the current goroutine owns the lock, and another goroutine is trying to acquire a writer lock.
+// Do not use this.
 func (r *layerStore) RecursiveLock() {
 	r.lockfile.RecursiveLock()
 }

--- a/pkg/lockfile/lockfile.go
+++ b/pkg/lockfile/lockfile.go
@@ -19,6 +19,9 @@ type Locker interface {
 
 	// Acquire a writer lock recursively, allowing for recursive acquisitions
 	// within the same process space.
+	//
+	// Deprecated: This can block indefinitely if the current goroutine owns the lock, and another goroutine is trying to acquire a writer lock.
+	// Do not use this.
 	RecursiveLock()
 
 	// Unlock the lock.

--- a/pkg/lockfile/lockfile_windows.go
+++ b/pkg/lockfile/lockfile_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package lockfile
@@ -36,6 +37,8 @@ func (l *lockfile) Lock() {
 	l.locked = true
 }
 
+// Deprecated: This can block indefinitely if the current goroutine owns the lock, and another goroutine is trying to acquire a writer lock.
+// Do not use this.
 func (l *lockfile) RecursiveLock() {
 	// We don't support Windows but a recursive writer-lock in one process-space
 	// is really a writer lock, so just panic.


### PR DESCRIPTION
It is not valid as currently implemented, and there is no known user.

Cc: @vrothberg : This was added in #347 , supposedly for the concurrent copy detection.