### PR TITLE
Make {container, layer, image} store APIs private

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -66,12 +66,12 @@ type Container struct {
 	Flags map[string]interface{} `json:"flags,omitempty"`
 }
 
-// ContainerStore provides bookkeeping for information about Containers.
-type ContainerStore interface {
-	FileBasedStore
-	MetadataStore
-	ContainerBigDataStore
-	FlaggableStore
+// rwContainerStore provides bookkeeping for information about Containers.
+type rwContainerStore interface {
+	fileBasedStore
+	metadataStore
+	containerBigDataStore
+	flaggableStore
 
 	// Create creates a container that has a specified ID (or generates a
 	// random one if an empty value is supplied) and optional names,
@@ -249,7 +249,7 @@ func (r *containerStore) Save() error {
 	return r.Touch()
 }
 
-func newContainerStore(dir string) (ContainerStore, error) {
+func newContainerStore(dir string) (rwContainerStore, error) {
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return nil, err
 	}

--- a/deprecated.go
+++ b/deprecated.go
@@ -1,0 +1,216 @@
+package storage
+
+import (
+	"io"
+	"time"
+
+	drivers "github.com/containers/storage/drivers"
+	"github.com/containers/storage/pkg/archive"
+	digest "github.com/opencontainers/go-digest"
+)
+
+// The type definitions in this file exist ONLY to maintain formal API compatibility.
+// DO NOT ADD ANY NEW METHODS TO THESE INTERFACES.
+
+// ROFileBasedStore is a deprecated interface with no documented way to use it from callers outside of c/storage.
+//
+// Deprecated: There is no way to use this from any external user of c/storage to invoke c/storage functionality.
+type ROFileBasedStore interface {
+	Locker
+	Load() error
+	ReloadIfChanged() error
+}
+
+// RWFileBasedStore is a deprecated interface with no documented way to use it from callers outside of c/storage.
+//
+// Deprecated: There is no way to use this from any external user of c/storage to invoke c/storage functionality.
+type RWFileBasedStore interface {
+	Save() error
+}
+
+// FileBasedStore is a deprecated interface with no documented way to use it from callers outside of c/storage.
+//
+// Deprecated: There is no way to use this from any external user of c/storage to invoke c/storage functionality.
+type FileBasedStore interface {
+	ROFileBasedStore
+	RWFileBasedStore
+}
+
+// ROMetadataStore is a deprecated interface with no documented way to use it from callers outside of c/storage.
+//
+// Deprecated: There is no way to use this from any external user of c/storage to invoke c/storage functionality.
+type ROMetadataStore interface {
+	Metadata(id string) (string, error)
+}
+
+// RWMetadataStore is a deprecated interface with no documented way to use it from callers outside of c/storage.
+//
+// Deprecated: There is no way to use this from any external user of c/storage to invoke c/storage functionality.
+type RWMetadataStore interface {
+	SetMetadata(id, metadata string) error
+}
+
+// MetadataStore is a deprecated interface with no documented way to use it from callers outside of c/storage.
+//
+// Deprecated: There is no way to use this from any external user of c/storage to invoke c/storage functionality.
+type MetadataStore interface {
+	ROMetadataStore
+	RWMetadataStore
+}
+
+// ROBigDataStore is a deprecated interface with no documented way to use it from callers outside of c/storage.
+//
+// Deprecated: There is no way to use this from any external user of c/storage to invoke c/storage functionality.
+type ROBigDataStore interface {
+	BigData(id, key string) ([]byte, error)
+	BigDataSize(id, key string) (int64, error)
+	BigDataDigest(id, key string) (digest.Digest, error)
+	BigDataNames(id string) ([]string, error)
+}
+
+// RWImageBigDataStore is a deprecated interface with no documented way to use it from callers outside of c/storage.
+//
+// Deprecated: There is no way to use this from any external user of c/storage to invoke c/storage functionality.
+type RWImageBigDataStore interface {
+	SetBigData(id, key string, data []byte, digestManifest func([]byte) (digest.Digest, error)) error
+}
+
+// ContainerBigDataStore is a deprecated interface with no documented way to use it from callers outside of c/storage.
+//
+// Deprecated: There is no way to use this from any external user of c/storage to invoke c/storage functionality.
+type ContainerBigDataStore interface {
+	ROBigDataStore
+	SetBigData(id, key string, data []byte) error
+}
+
+// ROLayerBigDataStore is a deprecated interface with no documented way to use it from callers outside of c/storage.
+//
+// Deprecated: There is no way to use this from any external user of c/storage to invoke c/storage functionality.
+type ROLayerBigDataStore interface {
+	BigData(id, key string) (io.ReadCloser, error)
+	BigDataNames(id string) ([]string, error)
+}
+
+// RWLayerBigDataStore is a deprecated interface with no documented way to use it from callers outside of c/storage.
+//
+// Deprecated: There is no way to use this from any external user of c/storage to invoke c/storage functionality.
+type RWLayerBigDataStore interface {
+	SetBigData(id, key string, data io.Reader) error
+}
+
+// LayerBigDataStore is a deprecated interface with no documented way to use it from callers outside of c/storage.
+//
+// Deprecated: There is no way to use this from any external user of c/storage to invoke c/storage functionality.
+type LayerBigDataStore interface {
+	ROLayerBigDataStore
+	RWLayerBigDataStore
+}
+
+// FlaggableStore is a deprecated interface with no documented way to use it from callers outside of c/storage.
+//
+// Deprecated: There is no way to use this from any external user of c/storage to invoke c/storage functionality.
+type FlaggableStore interface {
+	ClearFlag(id string, flag string) error
+	SetFlag(id string, flag string, value interface{}) error
+}
+
+// ContainerStore is a deprecated interface with no documented way to use it from callers outside of c/storage.
+//
+// Deprecated: There is no way to use this from any external user of c/storage to invoke c/storage functionality.
+type ContainerStore interface {
+	FileBasedStore
+	MetadataStore
+	ContainerBigDataStore
+	FlaggableStore
+	Create(id string, names []string, image, layer, metadata string, options *ContainerOptions) (*Container, error)
+	SetNames(id string, names []string) error
+	AddNames(id string, names []string) error
+	RemoveNames(id string, names []string) error
+	Get(id string) (*Container, error)
+	Exists(id string) bool
+	Delete(id string) error
+	Wipe() error
+	Lookup(name string) (string, error)
+	Containers() ([]Container, error)
+}
+
+// ROImageStore is a deprecated interface with no documented way to use it from callers outside of c/storage.
+//
+// Deprecated: There is no way to use this from any external user of c/storage to invoke c/storage functionality.
+type ROImageStore interface {
+	ROFileBasedStore
+	ROMetadataStore
+	ROBigDataStore
+	Exists(id string) bool
+	Get(id string) (*Image, error)
+	Lookup(name string) (string, error)
+	Images() ([]Image, error)
+	ByDigest(d digest.Digest) ([]*Image, error)
+}
+
+// ImageStore is a deprecated interface with no documented way to use it from callers outside of c/storage.
+//
+// Deprecated: There is no way to use this from any external user of c/storage to invoke c/storage functionality.
+type ImageStore interface {
+	ROImageStore
+	RWFileBasedStore
+	RWMetadataStore
+	RWImageBigDataStore
+	FlaggableStore
+	Create(id string, names []string, layer, metadata string, created time.Time, searchableDigest digest.Digest) (*Image, error)
+	SetNames(id string, names []string) error
+	AddNames(id string, names []string) error
+	RemoveNames(id string, names []string) error
+	Delete(id string) error
+	Wipe() error
+}
+
+// ROLayerStore is a deprecated interface with no documented way to use it from callers outside of c/storage.
+//
+// Deprecated: There is no way to use this from any external user of c/storage to invoke c/storage functionality.
+type ROLayerStore interface {
+	ROFileBasedStore
+	ROMetadataStore
+	ROLayerBigDataStore
+	Exists(id string) bool
+	Get(id string) (*Layer, error)
+	Status() ([][2]string, error)
+	Changes(from, to string) ([]archive.Change, error)
+	Diff(from, to string, options *DiffOptions) (io.ReadCloser, error)
+	DiffSize(from, to string) (int64, error)
+	Size(name string) (int64, error)
+	Lookup(name string) (string, error)
+	LayersByCompressedDigest(d digest.Digest) ([]Layer, error)
+	LayersByUncompressedDigest(d digest.Digest) ([]Layer, error)
+	Layers() ([]Layer, error)
+}
+
+// LayerStore is a deprecated interface with no documented way to use it from callers outside of c/storage.
+//
+// Deprecated: There is no way to use this from any external user of c/storage to invoke c/storage functionality.
+type LayerStore interface {
+	ROLayerStore
+	RWFileBasedStore
+	RWMetadataStore
+	FlaggableStore
+	RWLayerBigDataStore
+	Create(id string, parent *Layer, names []string, mountLabel string, options map[string]string, moreOptions *LayerOptions, writeable bool) (*Layer, error)
+	CreateWithFlags(id string, parent *Layer, names []string, mountLabel string, options map[string]string, moreOptions *LayerOptions, writeable bool, flags map[string]interface{}) (layer *Layer, err error)
+	Put(id string, parent *Layer, names []string, mountLabel string, options map[string]string, moreOptions *LayerOptions, writeable bool, flags map[string]interface{}, diff io.Reader) (*Layer, int64, error)
+	SetNames(id string, names []string) error
+	AddNames(id string, names []string) error
+	RemoveNames(id string, names []string) error
+	Delete(id string) error
+	Wipe() error
+	Mount(id string, options drivers.MountOpts) (string, error)
+	Unmount(id string, force bool) (bool, error)
+	Mounted(id string) (int, error)
+	ParentOwners(id string) (uids, gids []int, err error)
+	ApplyDiff(to string, diff io.Reader) (int64, error)
+	ApplyDiffWithDiffer(to string, options *drivers.ApplyDiffOpts, differ drivers.Differ) (*drivers.DriverWithDifferOutput, error)
+	CleanupStagingDirectory(stagingDirectory string) error
+	ApplyDiffFromStagingDirectory(id, stagingDirectory string, diffOutput *drivers.DriverWithDifferOutput, options *drivers.ApplyDiffOpts) error
+	DifferTarget(id string) (string, error)
+	LoadLocked() error
+	PutAdditionalLayer(id string, parentLayer *Layer, names []string, aLayer drivers.AdditionalLayer) (layer *Layer, err error)
+}

--- a/images.go
+++ b/images.go
@@ -106,10 +106,6 @@ type roImageStore interface {
 	// Get retrieves information about an image given an ID or name.
 	Get(id string) (*Image, error)
 
-	// Lookup attempts to translate a name to an ID.  Most methods do this
-	// implicitly.
-	Lookup(name string) (string, error)
-
 	// Images returns a slice enumerating the known images.
 	Images() ([]Image, error)
 
@@ -612,13 +608,6 @@ func (r *imageStore) Get(id string) (*Image, error) {
 		return copyImage(image), nil
 	}
 	return nil, fmt.Errorf("locating image with ID %q: %w", id, ErrImageUnknown)
-}
-
-func (r *imageStore) Lookup(name string) (id string, err error) {
-	if image, ok := r.lookup(name); ok {
-		return image.ID, nil
-	}
-	return "", fmt.Errorf("locating image with ID %q: %w", id, ErrImageUnknown)
 }
 
 func (r *imageStore) Exists(id string) bool {

--- a/images.go
+++ b/images.go
@@ -94,11 +94,11 @@ type Image struct {
 	Flags map[string]interface{} `json:"flags,omitempty"`
 }
 
-// ROImageStore provides bookkeeping for information about Images.
-type ROImageStore interface {
-	ROFileBasedStore
-	ROMetadataStore
-	ROBigDataStore
+// roImageStore provides bookkeeping for information about Images.
+type roImageStore interface {
+	roFileBasedStore
+	roMetadataStore
+	roBigDataStore
 
 	// Exists checks if there is an image with the given ID or name.
 	Exists(id string) bool
@@ -120,13 +120,13 @@ type ROImageStore interface {
 	ByDigest(d digest.Digest) ([]*Image, error)
 }
 
-// ImageStore provides bookkeeping for information about Images.
-type ImageStore interface {
-	ROImageStore
-	RWFileBasedStore
-	RWMetadataStore
-	RWImageBigDataStore
-	FlaggableStore
+// rwImageStore provides bookkeeping for information about Images.
+type rwImageStore interface {
+	roImageStore
+	rwFileBasedStore
+	rwMetadataStore
+	rwImageBigDataStore
+	flaggableStore
 
 	// Create creates an image that has a specified ID (or a random one) and
 	// optional names, using the specified layer as its topmost (hopefully
@@ -330,7 +330,7 @@ func (r *imageStore) Save() error {
 	return r.Touch()
 }
 
-func newImageStore(dir string) (ImageStore, error) {
+func newImageStore(dir string) (rwImageStore, error) {
 	if err := os.MkdirAll(dir, 0700); err != nil {
 		return nil, err
 	}
@@ -354,7 +354,7 @@ func newImageStore(dir string) (ImageStore, error) {
 	return &istore, nil
 }
 
-func newROImageStore(dir string) (ROImageStore, error) {
+func newROImageStore(dir string) (roImageStore, error) {
 	lockfile, err := GetROLockfile(filepath.Join(dir, "images.lock"))
 	if err != nil {
 		return nil, err

--- a/images_test.go
+++ b/images_test.go
@@ -8,14 +8,14 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func newTestImageStore(t *testing.T) ImageStore {
+func newTestImageStore(t *testing.T) rwImageStore {
 	t.Helper()
 	store, err := newImageStore(t.TempDir())
 	require.Nil(t, err)
 	return store
 }
 
-func addTestImage(t *testing.T, store ImageStore, id string, names []string) {
+func addTestImage(t *testing.T, store rwImageStore, id string, names []string) {
 	store.Lock()
 	defer store.Unlock()
 

--- a/layers.go
+++ b/layers.go
@@ -266,10 +266,6 @@ type rwLayerStore interface {
 	// DifferTarget gets the location where files are stored for the layer.
 	DifferTarget(id string) (string, error)
 
-	// LoadLocked wraps Load in a locked state. This means it loads the store
-	// and cleans-up invalid layers if needed.
-	LoadLocked() error
-
 	// PutAdditionalLayer creates a layer using the diff contained in the additional layer
 	// store.
 	// This API is experimental and can be changed without bumping the major version number.
@@ -427,12 +423,6 @@ func (r *layerStore) Load() error {
 	}
 
 	return err
-}
-
-func (r *layerStore) LoadLocked() error {
-	r.lockfile.Lock()
-	defer r.lockfile.Unlock()
-	return r.Load()
 }
 
 func (r *layerStore) loadMounts() error {

--- a/layers.go
+++ b/layers.go
@@ -177,10 +177,6 @@ type roLayerStore interface {
 	// found, it returns an error.
 	Size(name string) (int64, error)
 
-	// Lookup attempts to translate a name to an ID.  Most methods do this
-	// implicitly.
-	Lookup(name string) (string, error)
-
 	// LayersByCompressedDigest returns a slice of the layers with the
 	// specified compressed digest value recorded for them.
 	LayersByCompressedDigest(d digest.Digest) ([]Layer, error)
@@ -1373,13 +1369,6 @@ func (r *layerStore) Delete(id string) error {
 		return err
 	}
 	return r.Save()
-}
-
-func (r *layerStore) Lookup(name string) (id string, err error) {
-	if layer, ok := r.lookup(name); ok {
-		return layer.ID, nil
-	}
-	return "", ErrLayerUnknown
 }
 
 func (r *layerStore) Exists(id string) bool {

--- a/layers.go
+++ b/layers.go
@@ -137,13 +137,13 @@ type DiffOptions struct {
 	Compression *archive.Compression
 }
 
-// ROLayerStore wraps a graph driver, adding the ability to refer to layers by
+// roLayerStore wraps a graph driver, adding the ability to refer to layers by
 // name, and keeping track of parent-child relationships, along with a list of
 // all known layers.
-type ROLayerStore interface {
-	ROFileBasedStore
-	ROMetadataStore
-	ROLayerBigDataStore
+type roLayerStore interface {
+	roFileBasedStore
+	roMetadataStore
+	roLayerBigDataStore
 
 	// Exists checks if a layer with the specified name or ID is known.
 	Exists(id string) bool
@@ -193,15 +193,15 @@ type ROLayerStore interface {
 	Layers() ([]Layer, error)
 }
 
-// LayerStore wraps a graph driver, adding the ability to refer to layers by
+// rwLayerStore wraps a graph driver, adding the ability to refer to layers by
 // name, and keeping track of parent-child relationships, along with a list of
 // all known layers.
-type LayerStore interface {
-	ROLayerStore
-	RWFileBasedStore
-	RWMetadataStore
-	FlaggableStore
-	RWLayerBigDataStore
+type rwLayerStore interface {
+	roLayerStore
+	rwFileBasedStore
+	rwMetadataStore
+	flaggableStore
+	rwLayerBigDataStore
 
 	// Create creates a new layer, optionally giving it a specified ID rather than
 	// a randomly-generated one, either inheriting data from another specified
@@ -540,7 +540,7 @@ func (r *layerStore) saveMounts() error {
 	return r.loadMounts()
 }
 
-func (s *store) newLayerStore(rundir string, layerdir string, driver drivers.Driver) (LayerStore, error) {
+func (s *store) newLayerStore(rundir string, layerdir string, driver drivers.Driver) (rwLayerStore, error) {
 	if err := os.MkdirAll(rundir, 0700); err != nil {
 		return nil, err
 	}
@@ -575,7 +575,7 @@ func (s *store) newLayerStore(rundir string, layerdir string, driver drivers.Dri
 	return &rlstore, nil
 }
 
-func newROLayerStore(rundir string, layerdir string, driver drivers.Driver) (ROLayerStore, error) {
+func newROLayerStore(rundir string, layerdir string, driver drivers.Driver) (roLayerStore, error) {
 	lockfile, err := GetROLockfile(filepath.Join(layerdir, "layers.lock"))
 	if err != nil {
 		return nil, err

--- a/userns.go
+++ b/userns.go
@@ -163,7 +163,7 @@ outer:
 		return 0, fmt.Errorf("cannot find layer %q", layerName)
 	}
 
-	rlstore, err := s.LayerStore()
+	rlstore, err := s.getLayerStore()
 	if err != nil {
 		return 0, err
 	}

--- a/userns.go
+++ b/userns.go
@@ -125,11 +125,7 @@ func parseMountedFiles(containerMount, passwdFile, groupFile string) uint32 {
 // getMaxSizeFromImage returns the maximum ID used by the specified image.
 // The layer stores must be already locked.
 func (s *store) getMaxSizeFromImage(image *Image, passwdFile, groupFile string) (_ uint32, retErr error) {
-	lstore, err := s.LayerStore()
-	if err != nil {
-		return 0, err
-	}
-	lstores, err := s.ROLayerStores()
+	layerStores, err := s.allLayerStores()
 	if err != nil {
 		return 0, err
 	}
@@ -140,7 +136,7 @@ func (s *store) getMaxSizeFromImage(image *Image, passwdFile, groupFile string) 
 	layerName := image.TopLayer
 outer:
 	for {
-		for _, ls := range append([]ROLayerStore{lstore}, lstores...) {
+		for _, ls := range layerStores {
 			layer, err := ls.Get(layerName)
 			if err != nil {
 				continue


### PR DESCRIPTION
c/storage currently exports `ContainerStore`,`ImageStore`,`LayerStore`, and several component interfaces, publicly.

Meanwhile there are no _public_ ways to obtain implementations of these interfaces (and no non-public callers in Podman or CRI-O that I can find); and the public interfaces at least _look_ like an impediment to changing the C/I/L store interfaces (e.g. to change locking).

To clarify that, make the used C/I/L store implementations private (and keep the public interfaces in `deprecated.go` purely for formal API compatibility).

Then, as a proof of concept, remove unused <s>`RecursiveLock` (compare #1344),</s> `LoadLocked`, and `Lookup` methods.

@nalind RFC. I might well be missing something about external users of these interfaces.
Cc: @vrothberg for the `RecursiveLock` method removal, along with #1344.

See individual commit messages for details.