### PR TITLE
In-process exclusion of readers and writers

### DIFF
--- a/images.go
+++ b/images.go
@@ -261,56 +261,80 @@ func (r *imageStore) startReadingWithReload(canReload bool) error {
 			unlockFn()
 		}
 	}()
+	r.inProcessLock.RLock()
+	unlockFn = r.stopReading
 
 	if canReload {
-		var tryLockedForWriting bool
-		if err := inProcessLocked(func() error {
-			var err error
-			tryLockedForWriting, err = r.reloadIfChanged(false)
+		// If we are lucky, we can just hold the read locks, check that we are fresh, and continue.
+		_, modified, err := r.modified()
+		if err != nil {
 			return err
-		}); err != nil {
-			if !tryLockedForWriting {
-				return err
-			}
-			unlockFn()
-			unlockFn = nil
-
-			r.lockfile.Lock()
+		}
+		if modified {
+			// We are unlucky, and need to reload.
+			// NOTE: Multiple goroutines can get to this place approximately simultaneously.
+			r.inProcessLock.RUnlock()
 			unlockFn = r.lockfile.Unlock
+
+			// r.lastWrite can change at this point if another goroutine reloads the store before us. That’s why we don’t unconditionally
+			// trigger a load below; we (lock and) reloadIfChanged() again.
+
+			// First try reloading with r.lockfile held for reading.
+			// r.inProcessLock will serialize all goroutines that got here;
+			// each will re-check on-disk state vs. r.lastWrite, and the first one will actually reload the data.
+			var tryLockedForWriting bool
 			if err := inProcessLocked(func() error {
-				_, err := r.reloadIfChanged(true)
+				// We could optimize this further: The r.lockfile.GetLastWrite() value shouldn’t change as long as we hold r.lockfile,
+				// so if r.lastWrite was already updated, we don’t need to actually read the on-filesystem lock.
+				var err error
+				tryLockedForWriting, err = r.reloadIfChanged(false)
 				return err
 			}); err != nil {
-				return err
-			}
-			unlockFn()
-			unlockFn = nil
+				if !tryLockedForWriting {
+					return err
+				}
+				// Not good enough, we need r.lockfile held for writing. So, let’s do that.
+				unlockFn()
+				unlockFn = nil
 
-			r.lockfile.RLock()
-			unlockFn = r.lockfile.Unlock
-			// We need to check for a reload reload once more because the on-disk state could have been modified
-			// after we released the lock.
-			// If that, _again_, finds inconsistent state, just give up.
-			// We could, plausibly, retry a few times, but that inconsistent state (duplicate image names)
-			// shouldn’t be saved (by correct implementations) in the first place.
-			if err := inProcessLocked(func() error {
-				_, err := r.reloadIfChanged(false)
-				return err
-			}); err != nil {
-				return fmt.Errorf("(even after successfully cleaning up once:) %w", err)
+				r.lockfile.Lock()
+				unlockFn = r.lockfile.Unlock
+				if err := inProcessLocked(func() error {
+					_, err := r.reloadIfChanged(true)
+					return err
+				}); err != nil {
+					return err
+				}
+				unlockFn()
+				unlockFn = nil
+
+				r.lockfile.RLock()
+				unlockFn = r.lockfile.Unlock
+				// We need to check for a reload once more because the on-disk state could have been modified
+				// after we released the lock.
+				// If that, _again_, finds inconsistent state, just give up.
+				// We could, plausibly, retry a few times, but that inconsistent state (duplicate image names)
+				// shouldn’t be saved (by correct implementations) in the first place.
+				if err := inProcessLocked(func() error {
+					_, err := r.reloadIfChanged(false)
+					return err
+				}); err != nil {
+					return fmt.Errorf("(even after successfully cleaning up once:) %w", err)
+				}
 			}
+
+			// NOTE that we hold neither a read nor write inProcessLock at this point. That’s fine in ordinary operation, because
+			// the on-filesystem r.lockfile should protect us against (cooperating) writers, and any use of r.inProcessLock
+			// protects us against in-process writers modifying data.
+			// In presence of non-cooperating writers, we just ensure that 1) the in-memory data is not clearly out-of-date
+			// and 2) access to the in-memory data is not racy;
+			// but we can’t protect against those out-of-process writers modifying _files_ while we are assuming they are in a consistent state.
+
+			r.inProcessLock.RLock()
 		}
 	}
 
-	// NOTE that we hold neither a read nor write inProcessLock at this point. That’s fine in ordinary operation, because
-	// the on-filesystem r.lockfile should protect us against (cooperating) writers, and any use of r.inProcessLock
-	// protects us against in-process writers modifying data.
-	// In presence of non-cooperating writers, we just ensure that 1) the in-memory data is not clearly out-of-date
-	// and 2) access to the in-memory data is not racy;
-	// but we can’t protect against those out-of-process writers modifying _files_ while we are assuming they are in a consistent state.
-
 	unlockFn = nil
-	r.inProcessLock.RLock()
 	return nil
 }
 
@@ -326,6 +350,15 @@ func (r *imageStore) stopReading() {
 	r.lockfile.Unlock()
 }
 
+// modified returns true if the on-disk state has changed (i.e. if reloadIfChanged may need to modify the store),
+// and a lockfile.LastWrite value for that update.
+//
+// The caller must hold r.lockfile for reading _or_ writing.
+// The caller must hold r.inProcessLock for reading or writing.
+func (r *imageStore) modified() (lockfile.LastWrite, bool, error) {
+	return r.lockfile.ModifiedSince(r.lastWrite)
+}
+
 // reloadIfChanged reloads the contents of the store from disk if it is changed.
 //
 // The caller must hold r.lockfile for reading _or_ writing; lockedForWriting is true
@@ -336,7 +369,7 @@ func (r *imageStore) stopReading() {
 // If !lockedForWriting and this function fails, the return value indicates whether
 // reloadIfChanged() with lockedForWriting could succeed.
 func (r *imageStore) reloadIfChanged(lockedForWriting bool) (bool, error) {
-	lastWrite, modified, err := r.lockfile.ModifiedSince(r.lastWrite)
+	lastWrite, modified, err := r.modified()
 	if err != nil {
 		return false, err
 	}

--- a/store.go
+++ b/store.go
@@ -272,6 +272,10 @@ type Store interface {
 	Unmount(id string, force bool) (bool, error)
 
 	// Mounted returns number of times the layer has been mounted.
+	//
+	// WARNING: This value might already be obsolete by the time it is returned;
+	// In situations where concurrent mount/unmount attempts can happen, this field
+	// should not be used for any decisions, maybe apart from heuristic user warnings.
 	Mounted(id string) (int, error)
 
 	// Changes returns a summary of the changes which would need to be made

--- a/userns.go
+++ b/userns.go
@@ -197,7 +197,7 @@ outer:
 		return 0, err
 	}
 	defer func() {
-		if _, err2 := rlstore.Unmount(clayer.ID, true); err2 != nil {
+		if _, err2 := rlstore.unmount(clayer.ID, true, false); err2 != nil {
 			if retErr == nil {
 				retErr = fmt.Errorf("unmounting temporary layer %#v: %w", clayer.ID, err2)
 			} else {


### PR DESCRIPTION
**EDIT: See the description in https://github.com/containers/storage/pull/1346#issuecomment-1314316901 instead.**

To see what fixing #1332 would be like. This is on top of, and includes, #1345.

The goal is to protect in-process readers against concurrent writes to memory by `Load`. Let’s discuss the theory of that, and the performance, in #1332 , this is an attempt to draft what that could look like.

(Most of this PR could be merged, and might be useful, without actually changing the locking scheme — but without changing the locking scheme I don’t think we have a reason to do and review all of those code changes).

Right now, locking is open-coded all over the >3000 lines of `storage.store`:
```go
func (s *store) ListLayerBigData(id string) ([]string, error) {
        lstore, err := s.LayerStore()
        if err != nil {
                return nil, err
        }
        lstores, err := s.ROLayerStores()
        if err != nil {
                return nil, err
        }
        foundLayer := false
        for _, s := range append([]ROLayerStore{lstore}, lstores...) {
                store := s
                store.RLock()
                defer store.Unlock()
                if err := store.ReloadIfChanged(); err != nil {
                        return nil, err
                }
                data, err := store.BigDataNames(id)
                if err == nil {
                        return data, nil
                }
                if store.Exists(id) {
                        foundLayer = true
                }
        }
        if foundLayer {
                return nil, fmt.Errorf("locating big data for layer with ID %q: %w", id, os.ErrNotExist)
        }
        return nil, fmt.Errorf("locating layer with ID %q: %w", id, ErrLayerUnknown)
}
```
and adding _extra_ code to each of these sites to deal with the in-process lock would be a tedious nightmare with too many opportunities to overlook something..

So, this PR proposes consolidating almost all of these repeated snippets into helpers that call closures: `layerReadAccess` and `layerWriteAccess` at the level of a `layerStore`, and even higher-level (especially for reads) `store.writeToLayerStore` and `readAllLayerStores[T](*store)`.

The same function can now be:
```go
func (s *store) ListLayerBigData(id string) ([]string, error) {
	foundLayer := false
	if data, err, done := readAllLayerStores(s, func(store roLayerStore, token layerReadToken) ([]string, error, bool) {
		data, err := store.bigDataNames(token, id)
		if err == nil {
			return data, nil, true
		}
		if store.exists(token, id) {
			foundLayer = true
		}
		return nil, nil, false
	}); done {
		return data, err
	}
	if foundLayer {
		return nil, fmt.Errorf("locating big data for layer with ID %q: %w", id, os.ErrNotExist)
	}
	return nil, fmt.Errorf("locating layer with ID %q: %w", id, ErrLayerUnknown)
}
```
which is < 2/3 of the original size.

At least for the read side, it seems to me that any variant without Go 1.18 generics would need 2 or 3 more tedious lines at every call site. That’s not a show-stopper, but let’s discuss whether we can do it this way. (A notable downside is that the Go 1.18 requirement might not allow us to backport the locking changes to any earlier version … but then with the size of the locking changes, more than almost all of `store.go`, we might not want to do that anyway?)

After having the closures, we can now quite cheaply add `layerReadToken` and `layerWriteToken` types that serve as markers that the layer store’s methods are called with the correct lock held. That’s not nearly as good as a safe language-level support (making the lock-protected fields outright unreachable without holding a lock), but it’s _something_.

---

This does not actually show handling of the harder cases, like `CreateContainer`, where we might need to lock several stores, and the like. I’m confident that can be done — we can always do locking manually instead of through the closures; but I didn’t want to spend time on this without having basic consensus on the approach at all.

Also, there seem to be _quite a few_ opportunities for small-scale optimization, typically to check for `ErrLayerUnknown` from a call instead of calling `Exists` before/after the main query. After a few false starts, this PR tries _very hard_ not to touch that logic, because that would ballon the scope of this work to a completely unmanageable and impossible to review size.

---

See the individual commit messages for details.

I’d _very much_ appreciate
- opinions on whether this style is reasonable and acceptable overall
- any suggestions to make the code cleaner. (I never thought I’d say this but I found myself thinking that this would probably be significantly easier to do, _and_ even easier to prove correct, in C++, due to tuples, variadic templates and `const`.) 
