### PR TITLE
tests/tools/Makefile: we don't use ffjson any more

### DIFF
--- a/tests/tools/Makefile
+++ b/tests/tools/Makefile
@@ -23,13 +23,9 @@ clean:
 	rm -rf $(BUILDDIR)
 
 $(BUILDDIR): \
-	$(BUILDDIR)/ffjson \
 	$(BUILDDIR)/git-validation \
 	$(BUILDDIR)/go-md2man \
 	$(BUILDDIR)/golangci-lint
-
-$(BUILDDIR)/ffjson:
-	$(call go-build,./vendor/github.com/pquerna/ffjson)
 
 $(BUILDDIR)/git-validation:
 	$(call go-build,./vendor/github.com/vbatts/git-validation)


### PR DESCRIPTION
We don't use ffjson any more, so don't try to build it.