### PR TITLE
tests/idmaps.bats: only test .imagestore on overlay and vfs

### DIFF
--- a/tests/idmaps.bats
+++ b/tests/idmaps.bats
@@ -965,10 +965,10 @@ load helpers
 
 @test "idmaps-create-layer-from-another-image-store" {
 	case "$STORAGE_DRIVER" in
-	btrfs|devicemapper|overlay*|vfs|zfs)
+	overlay*|vfs)
 		;;
 	*)
-		skip "not supported by driver $STORAGE_DRIVER"
+		skip ".imagestore option not supported by driver ${STORAGE_DRIVER}"
 		;;
 	esac
 	case "$STORAGE_OPTION" in


### PR DESCRIPTION
Don't try to test with a .imagestore option on btrfs, devicemapper, or zfs.