### PR TITLE
Fix accessing to layer without lock

### DIFF
--- a/layers.go
+++ b/layers.go
@@ -563,6 +563,8 @@ func (s *store) newLayerStore(rundir string, layerdir string, driver drivers.Dri
 		uidMap:         copyIDMap(s.uidMap),
 		gidMap:         copyIDMap(s.gidMap),
 	}
+	rlstore.Lock()
+	defer rlstore.Unlock()
 	if err := rlstore.Load(); err != nil {
 		return nil, err
 	}
@@ -584,6 +586,8 @@ func newROLayerStore(rundir string, layerdir string, driver drivers.Driver) (ROL
 		bymount:        make(map[string]*Layer),
 		byname:         make(map[string]*Layer),
 	}
+	rlstore.RLock()
+	defer rlstore.Unlock()
 	if err := rlstore.Load(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
There was a possibility to panic due to such behavior: attempted to update last-writer in lockfile without the write lock

Fixes: https://github.com/containers/storage/issues/1324

Signed-off-by: Mikhail Khachayants <tyler92@inbox.ru>