### PR TITLE
Fix LUtimesNano on FreeBSD

### DIFF
--- a/pkg/system/meminfo_unix_test.go
+++ b/pkg/system/meminfo_unix_test.go
@@ -1,4 +1,5 @@
-// +build linux freebsd
+//go:build linux
+// +build linux
 
 package system
 

--- a/pkg/system/stat_freebsd_test.go
+++ b/pkg/system/stat_freebsd_test.go
@@ -1,0 +1,19 @@
+//go:build freebsd
+// +build freebsd
+
+package system
+
+import (
+	"syscall"
+	"testing"
+)
+
+// TestFromStatT tests fromStatT for a tempfile
+func platformTestFromStatT(t *testing.T, stat *syscall.Stat_t, s *StatT) {
+	if stat.Mode != uint16(s.Mode()) {
+		t.Fatal("got invalid mode")
+	}
+	if stat.Mtimespec != s.Mtim() {
+		t.Fatal("got invalid mtim")
+	}
+}

--- a/pkg/system/stat_linux_test.go
+++ b/pkg/system/stat_linux_test.go
@@ -1,0 +1,19 @@
+//go:build linux
+// +build linux
+
+package system
+
+import (
+	"syscall"
+	"testing"
+)
+
+// TestFromStatT tests fromStatT for a tempfile
+func platformTestFromStatT(t *testing.T, stat *syscall.Stat_t, s *StatT) {
+	if stat.Mode != s.Mode() {
+		t.Fatal("got invalid mode")
+	}
+	if stat.Mtim != s.Mtim() {
+		t.Fatal("got invalid mtim")
+	}
+}

--- a/pkg/system/stat_unix_test.go
+++ b/pkg/system/stat_unix_test.go
@@ -22,9 +22,6 @@ func TestFromStatT(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	if stat.Mode != s.Mode() {
-		t.Fatal("got invalid mode")
-	}
 	if stat.Uid != s.UID() {
 		t.Fatal("got invalid uid")
 	}
@@ -34,7 +31,7 @@ func TestFromStatT(t *testing.T) {
 	if stat.Rdev != s.Rdev() {
 		t.Fatal("got invalid rdev")
 	}
-	if stat.Mtim != s.Mtim() {
-		t.Fatal("got invalid mtim")
-	}
+	// Types for Mode can vary and not all platforms have an Mtim
+	// member in Stat_t
+	platformTestFromStatT(t, stat, s)
 }

--- a/pkg/system/utimes_freebsd.go
+++ b/pkg/system/utimes_freebsd.go
@@ -10,13 +10,14 @@ import (
 // LUtimesNano is used to change access and modification time of the specified path.
 // It's used for symbol link file because unix.UtimesNano doesn't support a NOFOLLOW flag atm.
 func LUtimesNano(path string, ts []syscall.Timespec) error {
+	atFdCwd := unix.AT_FDCWD
+
 	var _path *byte
 	_path, err := unix.BytePtrFromString(path)
 	if err != nil {
 		return err
 	}
-
-	if _, _, err := unix.Syscall(unix.SYS_LUTIMES, uintptr(unsafe.Pointer(_path)), uintptr(unsafe.Pointer(&ts[0])), 0); err != 0 && err != unix.ENOSYS {
+	if _, _, err := unix.Syscall6(unix.SYS_UTIMENSAT, uintptr(atFdCwd), uintptr(unsafe.Pointer(_path)), uintptr(unsafe.Pointer(&ts[0])), unix.AT_SYMLINK_NOFOLLOW, 0, 0); err != 0 && err != unix.ENOSYS {
 		return err
 	}
 


### PR DESCRIPTION
The code was passing timespec arguments to lutimes which expects timeval arguments. This likely only ever 'worked' because the nanoseconds field is nearly always zero.

Signed-off-by: Doug Rabson <dfr@rabson.org>