### PR TITLE
pkg/system: Allow EnsureRemoveAll to delete trees with immutable files

### DIFF
--- a/pkg/system/rm.go
+++ b/pkg/system/rm.go
@@ -35,6 +35,9 @@ func EnsureRemoveAll(dir string) error {
 	}
 
 	for {
+		if err := resetFileFlags(dir); err != nil {
+			return fmt.Errorf("resetting file flags: %w", err)
+		}
 		err := os.RemoveAll(dir)
 		if err == nil {
 			return nil

--- a/pkg/system/rm_common.go
+++ b/pkg/system/rm_common.go
@@ -1,0 +1,10 @@
+//go:build !freebsd
+// +build !freebsd
+
+package system
+
+// Reset file flags in a directory tree. This allows EnsureRemoveAll
+// to delete trees which have the immutable flag set.
+func resetFileFlags(dir string) error {
+	return nil
+}

--- a/pkg/system/rm_freebsd.go
+++ b/pkg/system/rm_freebsd.go
@@ -1,0 +1,32 @@
+package system
+
+import (
+	"io/fs"
+	"path/filepath"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+func lchflags(path string, flags int) (err error) {
+	p, err := unix.BytePtrFromString(path)
+	if err != nil {
+		return err
+	}
+	_, _, e1 := unix.Syscall(unix.SYS_LCHFLAGS, uintptr(unsafe.Pointer(p)), uintptr(flags), 0)
+	if e1 != 0 {
+		return e1
+	}
+	return nil
+}
+
+// Reset file flags in a directory tree. This allows EnsureRemoveAll
+// to delete trees which have the immutable flag set.
+func resetFileFlags(dir string) error {
+	return filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
+		if err := lchflags(path, 0); err != nil {
+			return err
+		}
+		return nil
+	})
+}


### PR DESCRIPTION
Fixes #1354.

Signed-off-by: Doug Rabson <dfr@rabson.org>