### PR TITLE
If XDG_CONFIG_HOME env is set we should use it and ignore defaults

### DIFF
--- a/types/options.go
+++ b/types/options.go
@@ -48,6 +48,12 @@ func loadDefaultStoreOptions() {
 			loadDefaultStoreOptionsErr = err
 			return
 		}
+	} else if path, ok := os.LookupEnv("XDG_CONFIG_HOME"); ok {
+		defaultOverrideConfigFile = filepath.Join(path, "containers", "storage.conf")
+		if err := ReloadConfigurationFileIfNeeded(defaultOverrideConfigFile, &defaultStoreOptions); err != nil {
+			loadDefaultStoreOptionsErr = err
+			return
+		}
 	} else if _, err := os.Stat(defaultOverrideConfigFile); err == nil {
 		// The DefaultConfigFile(rootless) function returns the path
 		// of the used storage.conf file, by returning defaultConfigFile


### PR DESCRIPTION
HPC Customers noticed that storage was attempting to read files in /usr and /etc, even though they set XDG_CONFIG_HOME, they expect to only read config files in this directory.

Fixes: https://github.com/containers/podman/issues/15680

(Actually partial fixes), need to look at other config files.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>