### PR TITLE
Use system defaults if storage.conf does not exist in XDG_CONFIG_HOME

### DIFF
--- a/types/options.go
+++ b/types/options.go
@@ -38,9 +38,18 @@ var (
 )
 
 func loadDefaultStoreOptions() {
-	defaultStoreOptions.RunRoot = defaultRunRoot
-	defaultStoreOptions.GraphRoot = defaultGraphRoot
 	defaultStoreOptions.GraphDriverName = ""
+
+	setDefaults := func() {
+		// reload could set values to empty for run and graph root if config does not contains anything
+		if defaultStoreOptions.RunRoot == "" {
+			defaultStoreOptions.RunRoot = defaultRunRoot
+		}
+		if defaultStoreOptions.GraphRoot == "" {
+			defaultStoreOptions.GraphRoot = defaultGraphRoot
+		}
+	}
+	setDefaults()
 
 	if path, ok := os.LookupEnv(storageConfEnv); ok {
 		defaultOverrideConfigFile = path
@@ -48,13 +57,25 @@ func loadDefaultStoreOptions() {
 			loadDefaultStoreOptionsErr = err
 			return
 		}
-	} else if path, ok := os.LookupEnv("XDG_CONFIG_HOME"); ok {
-		defaultOverrideConfigFile = filepath.Join(path, "containers", "storage.conf")
-		if err := ReloadConfigurationFileIfNeeded(defaultOverrideConfigFile, &defaultStoreOptions); err != nil {
-			loadDefaultStoreOptionsErr = err
-			return
+		setDefaults()
+		return
+	}
+
+	if path, ok := os.LookupEnv("XDG_CONFIG_HOME"); ok {
+		homeConfigFile := filepath.Join(path, "containers", "storage.conf")
+		if _, err := os.Stat(homeConfigFile); err == nil {
+			// user storage.conf in XDG_CONFIG_HOME if it exists
+			defaultOverrideConfigFile = homeConfigFile
+		} else {
+			if !os.IsNotExist(err) {
+				loadDefaultStoreOptionsErr = err
+				return
+			}
 		}
-	} else if _, err := os.Stat(defaultOverrideConfigFile); err == nil {
+	}
+
+	_, err := os.Stat(defaultOverrideConfigFile)
+	if err == nil {
 		// The DefaultConfigFile(rootless) function returns the path
 		// of the used storage.conf file, by returning defaultConfigFile
 		// If override exists containers/storage uses it by default.
@@ -63,22 +84,18 @@ func loadDefaultStoreOptions() {
 			loadDefaultStoreOptionsErr = err
 			return
 		}
-	} else {
-		if !os.IsNotExist(err) {
-			logrus.Warningf("Attempting to use %s, %v", defaultConfigFile, err)
-		}
-		if err := ReloadConfigurationFileIfNeeded(defaultConfigFile, &defaultStoreOptions); err != nil && !errors.Is(err, os.ErrNotExist) {
-			loadDefaultStoreOptionsErr = err
-			return
-		}
+		setDefaults()
+		return
 	}
-	// reload could set values to empty for run and graph root if config does not contains anything
-	if defaultStoreOptions.RunRoot == "" {
-		defaultStoreOptions.RunRoot = defaultRunRoot
+
+	if !os.IsNotExist(err) {
+		logrus.Warningf("Attempting to use %s, %v", defaultConfigFile, err)
 	}
-	if defaultStoreOptions.GraphRoot == "" {
-		defaultStoreOptions.GraphRoot = defaultGraphRoot
+	if err := ReloadConfigurationFileIfNeeded(defaultConfigFile, &defaultStoreOptions); err != nil && !errors.Is(err, os.ErrNotExist) {
+		loadDefaultStoreOptionsErr = err
+		return
 	}
+	setDefaults()
 }
 
 // defaultStoreOptionsIsolated is an internal implementation detail of DefaultStoreOptions to allow testing.


### PR DESCRIPTION
Follow up to https://github.com/containers/storage/pull/1357

Podman tests suggest that do not need to use XDG_CONFIG_HOME if storage.conf does not exists.  In that case we fall back to /etc/containers/storage.conf and /usr/share/containers/storage.conf

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>