### PR TITLE
cirrus: run vendor and linter tasks using Go 1.18

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -117,7 +117,7 @@ lint_task:
     env:
         CIRRUS_WORKING_DIR: "/go/src/github.com/containers/storage"
     container:
-        image: golang:1.16
+        image: golang:1.18
     modules_cache:
         fingerprint_script: cat go.sum
         folder: $GOPATH/pkg/mod
@@ -154,7 +154,7 @@ meta_task:
 
 vendor_task:
     container:
-        image: golang:1.16
+        image: golang:1.18
     modules_cache:
         fingerprint_script: cat go.sum
         folder: $GOPATH/pkg/mod
@@ -172,6 +172,6 @@ success_task:
         - meta
         - vendor
     container:
-        image: golang:1.16
+        image: golang:1.18
     clone_script: 'mkdir -p "$CIRRUS_WORKING_DIR"'  # Source code not needed
     script: /bin/true

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,4 @@
-export GO111MODULE=off
+export GO111MODULE=on
 export GOPROXY=https://proxy.golang.org
 
 .PHONY: \
@@ -111,7 +111,7 @@ install.docs: docs
 install: install.docs
 
 lint: install.tools
-	tests/tools/build/golangci-lint run --build-tags="$(AUTOTAGS) $(TAGS)"
+	tests/tools/build/golangci-lint run --build-tags="$(AUTOTAGS) $(TAGS)" .
 
 help: ## this help
 	@awk 'BEGIN {FS = ":.*?## "} /^[a-z A-Z_-]+:.*?## / {gsub(" ",",",$$1);gsub("\\\\n",sprintf("\n%22c"," "), $$2);printf "\033[36m%-21s\033[0m %s\n", $$1, $$2}' $(MAKEFILE_LIST)

--- a/store.go
+++ b/store.go
@@ -24,7 +24,7 @@ import (
 	"github.com/containers/storage/pkg/stringutils"
 	"github.com/containers/storage/pkg/system"
 	"github.com/containers/storage/types"
-	"github.com/hashicorp/go-multierror"
+	multierror "github.com/hashicorp/go-multierror"
 	digest "github.com/opencontainers/go-digest"
 	"github.com/opencontainers/selinux/go-selinux/label"
 )

--- a/tests/tools/Makefile
+++ b/tests/tools/Makefile
@@ -35,7 +35,7 @@ $(BUILDDIR)/go-md2man:
 
 $(BUILDDIR)/golangci-lint:
 	export \
-		VERSION=v1.24.0 \
+		VERSION=v1.49.0 \
 		URL=https://raw.githubusercontent.com/golangci/golangci-lint \
 		BINDIR=$(BUILDDIR) && \
 	curl -sfL $$URL/$$VERSION/install.sh | sh -s $$VERSION


### PR DESCRIPTION
Run linter tasks with Go 1.18 instead of 1.16, which is no longer current.