### PR TITLE
drivers/overlay: Notify the user if the backing filesystem is not supported with OverlayFS

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -309,9 +309,11 @@ func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) 
 	if err != nil {
 		return nil, err
 	}
-	if fsName, ok := graphdriver.FsNames[fsMagic]; ok {
-		backingFs = fsName
+	fsName, ok := graphdriver.FsNames[fsMagic]
+	if !ok {
+		return nil, fmt.Errorf("filesystem type %#x reported for %s is not supported with 'overlay': %w", fsMagic, filepath.Dir(home), graphdriver.ErrIncompatibleFS)
 	}
+	backingFs = fsName
 
 	runhome := filepath.Join(options.RunRoot, filepath.Base(home))
 	rootUID, rootGID, err := idtools.GetRootUIDGID(options.UIDMaps, options.GIDMaps)


### PR DESCRIPTION
If the backing filesystem is not supported with OverlayFS as a container storage driver/or graph driver then do not continue. In this context, report the incompatibility by notifying the user of an unsupported configuration. The filesystem type/or ID that is returned by the statfs(2) system call is reported too, to assist further troubleshooting efforts. It can be used to deduce the actual filesystem used for the container storage graph directory.

Signed-off-by: Aaron Tomlin <atomlin@redhat.com>