### PR TITLE
Add support for exporting and importing file flags on FreeBSD

### DIFF
--- a/pkg/archive/changes_bsd_test.go
+++ b/pkg/archive/changes_bsd_test.go
@@ -1,0 +1,98 @@
+//go:build freebsd
+// +build freebsd
+
+package archive
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/containers/storage/pkg/idtools"
+	"github.com/containers/storage/pkg/system"
+	"github.com/stretchr/testify/require"
+)
+
+// Verify that file flag changes are reported
+func TestChangeFileFlags(t *testing.T) {
+	src := t.TempDir()
+	createSampleDir(t, src)
+
+	dst := src + "-copy"
+	err := copyDir(src, dst)
+	require.NoError(t, err)
+	file1 := path.Join(dst, "dir1/file1-1")
+	err = system.Lchflags(file1, system.UF_READONLY)
+	require.NoError(t, err)
+
+	changes, err := ChangesDirs(dst, &idtools.IDMappings{}, src, &idtools.IDMappings{})
+	require.NoError(t, err)
+
+	expectedChanges := []Change{
+		{"/dir1", ChangeModify},
+		{"/dir1/file1-1", ChangeModify},
+	}
+	checkChanges(t, expectedChanges, changes)
+}
+
+// Verify that file flag changes are copied
+func TestCopyFileFlags(t *testing.T) {
+	src := t.TempDir()
+	createSampleDir(t, src)
+	file1 := path.Join(src, "dir1/file1-1")
+	err := system.Lchflags(file1, system.UF_READONLY)
+	require.NoError(t, err)
+
+	dst := src + "-copy"
+	err = copyDir(src, dst)
+	require.NoError(t, err)
+
+	changes, err := ChangesDirs(dst, &idtools.IDMappings{}, src, &idtools.IDMappings{})
+	require.NoError(t, err)
+
+	if len(changes) != 0 {
+		t.Fatalf("Changes with no difference should have detect no changes, but detected %d", len(changes))
+	}
+}
+
+// Make sure we can apply changes to an immutable file, including deleting
+func TestApplyToImmutable(t *testing.T) {
+	// Make a directory with an immutable file
+	src := t.TempDir()
+	createSampleDir(t, src)
+	file1 := path.Join(src, "dir1/file1-1")
+	file2 := path.Join(src, "dir1/file1-2")
+	require.NoError(t, os.Chmod(file1, 0777))
+	require.NoError(t, system.Lchflags(file1, system.SF_IMMUTABLE))
+	require.NoError(t, system.Lchflags(file2, system.SF_IMMUTABLE))
+
+	// Copy it, and change file1, delete file2
+	dst := src + "-copy"
+	err := copyDir(src, dst)
+	require.NoError(t, err)
+	file1 = path.Join(dst, "dir1/file1-1")
+	file2 = path.Join(dst, "dir1/file1-2")
+	require.NoError(t, system.Lchflags(file1, 0))
+	require.NoError(t, os.Chmod(file1, 0666))
+	require.NoError(t, system.Lchflags(file2, 0))
+	require.NoError(t, os.RemoveAll(file2))
+
+	changes, err := ChangesDirs(dst, &idtools.IDMappings{}, src, &idtools.IDMappings{})
+	require.NoError(t, err)
+
+	layer, err := ExportChanges(dst, changes, nil, nil)
+	require.NoError(t, err)
+
+	layerCopy, err := NewTempArchive(layer, "")
+	require.NoError(t, err)
+
+	_, err = ApplyLayer(src, layerCopy)
+	require.NoError(t, err)
+
+	changes2, err := ChangesDirs(src, &idtools.IDMappings{}, dst, &idtools.IDMappings{})
+	require.NoError(t, err)
+
+	if len(changes2) != 0 {
+		t.Fatalf("Unexpected differences after reapplying mutation: %v", changes2)
+	}
+}

--- a/pkg/archive/changes_unix.go
+++ b/pkg/archive/changes_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package archive
@@ -29,6 +30,7 @@ func statDifferent(oldStat *system.StatT, oldInfo *FileInfo, newStat *system.Sta
 	if oldStat.Mode() != newStat.Mode() ||
 		ownerChanged ||
 		oldStat.Rdev() != newStat.Rdev() ||
+		oldStat.Flags() != newStat.Flags() ||
 		// Don't look at size for dirs, its not a good measure of change
 		(oldStat.Mode()&unix.S_IFDIR != unix.S_IFDIR &&
 			(!sameFsTimeSpec(oldStat.Mtim(), newStat.Mtim()) || (oldStat.Size() != newStat.Size()))) {

--- a/pkg/archive/diff.go
+++ b/pkg/archive/diff.go
@@ -145,6 +145,9 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 						return nil
 					}
 					if _, exists := unpackedPaths[path]; !exists {
+						if err := resetImmutable(path, nil); err != nil {
+							return err
+						}
 						err := os.RemoveAll(path)
 						return err
 					}
@@ -156,6 +159,9 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 			} else {
 				originalBase := base[len(WhiteoutPrefix):]
 				originalPath := filepath.Join(dir, originalBase)
+				if err := resetImmutable(originalPath, nil); err != nil {
+					return 0, err
+				}
 				if err := os.RemoveAll(originalPath); err != nil {
 					return 0, err
 				}
@@ -165,7 +171,15 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 			// The only exception is when it is a directory *and* the file from
 			// the layer is also a directory. Then we want to merge them (i.e.
 			// just apply the metadata from the layer).
+			//
+			// We always reset the immutable flag (if present) to allow metadata
+			// changes and to allow directory modification. The flag will be
+			// re-applied based on the contents of hdr either at the end for
+			// directories or in createTarFile otherwise.
 			if fi, err := os.Lstat(path); err == nil {
+				if err := resetImmutable(path, &fi); err != nil {
+					return 0, err
+				}
 				if !(fi.IsDir() && hdr.Typeflag == tar.TypeDir) {
 					if err := os.RemoveAll(path); err != nil {
 						return 0, err
@@ -213,6 +227,9 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 	for _, hdr := range dirs {
 		path := filepath.Join(dest, hdr.Name)
 		if err := system.Chtimes(path, hdr.AccessTime, hdr.ModTime); err != nil {
+			return 0, err
+		}
+		if err := WriteFileFlagsFromTarHeader(path, hdr); err != nil {
 			return 0, err
 		}
 	}

--- a/pkg/archive/fflags_bsd.go
+++ b/pkg/archive/fflags_bsd.go
@@ -1,0 +1,167 @@
+//go:build freebsd
+// +build freebsd
+
+package archive
+
+import (
+	"archive/tar"
+	"fmt"
+	"math/bits"
+	"os"
+	"strings"
+	"syscall"
+
+	"github.com/containers/storage/pkg/system"
+)
+
+const (
+	paxSCHILYFflags = "SCHILY.fflags"
+)
+
+var (
+	flagNameToValue = map[string]uint32{
+		"sappnd":     system.SF_APPEND,
+		"sappend":    system.SF_APPEND,
+		"arch":       system.SF_ARCHIVED,
+		"archived":   system.SF_ARCHIVED,
+		"schg":       system.SF_IMMUTABLE,
+		"schange":    system.SF_IMMUTABLE,
+		"simmutable": system.SF_IMMUTABLE,
+		"sunlnk":     system.SF_NOUNLINK,
+		"sunlink":    system.SF_NOUNLINK,
+		"snapshot":   system.SF_SNAPSHOT,
+		"uappnd":     system.UF_APPEND,
+		"uappend":    system.UF_APPEND,
+		"uarch":      system.UF_ARCHIVE,
+		"uarchive":   system.UF_ARCHIVE,
+		"hidden":     system.UF_HIDDEN,
+		"uhidden":    system.UF_HIDDEN,
+		"uchg":       system.UF_IMMUTABLE,
+		"uchange":    system.UF_IMMUTABLE,
+		"uimmutable": system.UF_IMMUTABLE,
+		"uunlnk":     system.UF_NOUNLINK,
+		"uunlink":    system.UF_NOUNLINK,
+		"offline":    system.UF_OFFLINE,
+		"uoffline":   system.UF_OFFLINE,
+		"opaque":     system.UF_OPAQUE,
+		"rdonly":     system.UF_READONLY,
+		"urdonly":    system.UF_READONLY,
+		"readonly":   system.UF_READONLY,
+		"ureadonly":  system.UF_READONLY,
+		"reparse":    system.UF_REPARSE,
+		"ureparse":   system.UF_REPARSE,
+		"sparse":     system.UF_SPARSE,
+		"usparse":    system.UF_SPARSE,
+		"system":     system.UF_SYSTEM,
+		"usystem":    system.UF_SYSTEM,
+	}
+	// Only include the short names for the reverse map
+	flagValueToName = map[uint32]string{
+		system.SF_APPEND:    "sappnd",
+		system.SF_ARCHIVED:  "arch",
+		system.SF_IMMUTABLE: "schg",
+		system.SF_NOUNLINK:  "sunlnk",
+		system.SF_SNAPSHOT:  "snapshot",
+		system.UF_APPEND:    "uappnd",
+		system.UF_ARCHIVE:   "uarch",
+		system.UF_HIDDEN:    "hidden",
+		system.UF_IMMUTABLE: "uchg",
+		system.UF_NOUNLINK:  "uunlnk",
+		system.UF_OFFLINE:   "offline",
+		system.UF_OPAQUE:    "opaque",
+		system.UF_READONLY:  "rdonly",
+		system.UF_REPARSE:   "reparse",
+		system.UF_SPARSE:    "sparse",
+		system.UF_SYSTEM:    "system",
+	}
+)
+
+func parseFileFlags(fflags string) (uint32, uint32, error) {
+	var set, clear uint32 = 0, 0
+	for _, fflag := range strings.Split(fflags, ",") {
+		isClear := false
+		if strings.HasPrefix(fflag, "no") {
+			isClear = true
+			fflag = strings.TrimPrefix(fflag, "no")
+		}
+		if value, ok := flagNameToValue[fflag]; ok {
+			if isClear {
+				clear |= value
+			} else {
+				set |= value
+			}
+		} else {
+			return 0, 0, fmt.Errorf("parsing file flags, unrecognised token: %s", fflag)
+		}
+	}
+	return set, clear, nil
+}
+
+func formatFileFlags(fflags uint32) (string, error) {
+	var res = []string{}
+	for fflags != 0 {
+		// Extract lowest set bit
+		fflag := uint32(1) << bits.TrailingZeros32(fflags)
+		if name, ok := flagValueToName[fflag]; ok {
+			res = append(res, name)
+		} else {
+			return "", fmt.Errorf("formatting file flags, unrecognised flag: %x", fflag)
+		}
+		fflags &= ^fflag
+	}
+	return strings.Join(res, ","), nil
+}
+
+func ReadFileFlagsToTarHeader(path string, hdr *tar.Header) error {
+	st, err := system.Lstat(path)
+	if err != nil {
+		return err
+	}
+	fflags, err := formatFileFlags(st.Flags())
+	if err != nil {
+		return err
+	}
+	if fflags != "" {
+		if hdr.PAXRecords == nil {
+			hdr.PAXRecords = map[string]string{}
+		}
+		hdr.PAXRecords[paxSCHILYFflags] = fflags
+	}
+	return nil
+}
+
+func WriteFileFlagsFromTarHeader(path string, hdr *tar.Header) error {
+	if fflags, ok := hdr.PAXRecords[paxSCHILYFflags]; ok {
+		var set, clear uint32
+		set, clear, err := parseFileFlags(fflags)
+		if err != nil {
+			return err
+		}
+
+		// Apply the delta to the existing file flags
+		st, err := system.Lstat(path)
+		if err != nil {
+			return err
+		}
+		return system.Lchflags(path, (st.Flags() & ^clear)|set)
+	}
+	return nil
+}
+
+func resetImmutable(path string, fi *os.FileInfo) error {
+	var flags uint32
+	if fi != nil {
+		flags = (*fi).Sys().(*syscall.Stat_t).Flags
+	} else {
+		st, err := system.Lstat(path)
+		if err != nil {
+			return err
+		}
+		flags = st.Flags()
+	}
+	if flags&(system.SF_IMMUTABLE|system.UF_IMMUTABLE) != 0 {
+		flags &= ^(system.SF_IMMUTABLE | system.UF_IMMUTABLE)
+		return system.Lchflags(path, flags)
+	}
+	return nil
+}

--- a/pkg/archive/fflags_unsupported.go
+++ b/pkg/archive/fflags_unsupported.go
@@ -1,0 +1,21 @@
+//go:build !freebsd
+// +build !freebsd
+
+package archive
+
+import (
+	"archive/tar"
+	"os"
+)
+
+func ReadFileFlagsToTarHeader(path string, hdr *tar.Header) error {
+	return nil
+}
+
+func WriteFileFlagsFromTarHeader(path string, hdr *tar.Header) error {
+	return nil
+}
+
+func resetImmutable(path string, fi *os.FileInfo) error {
+	return nil
+}

--- a/pkg/system/lchflags_bsd.go
+++ b/pkg/system/lchflags_bsd.go
@@ -1,0 +1,22 @@
+//go:build freebsd
+// +build freebsd
+
+package system
+
+import (
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+func Lchflags(path string, flags uint32) error {
+	p, err := unix.BytePtrFromString(path)
+	if err != nil {
+		return err
+	}
+	_, _, e1 := unix.Syscall(unix.SYS_LCHFLAGS, uintptr(unsafe.Pointer(p)), uintptr(flags), 0)
+	if e1 != 0 {
+		return e1
+	}
+	return nil
+}

--- a/pkg/system/lchflags_bsd.go
+++ b/pkg/system/lchflags_bsd.go
@@ -9,6 +9,40 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// Flag values from <sys/stat.h>
+const (
+	/*
+	 * Definitions of flags stored in file flags word.
+	 *
+	 * Super-user and owner changeable flags.
+	 */
+	UF_SETTABLE  uint32 = 0x0000ffff /* mask of owner changeable flags */
+	UF_NODUMP    uint32 = 0x00000001 /* do not dump file */
+	UF_IMMUTABLE uint32 = 0x00000002 /* file may not be changed */
+	UF_APPEND    uint32 = 0x00000004 /* writes to file may only append */
+	UF_OPAQUE    uint32 = 0x00000008 /* directory is opaque wrt. union */
+	UF_NOUNLINK  uint32 = 0x00000010 /* file may not be removed or renamed */
+
+	UF_SYSTEM   uint32 = 0x00000080 /* Windows system file bit */
+	UF_SPARSE   uint32 = 0x00000100 /* sparse file */
+	UF_OFFLINE  uint32 = 0x00000200 /* file is offline */
+	UF_REPARSE  uint32 = 0x00000400 /* Windows reparse point file bit */
+	UF_ARCHIVE  uint32 = 0x00000800 /* file needs to be archived */
+	UF_READONLY uint32 = 0x00001000 /* Windows readonly file bit */
+	/* This is the same as the MacOS X definition of UF_HIDDEN. */
+	UF_HIDDEN uint32 = 0x00008000 /* file is hidden */
+
+	/*
+	 * Super-user changeable flags.
+	 */
+	SF_SETTABLE  uint32 = 0xffff0000 /* mask of superuser changeable flags */
+	SF_ARCHIVED  uint32 = 0x00010000 /* file is archived */
+	SF_IMMUTABLE uint32 = 0x00020000 /* file may not be changed */
+	SF_APPEND    uint32 = 0x00040000 /* writes to file may only append */
+	SF_NOUNLINK  uint32 = 0x00100000 /* file may not be removed or renamed */
+	SF_SNAPSHOT  uint32 = 0x00200000 /* snapshot inode */
+)
+
 func Lchflags(path string, flags uint32) error {
 	p, err := unix.BytePtrFromString(path)
 	if err != nil {

--- a/pkg/system/rm_freebsd.go
+++ b/pkg/system/rm_freebsd.go
@@ -3,28 +3,13 @@ package system
 import (
 	"io/fs"
 	"path/filepath"
-	"unsafe"
-
-	"golang.org/x/sys/unix"
 )
-
-func lchflags(path string, flags int) (err error) {
-	p, err := unix.BytePtrFromString(path)
-	if err != nil {
-		return err
-	}
-	_, _, e1 := unix.Syscall(unix.SYS_LCHFLAGS, uintptr(unsafe.Pointer(p)), uintptr(flags), 0)
-	if e1 != 0 {
-		return e1
-	}
-	return nil
-}
 
 // Reset file flags in a directory tree. This allows EnsureRemoveAll
 // to delete trees which have the immutable flag set.
 func resetFileFlags(dir string) error {
 	return filepath.WalkDir(dir, func(path string, d fs.DirEntry, err error) error {
-		if err := lchflags(path, 0); err != nil {
+		if err := Lchflags(path, 0); err != nil {
 			return err
 		}
 		return nil

--- a/pkg/system/stat_common.go
+++ b/pkg/system/stat_common.go
@@ -1,0 +1,12 @@
+//go:build !freebsd
+// +build !freebsd
+
+package system
+
+type platformStatT struct {
+}
+
+// Flags return file flags if supported or zero otherwise
+func (s StatT) Flags() uint32 {
+	return 0
+}

--- a/pkg/system/stat_freebsd.go
+++ b/pkg/system/stat_freebsd.go
@@ -2,12 +2,23 @@ package system
 
 import "syscall"
 
+type platformStatT struct {
+	flags uint32
+}
+
+// Flags return file flags if supported or zero otherwise
+func (s StatT) Flags() uint32 {
+	return s.flags
+}
+
 // fromStatT converts a syscall.Stat_t type to a system.Stat_t type
 func fromStatT(s *syscall.Stat_t) (*StatT, error) {
-	return &StatT{size: s.Size,
+	st := &StatT{size: s.Size,
 		mode: uint32(s.Mode),
 		uid:  s.Uid,
 		gid:  s.Gid,
 		rdev: uint64(s.Rdev),
-		mtim: s.Mtimespec}, nil
+		mtim: s.Mtimespec}
+	st.flags = s.Flags
+	return st, nil
 }

--- a/pkg/system/stat_freebsd_test.go
+++ b/pkg/system/stat_freebsd_test.go
@@ -4,6 +4,8 @@
 package system
 
 import (
+	"os"
+	"path/filepath"
 	"syscall"
 	"testing"
 )
@@ -15,5 +17,24 @@ func platformTestFromStatT(t *testing.T, stat *syscall.Stat_t, s *StatT) {
 	}
 	if stat.Mtimespec != s.Mtim() {
 		t.Fatal("got invalid mtim")
+	}
+}
+
+func TestFileFlags(t *testing.T) {
+	dir := t.TempDir()
+	file := filepath.Join(dir, "append")
+	if err := os.WriteFile(file, []byte("hello"), 0644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := Lchflags(file, UF_READONLY); err != nil {
+		t.Fatal(err)
+	}
+	s, err := Stat(file)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if s.Flags() != UF_READONLY {
+		t.Fatal("got invalid flags")
 	}
 }

--- a/pkg/system/stat_unix.go
+++ b/pkg/system/stat_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package system
@@ -17,6 +18,7 @@ type StatT struct {
 	rdev uint64
 	size int64
 	mtim syscall.Timespec
+	platformStatT
 }
 
 // Mode returns file's permission mode.

--- a/tests/delete-container.bats
+++ b/tests/delete-container.bats
@@ -31,3 +31,50 @@ load helpers
 	run storage exists -c $container
 	[ "$status" -ne 0 ]
 }
+
+@test "delete-container-with-immutable" {
+	if [ "$OS" != "FreeBSD" ]; then
+		skip "not supported on $OS"
+	fi
+
+	# Create a layer.
+	run storage --debug=false create-layer
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	layer=$output
+
+	# Create an image using that layer.
+	run storage --debug=false create-image $layer
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	image=${output%%	*}
+
+	# Create an image using that layer.
+	run storage --debug=false create-container $image
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	container=${output%%	*}
+
+	# Check that the container can be found.
+	storage exists -c $container
+
+	run storage --debug=false mount $container
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	containermount="$output"
+
+	# Create a file and make it immutable
+	createrandom "$containermount"/file1
+	chflags schg "$containermount"/file1
+
+	run storage --debug=false unmount $container
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+
+	# Use delete-container to delete it.
+	storage delete-container $container
+
+	# Check that the container is gone.
+	run storage exists -c $container
+	[ "$status" -ne 0 ]
+}

--- a/tests/import-layer.bats
+++ b/tests/import-layer.bats
@@ -41,3 +41,96 @@ load helpers
 	checkchanges
 	checkdiffs
 }
+
+set_immutable() {
+	chflags schg $1
+}
+
+reset_immutable() {
+	chflags noschg $1
+}
+
+is_immutable() {
+	local flags=$(stat -f %#Xf $1)
+	[ "$((($flags & 0x20000) == 0x20000))" -ne 0 ]
+}
+
+@test "import-layer-with-immutable" {
+	if [ "$OS" != "FreeBSD" ]; then
+		skip "not supported on $OS"
+	fi
+
+	# Create a layer with a directory containing two files, both
+	# immutable. The directory is also set as immutablr.
+	run storage --debug=false create-layer
+	echo $output
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	lowerlayer="$output"
+	run storage --debug=false mount $lowerlayer
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	local m="$output"
+	mkdir $m/dir
+	createrandom $m/dir/layer1file1
+	createrandom $m/dir/layer1file2
+	set_immutable $m/dir/layer1file1
+	set_immutable $m/dir/layer1file2
+	set_immutable $m/dir
+	storage unmount $lowerlayer
+
+	# Create a second layer which deletes one file and removes immutable from the other
+	run storage --debug=false create-layer "$lowerlayer"
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	upperlayer="$output"
+	run storage --debug=false mount $upperlayer
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	m="$output"
+	reset_immutable $m/dir
+	reset_immutable $m/dir/layer1file1
+	rm $m/dir/layer1file1
+	reset_immutable $m/dir/layer1file2
+	set_immutable $m/dir
+	storage unmount $upperlayer
+
+	# Extract the layers.
+	storage diff -u -f $TESTDIR/lower.tar $lowerlayer
+	storage diff -u -f $TESTDIR/upper.tar $upperlayer
+
+	# Delete the layers.
+	storage delete-layer $upperlayer
+	storage delete-layer $lowerlayer
+
+	# Import new layers using the layer diffs.
+	run storage --debug=false import-layer -f $TESTDIR/lower.tar
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	lowerlayer="$output"
+
+	run storage --debug=false import-layer -f $TESTDIR/upper.tar "$lowerlayer"
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	upperlayer="$output"
+
+	# Verify layer contents
+	run storage --debug=false mount $lowerlayer
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	m="$output"
+	is_immutable $m/dir/layer1file1
+	is_immutable $m/dir/layer1file2
+	storage unmount $lowerlayer
+
+	run storage --debug=false mount $upperlayer
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	m="$output"
+	[ ! -f $m/dir/layer1file1 ]
+	! is_immutable $m/dir/layer1file2
+	storage unmount $upperlayer
+
+	storage delete-layer $upperlayer
+	storage delete-layer $lowerlayer
+}


### PR DESCRIPTION
The implementation could be shared with darwin and other BSDs if needed but initially is only enabled on FreeBSD. This uses the SCHILY.fflags PAX option to encode flags which is supported by libarchive (bsdtar) and star. The flag save/restore entry points are exported, allowing them to be used by buildah/copier.

To support applying diffs to trees with flags, I added logic to reset immutable flags during the UnpackLayer process - this is slightly complicated by the desire to support immutable directories which needs to defer setting fiags on directories to after all modifications to the directory contents. Fortunately, something similar is already in place for setting directory modify times.