### PR TITLE
Remove a manual layerStore.Touch() call from store.Shutdown()

### DIFF
--- a/store.go
+++ b/store.go
@@ -3313,7 +3313,6 @@ func (s *store) FromContainerRunDirectory(id, file string) ([]byte, error) {
 
 func (s *store) Shutdown(force bool) ([]string, error) {
 	mounted := []string{}
-	modified := false
 
 	rlstore, err := s.getLayerStore()
 	if err != nil {
@@ -3347,7 +3346,6 @@ func (s *store) Shutdown(force bool) ([]string, error) {
 					}
 					break
 				}
-				modified = true
 			}
 		}
 	}
@@ -3361,16 +3359,6 @@ func (s *store) Shutdown(force bool) ([]string, error) {
 				err = err2
 			} else {
 				err = fmt.Errorf("(graphLock.Touch failed: %v) %w", err2, err)
-			}
-		}
-		modified = true
-	}
-	if modified {
-		if err2 := rlstore.Touch(); err2 != nil {
-			if err == nil {
-				err = err2
-			} else {
-				err = fmt.Errorf("rlstore.Touch failed: %v) %w", err2, err)
 			}
 		}
 	}


### PR DESCRIPTION
It's completely unclear to me why this is necessary; the unmount calls actually write to the separate mountpoints.json file, with a separate lock.

When this was originally introduced in b046fb5a9a1ad6d25bd6c854400f090131c8a21c , there wasn't a separate `mountpoints.json` file (changed in 0183a293dc01f22561b83448340c08e55f9b979b ), and store.go was manually calling `Touch()` everywhere (changed in c496eac6c393dee3a50610deaa19d45351026dec) ; so my best guess is that this is just an artifact of making those two API changes, and the `Touch()` is not actually necessary.

@nalind @rhatdan is there some non-obvious purpose for the `Touch()` call here? 