### PR TITLE
Consolidate the common parts of simple writers

### DIFF
--- a/store.go
+++ b/store.go
@@ -1134,6 +1134,42 @@ func (s *store) writeToContainerStore(fn func(store rwContainerStore) error) err
 	return fn(store)
 }
 
+// writeToAllStores is a convenience helper for writing to all three stores:
+// It locks the stores for writing, checks for updates, and calls fn().
+// It returns the return value of fn, or its own error initializing the stores.
+func (s *store) writeToAllStores(fn func(rlstore rwLayerStore, ristore rwImageStore, rcstore rwContainerStore) error) error {
+	rlstore, err := s.getLayerStore()
+	if err != nil {
+		return err
+	}
+	ristore, err := s.getImageStore()
+	if err != nil {
+		return err
+	}
+	rcstore, err := s.getContainerStore()
+	if err != nil {
+		return err
+	}
+
+	rlstore.Lock()
+	defer rlstore.Unlock()
+	if err := rlstore.ReloadIfChanged(); err != nil {
+		return err
+	}
+	ristore.Lock()
+	defer ristore.Unlock()
+	if err := ristore.ReloadIfChanged(); err != nil {
+		return err
+	}
+	rcstore.Lock()
+	defer rcstore.Unlock()
+	if err := rcstore.ReloadIfChanged(); err != nil {
+		return err
+	}
+
+	return fn(rlstore, ristore, rcstore)
+}
+
 func (s *store) canUseShifting(uidmap, gidmap []idtools.IDMap) bool {
 	if s.graphDriver == nil || !s.graphDriver.SupportsShifting() {
 		return false
@@ -1594,45 +1630,18 @@ func (s *store) CreateContainer(id string, names []string, image, layer, metadat
 }
 
 func (s *store) SetMetadata(id, metadata string) error {
-	rlstore, err := s.getLayerStore()
-	if err != nil {
-		return err
-	}
-	ristore, err := s.getImageStore()
-	if err != nil {
-		return err
-	}
-	rcstore, err := s.getContainerStore()
-	if err != nil {
-		return err
-	}
-
-	rlstore.Lock()
-	defer rlstore.Unlock()
-	if err := rlstore.ReloadIfChanged(); err != nil {
-		return err
-	}
-	ristore.Lock()
-	defer ristore.Unlock()
-	if err := ristore.ReloadIfChanged(); err != nil {
-		return err
-	}
-	rcstore.Lock()
-	defer rcstore.Unlock()
-	if err := rcstore.ReloadIfChanged(); err != nil {
-		return err
-	}
-
-	if rlstore.Exists(id) {
-		return rlstore.SetMetadata(id, metadata)
-	}
-	if ristore.Exists(id) {
-		return ristore.SetMetadata(id, metadata)
-	}
-	if rcstore.Exists(id) {
-		return rcstore.SetMetadata(id, metadata)
-	}
-	return ErrNotAnID
+	return s.writeToAllStores(func(rlstore rwLayerStore, ristore rwImageStore, rcstore rwContainerStore) error {
+		if rlstore.Exists(id) {
+			return rlstore.SetMetadata(id, metadata)
+		}
+		if ristore.Exists(id) {
+			return ristore.SetMetadata(id, metadata)
+		}
+		if rcstore.Exists(id) {
+			return rcstore.SetMetadata(id, metadata)
+		}
+		return ErrNotAnID
+	})
 }
 
 func (s *store) Metadata(id string) (string, error) {
@@ -2284,417 +2293,286 @@ func (s *store) Lookup(name string) (string, error) {
 }
 
 func (s *store) DeleteLayer(id string) error {
-	rlstore, err := s.getLayerStore()
-	if err != nil {
-		return err
-	}
-	ristore, err := s.getImageStore()
-	if err != nil {
-		return err
-	}
-	rcstore, err := s.getContainerStore()
-	if err != nil {
-		return err
-	}
-
-	rlstore.Lock()
-	defer rlstore.Unlock()
-	if err := rlstore.ReloadIfChanged(); err != nil {
-		return err
-	}
-	ristore.Lock()
-	defer ristore.Unlock()
-	if err := ristore.ReloadIfChanged(); err != nil {
-		return err
-	}
-	rcstore.Lock()
-	defer rcstore.Unlock()
-	if err := rcstore.ReloadIfChanged(); err != nil {
-		return err
-	}
-
-	if rlstore.Exists(id) {
-		if l, err := rlstore.Get(id); err != nil {
-			id = l.ID
-		}
-		layers, err := rlstore.Layers()
-		if err != nil {
-			return err
-		}
-		for _, layer := range layers {
-			if layer.Parent == id {
-				return fmt.Errorf("used by layer %v: %w", layer.ID, ErrLayerHasChildren)
+	return s.writeToAllStores(func(rlstore rwLayerStore, ristore rwImageStore, rcstore rwContainerStore) error {
+		if rlstore.Exists(id) {
+			if l, err := rlstore.Get(id); err != nil {
+				id = l.ID
 			}
-		}
-		images, err := ristore.Images()
-		if err != nil {
-			return err
-		}
-
-		for _, image := range images {
-			if image.TopLayer == id {
-				return fmt.Errorf("layer %v used by image %v: %w", id, image.ID, ErrLayerUsedByImage)
+			layers, err := rlstore.Layers()
+			if err != nil {
+				return err
 			}
-			if stringutils.InSlice(image.MappedTopLayers, id) {
-				// No write access to the image store, fail before the layer is deleted
-				if _, ok := ristore.(*imageStore); !ok {
-					return fmt.Errorf("layer %v used by image %v: %w", id, image.ID, ErrLayerUsedByImage)
+			for _, layer := range layers {
+				if layer.Parent == id {
+					return fmt.Errorf("used by layer %v: %w", layer.ID, ErrLayerHasChildren)
 				}
 			}
-		}
-		containers, err := rcstore.Containers()
-		if err != nil {
-			return err
-		}
-		for _, container := range containers {
-			if container.LayerID == id {
-				return fmt.Errorf("layer %v used by container %v: %w", id, container.ID, ErrLayerUsedByContainer)
+			images, err := ristore.Images()
+			if err != nil {
+				return err
 			}
-		}
-		if err := rlstore.Delete(id); err != nil {
-			return fmt.Errorf("delete layer %v: %w", id, err)
-		}
 
-		// The check here is used to avoid iterating the images if we don't need to.
-		// There is already a check above for the imageStore to be writeable when the layer is part of MappedTopLayers.
-		if istore, ok := ristore.(*imageStore); ok {
 			for _, image := range images {
+				if image.TopLayer == id {
+					return fmt.Errorf("layer %v used by image %v: %w", id, image.ID, ErrLayerUsedByImage)
+				}
 				if stringutils.InSlice(image.MappedTopLayers, id) {
-					if err = istore.removeMappedTopLayer(image.ID, id); err != nil {
-						return fmt.Errorf("remove mapped top layer %v from image %v: %w", id, image.ID, err)
+					// No write access to the image store, fail before the layer is deleted
+					if _, ok := ristore.(*imageStore); !ok {
+						return fmt.Errorf("layer %v used by image %v: %w", id, image.ID, ErrLayerUsedByImage)
 					}
+				}
+			}
+			containers, err := rcstore.Containers()
+			if err != nil {
+				return err
+			}
+			for _, container := range containers {
+				if container.LayerID == id {
+					return fmt.Errorf("layer %v used by container %v: %w", id, container.ID, ErrLayerUsedByContainer)
+				}
+			}
+			if err := rlstore.Delete(id); err != nil {
+				return fmt.Errorf("delete layer %v: %w", id, err)
+			}
+
+			// The check here is used to avoid iterating the images if we don't need to.
+			// There is already a check above for the imageStore to be writeable when the layer is part of MappedTopLayers.
+			if istore, ok := ristore.(*imageStore); ok {
+				for _, image := range images {
+					if stringutils.InSlice(image.MappedTopLayers, id) {
+						if err = istore.removeMappedTopLayer(image.ID, id); err != nil {
+							return fmt.Errorf("remove mapped top layer %v from image %v: %w", id, image.ID, err)
+						}
+					}
+				}
+			}
+			return nil
+		}
+		return ErrNotALayer
+	})
+}
+
+func (s *store) DeleteImage(id string, commit bool) (layers []string, err error) {
+	layersToRemove := []string{}
+	if err := s.writeToAllStores(func(rlstore rwLayerStore, ristore rwImageStore, rcstore rwContainerStore) error {
+		if ristore.Exists(id) {
+			image, err := ristore.Get(id)
+			if err != nil {
+				return err
+			}
+			id = image.ID
+			containers, err := rcstore.Containers()
+			if err != nil {
+				return err
+			}
+			aContainerByImage := make(map[string]string)
+			for _, container := range containers {
+				aContainerByImage[container.ImageID] = container.ID
+			}
+			if container, ok := aContainerByImage[id]; ok {
+				return fmt.Errorf("image used by %v: %w", container, ErrImageUsedByContainer)
+			}
+			images, err := ristore.Images()
+			if err != nil {
+				return err
+			}
+			layers, err := rlstore.Layers()
+			if err != nil {
+				return err
+			}
+			childrenByParent := make(map[string][]string)
+			for _, layer := range layers {
+				childrenByParent[layer.Parent] = append(childrenByParent[layer.Parent], layer.ID)
+			}
+			otherImagesTopLayers := make(map[string]struct{})
+			for _, img := range images {
+				if img.ID != id {
+					otherImagesTopLayers[img.TopLayer] = struct{}{}
+					for _, layerID := range img.MappedTopLayers {
+						otherImagesTopLayers[layerID] = struct{}{}
+					}
+				}
+			}
+			if commit {
+				if err = ristore.Delete(id); err != nil {
+					return err
+				}
+			}
+			layer := image.TopLayer
+			layersToRemoveMap := make(map[string]struct{})
+			layersToRemove = append(layersToRemove, image.MappedTopLayers...)
+			for _, mappedTopLayer := range image.MappedTopLayers {
+				layersToRemoveMap[mappedTopLayer] = struct{}{}
+			}
+			for layer != "" {
+				if rcstore.Exists(layer) {
+					break
+				}
+				if _, used := otherImagesTopLayers[layer]; used {
+					break
+				}
+				parent := ""
+				if l, err := rlstore.Get(layer); err == nil {
+					parent = l.Parent
+				}
+				hasChildrenNotBeingRemoved := func() bool {
+					layersToCheck := []string{layer}
+					if layer == image.TopLayer {
+						layersToCheck = append(layersToCheck, image.MappedTopLayers...)
+					}
+					for _, layer := range layersToCheck {
+						if childList := childrenByParent[layer]; len(childList) > 0 {
+							for _, child := range childList {
+								if _, childIsSlatedForRemoval := layersToRemoveMap[child]; childIsSlatedForRemoval {
+									continue
+								}
+								return true
+							}
+						}
+					}
+					return false
+				}
+				if hasChildrenNotBeingRemoved() {
+					break
+				}
+				layersToRemove = append(layersToRemove, layer)
+				layersToRemoveMap[layer] = struct{}{}
+				layer = parent
+			}
+		} else {
+			return ErrNotAnImage
+		}
+		if commit {
+			for _, layer := range layersToRemove {
+				if err = rlstore.Delete(layer); err != nil {
+					return err
 				}
 			}
 		}
 		return nil
-	}
-	return ErrNotALayer
-}
-
-func (s *store) DeleteImage(id string, commit bool) (layers []string, err error) {
-	rlstore, err := s.getLayerStore()
-	if err != nil {
+	}); err != nil {
 		return nil, err
-	}
-	ristore, err := s.getImageStore()
-	if err != nil {
-		return nil, err
-	}
-	rcstore, err := s.getContainerStore()
-	if err != nil {
-		return nil, err
-	}
-
-	rlstore.Lock()
-	defer rlstore.Unlock()
-	if err := rlstore.ReloadIfChanged(); err != nil {
-		return nil, err
-	}
-	ristore.Lock()
-	defer ristore.Unlock()
-	if err := ristore.ReloadIfChanged(); err != nil {
-		return nil, err
-	}
-	rcstore.Lock()
-	defer rcstore.Unlock()
-	if err := rcstore.ReloadIfChanged(); err != nil {
-		return nil, err
-	}
-	layersToRemove := []string{}
-	if ristore.Exists(id) {
-		image, err := ristore.Get(id)
-		if err != nil {
-			return nil, err
-		}
-		id = image.ID
-		containers, err := rcstore.Containers()
-		if err != nil {
-			return nil, err
-		}
-		aContainerByImage := make(map[string]string)
-		for _, container := range containers {
-			aContainerByImage[container.ImageID] = container.ID
-		}
-		if container, ok := aContainerByImage[id]; ok {
-			return nil, fmt.Errorf("image used by %v: %w", container, ErrImageUsedByContainer)
-		}
-		images, err := ristore.Images()
-		if err != nil {
-			return nil, err
-		}
-		layers, err := rlstore.Layers()
-		if err != nil {
-			return nil, err
-		}
-		childrenByParent := make(map[string][]string)
-		for _, layer := range layers {
-			childrenByParent[layer.Parent] = append(childrenByParent[layer.Parent], layer.ID)
-		}
-		otherImagesTopLayers := make(map[string]struct{})
-		for _, img := range images {
-			if img.ID != id {
-				otherImagesTopLayers[img.TopLayer] = struct{}{}
-				for _, layerID := range img.MappedTopLayers {
-					otherImagesTopLayers[layerID] = struct{}{}
-				}
-			}
-		}
-		if commit {
-			if err = ristore.Delete(id); err != nil {
-				return nil, err
-			}
-		}
-		layer := image.TopLayer
-		layersToRemoveMap := make(map[string]struct{})
-		layersToRemove = append(layersToRemove, image.MappedTopLayers...)
-		for _, mappedTopLayer := range image.MappedTopLayers {
-			layersToRemoveMap[mappedTopLayer] = struct{}{}
-		}
-		for layer != "" {
-			if rcstore.Exists(layer) {
-				break
-			}
-			if _, used := otherImagesTopLayers[layer]; used {
-				break
-			}
-			parent := ""
-			if l, err := rlstore.Get(layer); err == nil {
-				parent = l.Parent
-			}
-			hasChildrenNotBeingRemoved := func() bool {
-				layersToCheck := []string{layer}
-				if layer == image.TopLayer {
-					layersToCheck = append(layersToCheck, image.MappedTopLayers...)
-				}
-				for _, layer := range layersToCheck {
-					if childList := childrenByParent[layer]; len(childList) > 0 {
-						for _, child := range childList {
-							if _, childIsSlatedForRemoval := layersToRemoveMap[child]; childIsSlatedForRemoval {
-								continue
-							}
-							return true
-						}
-					}
-				}
-				return false
-			}
-			if hasChildrenNotBeingRemoved() {
-				break
-			}
-			layersToRemove = append(layersToRemove, layer)
-			layersToRemoveMap[layer] = struct{}{}
-			layer = parent
-		}
-	} else {
-		return nil, ErrNotAnImage
-	}
-	if commit {
-		for _, layer := range layersToRemove {
-			if err = rlstore.Delete(layer); err != nil {
-				return nil, err
-			}
-		}
 	}
 	return layersToRemove, nil
 }
 
 func (s *store) DeleteContainer(id string) error {
-	rlstore, err := s.getLayerStore()
-	if err != nil {
-		return err
-	}
-	ristore, err := s.getImageStore()
-	if err != nil {
-		return err
-	}
-	rcstore, err := s.getContainerStore()
-	if err != nil {
-		return err
-	}
+	return s.writeToAllStores(func(rlstore rwLayerStore, ristore rwImageStore, rcstore rwContainerStore) error {
+		if !rcstore.Exists(id) {
+			return ErrNotAContainer
+		}
 
-	rlstore.Lock()
-	defer rlstore.Unlock()
-	if err := rlstore.ReloadIfChanged(); err != nil {
-		return err
-	}
-	ristore.Lock()
-	defer ristore.Unlock()
-	if err := ristore.ReloadIfChanged(); err != nil {
-		return err
-	}
-	rcstore.Lock()
-	defer rcstore.Unlock()
-	if err := rcstore.ReloadIfChanged(); err != nil {
-		return err
-	}
+		container, err := rcstore.Get(id)
+		if err != nil {
+			return ErrNotAContainer
+		}
 
-	if !rcstore.Exists(id) {
-		return ErrNotAContainer
-	}
+		errChan := make(chan error)
+		var wg sync.WaitGroup
 
-	container, err := rcstore.Get(id)
-	if err != nil {
-		return ErrNotAContainer
-	}
-
-	errChan := make(chan error)
-	var wg sync.WaitGroup
-
-	if rlstore.Exists(container.LayerID) {
+		if rlstore.Exists(container.LayerID) {
+			wg.Add(1)
+			go func() {
+				errChan <- rlstore.Delete(container.LayerID)
+				wg.Done()
+			}()
+		}
 		wg.Add(1)
 		go func() {
-			errChan <- rlstore.Delete(container.LayerID)
+			errChan <- rcstore.Delete(id)
 			wg.Done()
 		}()
-	}
-	wg.Add(1)
-	go func() {
-		errChan <- rcstore.Delete(id)
-		wg.Done()
-	}()
 
-	middleDir := s.graphDriverName + "-containers"
-	gcpath := filepath.Join(s.GraphRoot(), middleDir, container.ID)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		// attempt a simple rm -rf first
-		err := os.RemoveAll(gcpath)
-		if err == nil {
-			errChan <- nil
-			return
+		middleDir := s.graphDriverName + "-containers"
+		gcpath := filepath.Join(s.GraphRoot(), middleDir, container.ID)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// attempt a simple rm -rf first
+			err := os.RemoveAll(gcpath)
+			if err == nil {
+				errChan <- nil
+				return
+			}
+			// and if it fails get to the more complicated cleanup
+			errChan <- system.EnsureRemoveAll(gcpath)
+		}()
+
+		rcpath := filepath.Join(s.RunRoot(), middleDir, container.ID)
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			// attempt a simple rm -rf first
+			err := os.RemoveAll(rcpath)
+			if err == nil {
+				errChan <- nil
+				return
+			}
+			// and if it fails get to the more complicated cleanup
+			errChan <- system.EnsureRemoveAll(rcpath)
+		}()
+
+		go func() {
+			wg.Wait()
+			close(errChan)
+		}()
+
+		var errors []error
+		for err := range errChan {
+			if err != nil {
+				errors = append(errors, err)
+			}
 		}
-		// and if it fails get to the more complicated cleanup
-		errChan <- system.EnsureRemoveAll(gcpath)
-	}()
-
-	rcpath := filepath.Join(s.RunRoot(), middleDir, container.ID)
-	wg.Add(1)
-	go func() {
-		defer wg.Done()
-		// attempt a simple rm -rf first
-		err := os.RemoveAll(rcpath)
-		if err == nil {
-			errChan <- nil
-			return
-		}
-		// and if it fails get to the more complicated cleanup
-		errChan <- system.EnsureRemoveAll(rcpath)
-	}()
-
-	go func() {
-		wg.Wait()
-		close(errChan)
-	}()
-
-	var errors []error
-	for err := range errChan {
-		if err != nil {
-			errors = append(errors, err)
-		}
-	}
-	return multierror.Append(nil, errors...).ErrorOrNil()
+		return multierror.Append(nil, errors...).ErrorOrNil()
+	})
 }
 
 func (s *store) Delete(id string) error {
-	rlstore, err := s.getLayerStore()
-	if err != nil {
-		return err
-	}
-	ristore, err := s.getImageStore()
-	if err != nil {
-		return err
-	}
-	rcstore, err := s.getContainerStore()
-	if err != nil {
-		return err
-	}
-
-	rlstore.Lock()
-	defer rlstore.Unlock()
-	if err := rlstore.ReloadIfChanged(); err != nil {
-		return err
-	}
-	ristore.Lock()
-	defer ristore.Unlock()
-	if err := ristore.ReloadIfChanged(); err != nil {
-		return err
-	}
-	rcstore.Lock()
-	defer rcstore.Unlock()
-	if err := rcstore.ReloadIfChanged(); err != nil {
-		return err
-	}
-
-	if rcstore.Exists(id) {
-		if container, err := rcstore.Get(id); err == nil {
-			if rlstore.Exists(container.LayerID) {
-				if err = rlstore.Delete(container.LayerID); err != nil {
-					return err
+	return s.writeToAllStores(func(rlstore rwLayerStore, ristore rwImageStore, rcstore rwContainerStore) error {
+		if rcstore.Exists(id) {
+			if container, err := rcstore.Get(id); err == nil {
+				if rlstore.Exists(container.LayerID) {
+					if err = rlstore.Delete(container.LayerID); err != nil {
+						return err
+					}
+					if err = rcstore.Delete(id); err != nil {
+						return err
+					}
+					middleDir := s.graphDriverName + "-containers"
+					gcpath := filepath.Join(s.GraphRoot(), middleDir, container.ID, "userdata")
+					if err = os.RemoveAll(gcpath); err != nil {
+						return err
+					}
+					rcpath := filepath.Join(s.RunRoot(), middleDir, container.ID, "userdata")
+					if err = os.RemoveAll(rcpath); err != nil {
+						return err
+					}
+					return nil
 				}
-				if err = rcstore.Delete(id); err != nil {
-					return err
-				}
-				middleDir := s.graphDriverName + "-containers"
-				gcpath := filepath.Join(s.GraphRoot(), middleDir, container.ID, "userdata")
-				if err = os.RemoveAll(gcpath); err != nil {
-					return err
-				}
-				rcpath := filepath.Join(s.RunRoot(), middleDir, container.ID, "userdata")
-				if err = os.RemoveAll(rcpath); err != nil {
-					return err
-				}
-				return nil
+				return ErrNotALayer
 			}
-			return ErrNotALayer
 		}
-	}
-	if ristore.Exists(id) {
-		return ristore.Delete(id)
-	}
-	if rlstore.Exists(id) {
-		return rlstore.Delete(id)
-	}
-	return ErrLayerUnknown
+		if ristore.Exists(id) {
+			return ristore.Delete(id)
+		}
+		if rlstore.Exists(id) {
+			return rlstore.Delete(id)
+		}
+		return ErrLayerUnknown
+	})
 }
 
 func (s *store) Wipe() error {
-	rcstore, err := s.getContainerStore()
-	if err != nil {
-		return err
-	}
-	ristore, err := s.getImageStore()
-	if err != nil {
-		return err
-	}
-	rlstore, err := s.getLayerStore()
-	if err != nil {
-		return err
-	}
-
-	rlstore.Lock()
-	defer rlstore.Unlock()
-	if err := rlstore.ReloadIfChanged(); err != nil {
-		return err
-	}
-	ristore.Lock()
-	defer ristore.Unlock()
-	if err := ristore.ReloadIfChanged(); err != nil {
-		return err
-	}
-	rcstore.Lock()
-	defer rcstore.Unlock()
-	if err := rcstore.ReloadIfChanged(); err != nil {
-		return err
-	}
-
-	if err = rcstore.Wipe(); err != nil {
-		return err
-	}
-	if err = ristore.Wipe(); err != nil {
-		return err
-	}
-	return rlstore.Wipe()
+	return s.writeToAllStores(func(rlstore rwLayerStore, ristore rwImageStore, rcstore rwContainerStore) error {
+		if err := rcstore.Wipe(); err != nil {
+			return err
+		}
+		if err := ristore.Wipe(); err != nil {
+			return err
+		}
+		return rlstore.Wipe()
+	})
 }
 
 func (s *store) Status() ([][2]string, error) {


### PR DESCRIPTION
Factor out the repetitive “find and lock C/I/L store” parts out of the top-level `storage.Store` API into helpers: `writeTo{Container,Image,Layer}Store` and `writeToAllStores`.

Overall, this is just a refactoring that should not change behavior. The goal is to decrease the number of individual call sites to the locking code — so that the code refactored here does not need to be touched again for locking changes.

The more complex writers that don’t fit the simple locking schemes of these helpers remain unchanged; the locking in them will be updated individually.

See individual commit messages for (a bit) more detail. It might be more convenient to review this in a view that ignores whitespace changes.