### PR TITLE
Simplify the name update call stack

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -81,18 +81,8 @@ type rwContainerStore interface {
 	// convenience of the caller, nothing more.
 	Create(id string, names []string, image, layer, metadata string, options *ContainerOptions) (*Container, error)
 
-	// SetNames updates the list of names associated with the container
-	// with the specified ID.
-	// Deprecated: Prone to race conditions, suggested alternatives are `AddNames` and `RemoveNames`.
-	SetNames(id string, names []string) error
-
-	// AddNames adds the supplied values to the list of names associated with the container with
-	// the specified id.
-	AddNames(id string, names []string) error
-
-	// RemoveNames removes the supplied values from the list of names associated with the container with
-	// the specified id.
-	RemoveNames(id string, names []string) error
+	// updateNames modifies names associated with a  container based on (op, names).
+	updateNames(id string, names []string, op updateNameOperation) error
 
 	// Get retrieves information about a container given an ID or name.
 	Get(id string) (*Container, error)
@@ -386,19 +376,6 @@ func (r *containerStore) SetMetadata(id, metadata string) error {
 
 func (r *containerStore) removeName(container *Container, name string) {
 	container.Names = stringSliceWithoutValue(container.Names, name)
-}
-
-// Deprecated: Prone to race conditions, suggested alternatives are `AddNames` and `RemoveNames`.
-func (r *containerStore) SetNames(id string, names []string) error {
-	return r.updateNames(id, names, setNames)
-}
-
-func (r *containerStore) AddNames(id string, names []string) error {
-	return r.updateNames(id, names, addNames)
-}
-
-func (r *containerStore) RemoveNames(id string, names []string) error {
-	return r.updateNames(id, names, removeNames)
 }
 
 func (r *containerStore) updateNames(id string, names []string, op updateNameOperation) error {

--- a/images.go
+++ b/images.go
@@ -129,21 +129,10 @@ type rwImageStore interface {
 	// read-only) layer.  That layer can be referenced by multiple images.
 	Create(id string, names []string, layer, metadata string, created time.Time, searchableDigest digest.Digest) (*Image, error)
 
-	// SetNames replaces the list of names associated with an image with the
-	// supplied values.  The values are expected to be valid normalized
+	// updateNames modifies names associated with an image based on (op, names).
+	// The values are expected to be valid normalized
 	// named image references.
-	// Deprecated: Prone to race conditions, suggested alternatives are `AddNames` and `RemoveNames`.
-	SetNames(id string, names []string) error
-
-	// AddNames adds the supplied values to the list of names associated with the image with
-	// the specified id. The values are expected to be valid normalized
-	// named image references.
-	AddNames(id string, names []string) error
-
-	// RemoveNames removes the supplied values from the list of names associated with the image with
-	// the specified id.  The values are expected to be valid normalized
-	// named image references.
-	RemoveNames(id string, names []string) error
+	updateNames(id string, names []string, op updateNameOperation) error
 
 	// Delete removes the record of the image.
 	Delete(id string) error
@@ -514,19 +503,6 @@ func (r *imageStore) removeName(image *Image, name string) {
 
 func (i *Image) addNameToHistory(name string) {
 	i.NamesHistory = dedupeNames(append([]string{name}, i.NamesHistory...))
-}
-
-// Deprecated: Prone to race conditions, suggested alternatives are `AddNames` and `RemoveNames`.
-func (r *imageStore) SetNames(id string, names []string) error {
-	return r.updateNames(id, names, setNames)
-}
-
-func (r *imageStore) AddNames(id string, names []string) error {
-	return r.updateNames(id, names, addNames)
-}
-
-func (r *imageStore) RemoveNames(id string, names []string) error {
-	return r.updateNames(id, names, removeNames)
 }
 
 func (r *imageStore) updateNames(id string, names []string, op updateNameOperation) error {

--- a/images_test.go
+++ b/images_test.go
@@ -24,7 +24,7 @@ func addTestImage(t *testing.T, store rwImageStore, id string, names []string) {
 	)
 
 	require.Nil(t, err)
-	require.Nil(t, store.SetNames(id, names))
+	require.Nil(t, store.updateNames(id, names, setNames))
 }
 
 func TestAddNameToHistorySuccess(t *testing.T) {
@@ -72,7 +72,7 @@ func TestHistoryNames(t *testing.T) {
 	// And When
 	store.Lock()
 	defer store.Unlock()
-	require.Nil(t, store.SetNames(firstImageID, []string{"1", "2", "3", "4"}))
+	require.Nil(t, store.updateNames(firstImageID, []string{"1", "2", "3", "4"}, setNames))
 
 	// Then
 	firstImage, err = store.Get(firstImageID)
@@ -91,13 +91,13 @@ func TestHistoryNames(t *testing.T) {
 	require.Equal(t, secondImage.NamesHistory[1], "2")
 
 	// test independent add and remove operations
-	require.Nil(t, store.AddNames(firstImageID, []string{"5"}))
+	require.Nil(t, store.updateNames(firstImageID, []string{"5"}, addNames))
 	firstImage, err = store.Get(firstImageID)
 	require.Nil(t, err)
 	require.Equal(t, firstImage.NamesHistory, []string{"4", "3", "2", "1", "5"})
 
 	// history should still contain old values
-	require.Nil(t, store.RemoveNames(firstImageID, []string{"5"}))
+	require.Nil(t, store.updateNames(firstImageID, []string{"5"}, removeNames))
 	firstImage, err = store.Get(firstImageID)
 	require.Nil(t, err)
 	require.Equal(t, firstImage.NamesHistory, []string{"4", "3", "2", "1", "5"})

--- a/layers.go
+++ b/layers.go
@@ -214,18 +214,8 @@ type rwLayerStore interface {
 	// Put combines the functions of CreateWithFlags and ApplyDiff.
 	Put(id string, parent *Layer, names []string, mountLabel string, options map[string]string, moreOptions *LayerOptions, writeable bool, flags map[string]interface{}, diff io.Reader) (*Layer, int64, error)
 
-	// SetNames replaces the list of names associated with a layer with the
-	// supplied values.
-	// Deprecated: Prone to race conditions, suggested alternatives are `AddNames` and `RemoveNames`.
-	SetNames(id string, names []string) error
-
-	// AddNames adds the supplied values to the list of names associated with the layer with the
-	// specified id.
-	AddNames(id string, names []string) error
-
-	// RemoveNames remove the supplied values from the list of names associated with the layer with the
-	// specified id.
-	RemoveNames(id string, names []string) error
+	// updateNames modifies names associated with a layer based on (op, names).
+	updateNames(id string, names []string, op updateNameOperation) error
 
 	// Delete deletes a layer with the specified name or ID.
 	Delete(id string) error
@@ -1089,19 +1079,6 @@ func (r *layerStore) ParentOwners(id string) (uids, gids []int, err error) {
 
 func (r *layerStore) removeName(layer *Layer, name string) {
 	layer.Names = stringSliceWithoutValue(layer.Names, name)
-}
-
-// Deprecated: Prone to race conditions, suggested alternatives are `AddNames` and `RemoveNames`.
-func (r *layerStore) SetNames(id string, names []string) error {
-	return r.updateNames(id, names, setNames)
-}
-
-func (r *layerStore) AddNames(id string, names []string) error {
-	return r.updateNames(id, names, addNames)
-}
-
-func (r *layerStore) RemoveNames(id string, names []string) error {
-	return r.updateNames(id, names, removeNames)
 }
 
 func (r *layerStore) updateNames(id string, names []string, op updateNameOperation) error {

--- a/store.go
+++ b/store.go
@@ -2137,16 +2137,7 @@ func (s *store) updateNames(id string, names []string, op updateNameOperation) e
 			return nil
 		}
 		layerFound = true
-		switch op {
-		case setNames:
-			return rlstore.SetNames(id, deduped)
-		case removeNames:
-			return rlstore.RemoveNames(id, deduped)
-		case addNames:
-			return rlstore.AddNames(id, deduped)
-		default:
-			return errInvalidUpdateNameOperation
-		}
+		return rlstore.updateNames(id, deduped, op)
 	}); err != nil || layerFound {
 		return err
 	}
@@ -2161,16 +2152,7 @@ func (s *store) updateNames(id string, names []string, op updateNameOperation) e
 		return err
 	}
 	if ristore.Exists(id) {
-		switch op {
-		case setNames:
-			return ristore.SetNames(id, deduped)
-		case removeNames:
-			return ristore.RemoveNames(id, deduped)
-		case addNames:
-			return ristore.AddNames(id, deduped)
-		default:
-			return errInvalidUpdateNameOperation
-		}
+		return ristore.updateNames(id, deduped, op)
 	}
 
 	// Check is id refers to a RO Store
@@ -2204,16 +2186,7 @@ func (s *store) updateNames(id string, names []string, op updateNameOperation) e
 			return nil
 		}
 		containerFound = true
-		switch op {
-		case setNames:
-			return rcstore.SetNames(id, deduped)
-		case removeNames:
-			return rcstore.RemoveNames(id, deduped)
-		case addNames:
-			return rcstore.AddNames(id, deduped)
-		default:
-			return errInvalidUpdateNameOperation
-		}
+		return rcstore.updateNames(id, deduped, op)
 	}); err != nil || containerFound {
 		return err
 	}


### PR DESCRIPTION
Instead of going
-	3 store methods
-	store.updateNames+enum
-	3 sub-store methods
-	subStore.updateNames+enum
-	applyNameOperation+enum,

simplify to
-	3 store methods
-	store.updateNames+enum
-	subStore.updateNames+enum
-	applyNameOperation+enum,

Should not change behavior. Looking purely at `updateNameOperation`, invalid values would now be detected after doing more work, but there is no way for an external caller to trigger use of an invalid value anyway.
