### PR TITLE
Lock layers only for reading

### DIFF
--- a/store.go
+++ b/store.go
@@ -1286,22 +1286,14 @@ func (s *store) CreateLayer(id, parent string, names []string, mountLabel string
 
 func (s *store) CreateImage(id string, names []string, layer, metadata string, options *ImageOptions) (*Image, error) {
 	if layer != "" {
-		lstore, err := s.getLayerStore()
-		if err != nil {
-			return nil, err
-		}
-		lstores, err := s.getROLayerStores()
+		layerStores, err := s.allLayerStores()
 		if err != nil {
 			return nil, err
 		}
 		var ilayer *Layer
-		for _, s := range append([]roLayerStore{lstore}, lstores...) {
+		for _, s := range layerStores {
 			store := s
-			if store == lstore {
-				store.Lock()
-			} else {
-				store.RLock()
-			}
+			store.RLock()
 			defer store.Unlock()
 			err := store.ReloadIfChanged()
 			if err != nil {


### PR DESCRIPTION
Only lock the primary layer store for reading in `CreateImage` and `Layers`; I can’t see any reason for the exclusivity.

Cc: @nalind in case I’m missing something, primarily in `CreateImage`.