### PR TITLE
Fix layer locking in CreateContainer

### DIFF
--- a/store.go
+++ b/store.go
@@ -1249,6 +1249,11 @@ func (s *store) CreateImage(id string, names []string, layer, metadata string, o
 	return ristore.Create(id, names, layer, metadata, creationDate, options.Digest)
 }
 
+// imageTopLayerForMapping does ???
+// On entry:
+// - ristore must be locked EITHER for reading or writing
+// - rlstore must be locked for writing
+// - lstores must all be locked for reading
 func (s *store) imageTopLayerForMapping(image *Image, ristore roImageStore, createMappedLayer bool, rlstore rwLayerStore, lstores []roLayerStore, options types.IDMappingOptions) (*Layer, error) {
 	layerMatchesMappingOptions := func(layer *Layer, options types.IDMappingOptions) bool {
 		// If the driver supports shifting and the layer has no mappings, we can use it.
@@ -1270,13 +1275,6 @@ func (s *store) imageTopLayerForMapping(image *Image, ristore roImageStore, crea
 	// Locate the image's top layer and its parent, if it has one.
 	for _, s := range allStores {
 		store := s
-		if store != rlstore {
-			store.RLock()
-			defer store.Unlock()
-			if err := store.ReloadIfChanged(); err != nil {
-				return nil, err
-			}
-		}
 		// Walk the top layer list.
 		for _, candidate := range append([]string{image.TopLayer}, image.MappedTopLayers...) {
 			if cLayer, err := store.Get(candidate); err == nil {
@@ -1389,11 +1387,11 @@ func (s *store) CreateContainer(id string, names []string, image, layer, metadat
 		defer s.usernsLock.Unlock()
 	}
 
-	var imageHomeStore roImageStore
-	var istore rwImageStore
-	var istores []roImageStore
-	var lstores []roLayerStore
-	var cimage *Image
+	var imageHomeStore roImageStore // Set if image != ""
+	var istore rwImageStore         // Set, and locked read-write, if image != ""
+	var istores []roImageStore      // Set, and NOT NECESSARILY ALL locked read-only, if image != ""
+	var lstores []roLayerStore      // Set, and locked read-only, if image != ""
+	var cimage *Image               // Set if image != ""
 	if image != "" {
 		var err error
 		lstores, err = s.getROLayerStores()
@@ -1412,6 +1410,14 @@ func (s *store) CreateContainer(id string, names []string, image, layer, metadat
 		defer rlstore.Unlock()
 		if err := rlstore.ReloadIfChanged(); err != nil {
 			return nil, err
+		}
+		for _, s := range lstores {
+			store := s
+			store.RLock()
+			defer store.Unlock()
+			if err := store.ReloadIfChanged(); err != nil {
+				return nil, err
+			}
 		}
 		for _, s := range append([]roImageStore{istore}, istores...) {
 			store := s
@@ -1438,7 +1444,7 @@ func (s *store) CreateContainer(id string, names []string, image, layer, metadat
 
 	if options.AutoUserNs {
 		var err error
-		options.UIDMap, options.GIDMap, err = s.getAutoUserNS(&options.AutoUserNsOpts, cimage)
+		options.UIDMap, options.GIDMap, err = s.getAutoUserNS(&options.AutoUserNsOpts, cimage, rlstore, lstores)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
- `imageTopLayerForMapping`, in the `cParentLayer` loop, was reading all additional layer stores, although only some of them might have been locked at that point.
- `getAutoUserNS` → `getMaxSizeFromImage` was assuming that all layer stores are locked, but in fact the additional layer stores were all unlocked at that point
- `getMaxSizeFromImage` was calling `store.getLayerStore()` and the like, which could potentially trigger a reload via `graphLock` and return a _different_ store than the one that was locked

So, lock _all_ layer stores in `CreateContainer` (at least on the path where images are involved), and pass the locked layer stores down the call stack.

Also, document a bit more explicitly what's going on.