### PR TITLE
Correctly handle lockfiles without writes

### DIFF
--- a/pkg/lockfile/lockfile_unix.go
+++ b/pkg/lockfile/lockfile_unix.go
@@ -251,9 +251,10 @@ func (l *lockfile) Modified() (bool, error) {
 	if err != nil {
 		return true, err
 	}
-	if n != len(l.lw) {
-		return true, nil
-	}
+	// It is important to handle the partial read case, because
+	// the initial size of the lock file is zero, which is a valid
+	// state (no writes yet)
+	currentLW = currentLW[:n]
 	oldLW := l.lw
 	l.lw = currentLW
 	return !bytes.Equal(currentLW, oldLW), nil


### PR DESCRIPTION
A newly created lock-file is of size zero, which happens for example if you reset the storage state. In this state, lockfile.Modified() always returns true, because it thinks any short read means something changed.

I ran into this with the image store, which was empty (using images from a different store), and it keept re-reading the image store all the time even if nothing changed (i.e. both lock file reads returned zero bytes).

The proper way to handle this seems to be to compare partial reads also.

Signed-off-by: Alexander Larsson <alexl@redhat.com>