### PR TITLE
Fixup a comment in the overlay driver

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -89,7 +89,7 @@ const (
 	// is true (512 is a buffer for label metadata, 128 is the
 	// number of lowers we want to be able to use without having
 	// to use bind mounts to get all the way to the kernel limit).
-	// ((idLength + len(linkDir) + 1) * maxDepth) <= (pageSize - 512)
+	// ((idLength + len(linkDir) + 1) * 128) <= (pageSize - 512)
 	idLength = 26
 )
 


### PR DESCRIPTION
Since maxDepth is 500 and not 128, the comment doesn't make sense. Instead of defining a new named constant, just use the value, since the choice of 128 was already explained in the paragraph just above it.