### PR TITLE
Use testing.T.Setenv

### DIFF
--- a/types/options_test.go
+++ b/types/options_test.go
@@ -76,8 +76,7 @@ func TestGetRootlessStorageOpts(t *testing.T) {
 	})
 
 	t.Run("STORAGE_DRIVER=btrfs", func(t *testing.T) {
-		os.Setenv("STORAGE_DRIVER", "btrfs")
-		defer os.Unsetenv("STORAGE_DRIVER")
+		t.Setenv("STORAGE_DRIVER", "btrfs")
 		systemOpts := StoreOptions{}
 		systemOpts.GraphDriverName = vfsDriver
 		storageOpts, err := getRootlessStorageOpts(1000, systemOpts)
@@ -86,8 +85,7 @@ func TestGetRootlessStorageOpts(t *testing.T) {
 	})
 
 	t.Run("STORAGE_DRIVER=zfs", func(t *testing.T) {
-		os.Setenv("STORAGE_DRIVER", "zfs")
-		defer os.Unsetenv("STORAGE_DRIVER")
+		t.Setenv("STORAGE_DRIVER", "zfs")
 		systemOpts := StoreOptions{}
 		systemOpts.GraphDriverName = vfsDriver
 		storageOpts, err := getRootlessStorageOpts(1000, systemOpts)

--- a/types/utils_test.go
+++ b/types/utils_test.go
@@ -269,8 +269,7 @@ func TestDefaultStoreOpts(t *testing.T) {
 }
 
 func TestStorageConfOverrideEnvironmentDefaultConfigFileRootless(t *testing.T) {
-	os.Setenv("CONTAINERS_STORAGE_CONF", "default_override_test.conf")
-	defer os.Unsetenv("CONTAINERS_STORAGE_CONF")
+	t.Setenv("CONTAINERS_STORAGE_CONF", "default_override_test.conf")
 	defaultFile, err := DefaultConfigFile(true)
 
 	expectedPath := "default_override_test.conf"
@@ -280,8 +279,7 @@ func TestStorageConfOverrideEnvironmentDefaultConfigFileRootless(t *testing.T) {
 }
 
 func TestStorageConfOverrideEnvironmentDefaultConfigFileRoot(t *testing.T) {
-	os.Setenv("CONTAINERS_STORAGE_CONF", "default_override_test.conf")
-	defer os.Unsetenv("CONTAINERS_STORAGE_CONF")
+	t.Setenv("CONTAINERS_STORAGE_CONF", "default_override_test.conf")
 	defaultFile, err := DefaultConfigFile(false)
 
 	expectedPath := "default_override_test.conf"


### PR DESCRIPTION
Now that we require Go 1.17, benefit from it at least in this respect.