### PR TITLE
Move locking responsibility from store.go to the container/image/layer stores

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -235,6 +235,18 @@ func (r *containerStore) stopReading() {
 	r.lockfile.Unlock()
 }
 
+// ReloadIfChanged reloads the contents of the store from disk if it is changed.
+func (r *containerStore) ReloadIfChanged() error {
+	r.loadMut.Lock()
+	defer r.loadMut.Unlock()
+
+	modified, err := r.lockfile.Modified()
+	if err == nil && modified {
+		return r.Load()
+	}
+	return err
+}
+
 func (r *containerStore) Containers() ([]Container, error) {
 	containers := make([]Container, len(r.containers))
 	for i := range r.containers {
@@ -672,16 +684,4 @@ func (r *containerStore) Wipe() error {
 		}
 	}
 	return nil
-}
-
-// ReloadIfChanged reloads the contents of the store from disk if it is changed.
-func (r *containerStore) ReloadIfChanged() error {
-	r.loadMut.Lock()
-	defer r.loadMut.Unlock()
-
-	modified, err := r.lockfile.Modified()
-	if err == nil && modified {
-		return r.Load()
-	}
-	return err
 }

--- a/containers.go
+++ b/containers.go
@@ -86,13 +86,6 @@ type rwContainerStore interface {
 	// stopReading releases locks obtained by startReading.
 	stopReading()
 
-	// Load reloads the contents of the store from disk.  It should be called
-	// with the lock held.
-	Load() error
-
-	// ReloadIfChanged reloads the contents of the store from disk if it is changed.
-	ReloadIfChanged() error
-
 	// Save saves the contents of the store to disk.  It should be called with
 	// the lock held, and Touch() should be called afterward before releasing the
 	// lock.
@@ -256,6 +249,8 @@ func (r *containerStore) datapath(id, key string) string {
 	return filepath.Join(r.datadir(id), makeBigDataBaseName(key))
 }
 
+// Load reloads the contents of the store from disk.  It should be called
+// with the lock held.
 func (r *containerStore) Load() error {
 	needSave := false
 	rpath := r.containerspath()
@@ -677,6 +672,7 @@ func (r *containerStore) Unlock() {
 	r.lockfile.Unlock()
 }
 
+// ReloadIfChanged reloads the contents of the store from disk if it is changed.
 func (r *containerStore) ReloadIfChanged() error {
 	r.loadMut.Lock()
 	defer r.loadMut.Unlock()

--- a/containers.go
+++ b/containers.go
@@ -68,10 +68,52 @@ type Container struct {
 
 // rwContainerStore provides bookkeeping for information about Containers.
 type rwContainerStore interface {
-	fileBasedStore
 	metadataStore
 	containerBigDataStore
 	flaggableStore
+
+	// Acquire a writer lock.
+	// The default unix implementation panics if:
+	// - opening the lockfile failed
+	// - tried to lock a read-only lock-file
+	Lock()
+
+	// Unlock the lock.
+	// The default unix implementation panics if:
+	// - unlocking an unlocked lock
+	// - if the lock counter is corrupted
+	Unlock()
+
+	// Acquire a reader lock.
+	RLock()
+
+	// Touch records, for others sharing the lock, that the caller was the
+	// last writer.  It should only be called with the lock held.
+	Touch() error
+
+	// Modified() checks if the most recent writer was a party other than the
+	// last recorded writer.  It should only be called with the lock held.
+	Modified() (bool, error)
+
+	// TouchedSince() checks if the most recent writer modified the file (likely using Touch()) after the specified time.
+	TouchedSince(when time.Time) bool
+
+	// IsReadWrite() checks if the lock file is read-write
+	IsReadWrite() bool
+
+	// Locked() checks if lock is locked for writing by a thread in this process
+	Locked() bool
+	// Load reloads the contents of the store from disk.  It should be called
+	// with the lock held.
+	Load() error
+
+	// ReloadIfChanged reloads the contents of the store from disk if it is changed.
+	ReloadIfChanged() error
+
+	// Save saves the contents of the store to disk.  It should be called with
+	// the lock held, and Touch() should be called afterward before releasing the
+	// lock.
+	Save() error
 
 	// Create creates a container that has a specified ID (or generates a
 	// random one if an empty value is supplied) and optional names,

--- a/containers.go
+++ b/containers.go
@@ -72,17 +72,12 @@ type rwContainerStore interface {
 	containerBigDataStore
 	flaggableStore
 
-	// Acquire a writer lock.
-	// The default unix implementation panics if:
-	// - opening the lockfile failed
-	// - tried to lock a read-only lock-file
-	Lock()
+	// startWriting makes sure the store is fresh, and locks it for writing.
+	// If this succeeds, the caller MUST call stopWriting().
+	startWriting() error
 
-	// Unlock the lock.
-	// The default unix implementation panics if:
-	// - unlocking an unlocked lock
-	// - if the lock counter is corrupted
-	Unlock()
+	// stopWriting releases locks obtained by startWriting.
+	stopWriting()
 
 	// startReading makes sure the store is fresh, and locks it for reading.
 	// If this succeeds, the caller MUST call stopReading().
@@ -207,6 +202,30 @@ func (c *Container) MountOpts() []string {
 	default:
 		return nil
 	}
+}
+
+// startWriting makes sure the store is fresh, and locks it for writing.
+// If this succeeds, the caller MUST call stopWriting().
+func (r *containerStore) startWriting() error {
+	r.lockfile.Lock()
+	succeeded := false
+	defer func() {
+		if !succeeded {
+			r.lockfile.Unlock()
+		}
+	}()
+
+	if err := r.ReloadIfChanged(); err != nil {
+		return err
+	}
+
+	succeeded = true
+	return nil
+}
+
+// stopWriting releases locks obtained by startWriting.
+func (r *containerStore) stopWriting() {
+	r.lockfile.Unlock()
 }
 
 // startReading makes sure the store is fresh, and locks it for reading.

--- a/containers.go
+++ b/containers.go
@@ -86,11 +86,6 @@ type rwContainerStore interface {
 	// stopReading releases locks obtained by startReading.
 	stopReading()
 
-	// Save saves the contents of the store to disk.  It should be called with
-	// the lock held, and Touch() should be called afterward before releasing the
-	// lock.
-	Save() error
-
 	// Create creates a container that has a specified ID (or generates a
 	// random one if an empty value is supplied) and optional names,
 	// based on the specified image, using the specified layer as its
@@ -289,6 +284,8 @@ func (r *containerStore) Load() error {
 	return nil
 }
 
+// Save saves the contents of the store to disk.  It should be called with
+// the lock held.
 func (r *containerStore) Save() error {
 	if !r.lockfile.Locked() {
 		return errors.New("container store is not locked")

--- a/containers.go
+++ b/containers.go
@@ -94,12 +94,6 @@ type rwContainerStore interface {
 	// last recorded writer.  It should only be called with the lock held.
 	Modified() (bool, error)
 
-	// TouchedSince() checks if the most recent writer modified the file (likely using Touch()) after the specified time.
-	TouchedSince(when time.Time) bool
-
-	// IsReadWrite() checks if the lock file is read-write
-	IsReadWrite() bool
-
 	// Locked() checks if lock is locked for writing by a thread in this process
 	Locked() bool
 	// Load reloads the contents of the store from disk.  It should be called
@@ -699,14 +693,6 @@ func (r *containerStore) Touch() error {
 
 func (r *containerStore) Modified() (bool, error) {
 	return r.lockfile.Modified()
-}
-
-func (r *containerStore) IsReadWrite() bool {
-	return r.lockfile.IsReadWrite()
-}
-
-func (r *containerStore) TouchedSince(when time.Time) bool {
-	return r.lockfile.TouchedSince(when)
 }
 
 func (r *containerStore) Locked() bool {

--- a/images.go
+++ b/images.go
@@ -106,13 +106,6 @@ type roImageStore interface {
 	// stopReading releases locks obtained by startReading.
 	stopReading()
 
-	// Load reloads the contents of the store from disk.  It should be called
-	// with the lock held.
-	Load() error
-
-	// ReloadIfChanged reloads the contents of the store from disk if it is changed.
-	ReloadIfChanged() error
-
 	// Exists checks if there is an image with the given ID or name.
 	Exists(id string) bool
 
@@ -314,6 +307,8 @@ func (i *Image) recomputeDigests() error {
 	return nil
 }
 
+// Load reloads the contents of the store from disk.  It should be called
+// with the lock held.
 func (r *imageStore) Load() error {
 	shouldSave := false
 	rpath := r.imagespath()
@@ -849,6 +844,7 @@ func (r *imageStore) Unlock() {
 	r.lockfile.Unlock()
 }
 
+// ReloadIfChanged reloads the contents of the store from disk if it is changed.
 func (r *imageStore) ReloadIfChanged() error {
 	r.loadMut.Lock()
 	defer r.loadMut.Unlock()

--- a/images.go
+++ b/images.go
@@ -114,9 +114,6 @@ type roImageStore interface {
 	// last recorded writer.  It should only be called with the lock held.
 	Modified() (bool, error)
 
-	// TouchedSince() checks if the most recent writer modified the file (likely using Touch()) after the specified time.
-	TouchedSince(when time.Time) bool
-
 	// IsReadWrite() checks if the lock file is read-write
 	IsReadWrite() bool
 
@@ -876,10 +873,6 @@ func (r *imageStore) Modified() (bool, error) {
 
 func (r *imageStore) IsReadWrite() bool {
 	return r.lockfile.IsReadWrite()
-}
-
-func (r *imageStore) TouchedSince(when time.Time) bool {
-	return r.lockfile.TouchedSince(when)
 }
 
 func (r *imageStore) Locked() bool {

--- a/images.go
+++ b/images.go
@@ -136,11 +136,6 @@ type rwImageStore interface {
 	// stopWriting releases locks obtained by startWriting.
 	stopWriting()
 
-	// Save saves the contents of the store to disk.  It should be called with
-	// the lock held, and Touch() should be called afterward before releasing the
-	// lock.
-	Save() error
-
 	// Create creates an image that has a specified ID (or a random one) and
 	// optional names, using the specified layer as its topmost (hopefully
 	// read-only) layer.  That layer can be referenced by multiple images.
@@ -361,6 +356,8 @@ func (r *imageStore) Load() error {
 	return nil
 }
 
+// Save saves the contents of the store to disk.  It should be called with
+// the lock held.
 func (r *imageStore) Save() error {
 	if !r.lockfile.IsReadWrite() {
 		return fmt.Errorf("not allowed to modify the image store at %q: %w", r.imagespath(), ErrStoreIsReadOnly)

--- a/images.go
+++ b/images.go
@@ -264,6 +264,18 @@ func (r *imageStore) stopReading() {
 	r.lockfile.Unlock()
 }
 
+// ReloadIfChanged reloads the contents of the store from disk if it is changed.
+func (r *imageStore) ReloadIfChanged() error {
+	r.loadMut.Lock()
+	defer r.loadMut.Unlock()
+
+	modified, err := r.lockfile.Modified()
+	if err == nil && modified {
+		return r.Load()
+	}
+	return err
+}
+
 func (r *imageStore) Images() ([]Image, error) {
 	images := make([]Image, len(r.images))
 	for i := range r.images {
@@ -853,16 +865,4 @@ func (r *imageStore) Wipe() error {
 		}
 	}
 	return nil
-}
-
-// ReloadIfChanged reloads the contents of the store from disk if it is changed.
-func (r *imageStore) ReloadIfChanged() error {
-	r.loadMut.Lock()
-	defer r.loadMut.Unlock()
-
-	modified, err := r.lockfile.Modified()
-	if err == nil && modified {
-		return r.Load()
-	}
-	return err
 }

--- a/images.go
+++ b/images.go
@@ -99,13 +99,6 @@ type roImageStore interface {
 	roMetadataStore
 	roBigDataStore
 
-	// startWriting makes sure the store is fresh, and locks it for writing.
-	// If this succeeds, the caller MUST call stopWriting().
-	startWriting() error
-
-	// stopWriting releases locks obtained by startWriting.
-	stopWriting()
-
 	// startReading makes sure the store is fresh, and locks it for reading.
 	// If this succeeds, the caller MUST call stopReading().
 	startReading() error
@@ -159,6 +152,13 @@ type rwImageStore interface {
 	rwMetadataStore
 	rwImageBigDataStore
 	flaggableStore
+
+	// startWriting makes sure the store is fresh, and locks it for writing.
+	// If this succeeds, the caller MUST call stopWriting().
+	startWriting() error
+
+	// stopWriting releases locks obtained by startWriting.
+	stopWriting()
 
 	// Save saves the contents of the store to disk.  It should be called with
 	// the lock held, and Touch() should be called afterward before releasing the

--- a/images_test.go
+++ b/images_test.go
@@ -16,10 +16,11 @@ func newTestImageStore(t *testing.T) rwImageStore {
 }
 
 func addTestImage(t *testing.T, store rwImageStore, id string, names []string) {
-	store.Lock()
-	defer store.Unlock()
+	err := store.startWriting()
+	require.NoError(t, err)
+	defer store.stopWriting()
 
-	_, err := store.Create(
+	_, err = store.Create(
 		id, []string{}, "", "", time.Now(), digest.FromString(""),
 	)
 
@@ -70,8 +71,8 @@ func TestHistoryNames(t *testing.T) {
 	require.Equal(t, secondImage.NamesHistory[1], "2")
 
 	// And When
-	store.Lock()
-	defer store.Unlock()
+	require.NoError(t, store.startWriting())
+	defer store.stopWriting()
 	require.Nil(t, store.updateNames(firstImageID, []string{"1", "2", "3", "4"}, setNames))
 
 	// Then

--- a/layers.go
+++ b/layers.go
@@ -151,19 +151,9 @@ type roLayerStore interface {
 	// stopReading releases locks obtained by startReading.
 	stopReading()
 
-	// Touch records, for others sharing the lock, that the caller was the
-	// last writer.  It should only be called with the lock held.
-	Touch() error
-
 	// Modified() checks if the most recent writer was a party other than the
 	// last recorded writer.  It should only be called with the lock held.
 	Modified() (bool, error)
-
-	// IsReadWrite() checks if the lock file is read-write
-	IsReadWrite() bool
-
-	// Locked() checks if lock is locked for writing by a thread in this process
-	Locked() bool
 
 	// Load reloads the contents of the store from disk.  It should be called
 	// with the lock held.
@@ -427,7 +417,7 @@ func (r *layerStore) Load() error {
 	names := make(map[string]*Layer)
 	compressedsums := make(map[digest.Digest][]string)
 	uncompressedsums := make(map[digest.Digest][]string)
-	if r.IsReadWrite() {
+	if r.lockfile.IsReadWrite() {
 		selinux.ClearLabels()
 	}
 	if err = json.Unmarshal(data, &layers); len(data) == 0 || err == nil {
@@ -451,11 +441,11 @@ func (r *layerStore) Load() error {
 			if layer.MountLabel != "" {
 				selinux.ReserveLabel(layer.MountLabel)
 			}
-			layer.ReadOnly = !r.IsReadWrite()
+			layer.ReadOnly = !r.lockfile.IsReadWrite()
 		}
 		err = nil
 	}
-	if shouldSave && (!r.IsReadWrite() || !r.Locked()) {
+	if shouldSave && (!r.lockfile.IsReadWrite() || !r.lockfile.Locked()) {
 		return ErrDuplicateLayerNames
 	}
 	r.layers = layers
@@ -466,7 +456,7 @@ func (r *layerStore) Load() error {
 	r.byuncompressedsum = uncompressedsums
 
 	// Load and merge information about which layers are mounted, and where.
-	if r.IsReadWrite() {
+	if r.lockfile.IsReadWrite() {
 		r.mountsLockfile.RLock()
 		defer r.mountsLockfile.Unlock()
 		if err = r.loadMounts(); err != nil {
@@ -476,7 +466,7 @@ func (r *layerStore) Load() error {
 		// Last step: as we’re writable, try to remove anything that a previous
 		// user of this storage area marked for deletion but didn't manage to
 		// actually delete.
-		if r.Locked() {
+		if r.lockfile.Locked() {
 			for _, layer := range r.layers {
 				if layer.Flags == nil {
 					layer.Flags = make(map[string]interface{})
@@ -546,10 +536,10 @@ func (r *layerStore) Save() error {
 }
 
 func (r *layerStore) saveLayers() error {
-	if !r.IsReadWrite() {
+	if !r.lockfile.IsReadWrite() {
 		return fmt.Errorf("not allowed to modify the layer store at %q: %w", r.layerspath(), ErrStoreIsReadOnly)
 	}
-	if !r.Locked() {
+	if !r.lockfile.Locked() {
 		return errors.New("layer store is not locked for writing")
 	}
 	rpath := r.layerspath()
@@ -563,11 +553,11 @@ func (r *layerStore) saveLayers() error {
 	if err := ioutils.AtomicWriteFile(rpath, jldata, 0600); err != nil {
 		return err
 	}
-	return r.Touch()
+	return r.lockfile.Touch()
 }
 
 func (r *layerStore) saveMounts() error {
-	if !r.IsReadWrite() {
+	if !r.lockfile.IsReadWrite() {
 		return fmt.Errorf("not allowed to modify the layer store at %q: %w", r.layerspath(), ErrStoreIsReadOnly)
 	}
 	if !r.mountsLockfile.Locked() {
@@ -683,7 +673,7 @@ func (r *layerStore) Size(name string) (int64, error) {
 }
 
 func (r *layerStore) ClearFlag(id string, flag string) error {
-	if !r.IsReadWrite() {
+	if !r.lockfile.IsReadWrite() {
 		return fmt.Errorf("not allowed to clear flags on layers at %q: %w", r.layerspath(), ErrStoreIsReadOnly)
 	}
 	layer, ok := r.lookup(id)
@@ -695,7 +685,7 @@ func (r *layerStore) ClearFlag(id string, flag string) error {
 }
 
 func (r *layerStore) SetFlag(id string, flag string, value interface{}) error {
-	if !r.IsReadWrite() {
+	if !r.lockfile.IsReadWrite() {
 		return fmt.Errorf("not allowed to set flags on layers at %q: %w", r.layerspath(), ErrStoreIsReadOnly)
 	}
 	layer, ok := r.lookup(id)
@@ -770,7 +760,7 @@ func (r *layerStore) PutAdditionalLayer(id string, parentLayer *Layer, names []s
 }
 
 func (r *layerStore) Put(id string, parentLayer *Layer, names []string, mountLabel string, options map[string]string, moreOptions *LayerOptions, writeable bool, flags map[string]interface{}, diff io.Reader) (*Layer, int64, error) {
-	if !r.IsReadWrite() {
+	if !r.lockfile.IsReadWrite() {
 		return nil, -1, fmt.Errorf("not allowed to create new layers at %q: %w", r.layerspath(), ErrStoreIsReadOnly)
 	}
 	if err := os.MkdirAll(r.rundir, 0700); err != nil {
@@ -975,7 +965,7 @@ func (r *layerStore) Create(id string, parent *Layer, names []string, mountLabel
 }
 
 func (r *layerStore) Mounted(id string) (int, error) {
-	if !r.IsReadWrite() {
+	if !r.lockfile.IsReadWrite() {
 		return 0, fmt.Errorf("no mount information for layers at %q: %w", r.mountspath(), ErrStoreIsReadOnly)
 	}
 	r.mountsLockfile.RLock()
@@ -1005,7 +995,7 @@ func (r *layerStore) Mount(id string, options drivers.MountOpts) (string, error)
 
 	// You are not allowed to mount layers from readonly stores if they
 	// are not mounted read/only.
-	if !r.IsReadWrite() && !hasReadOnlyOpt(options.Options) {
+	if !r.lockfile.IsReadWrite() && !hasReadOnlyOpt(options.Options) {
 		return "", fmt.Errorf("not allowed to update mount locations for layers at %q: %w", r.mountspath(), ErrStoreIsReadOnly)
 	}
 	r.mountsLockfile.Lock()
@@ -1055,7 +1045,7 @@ func (r *layerStore) Mount(id string, options drivers.MountOpts) (string, error)
 }
 
 func (r *layerStore) Unmount(id string, force bool) (bool, error) {
-	if !r.IsReadWrite() {
+	if !r.lockfile.IsReadWrite() {
 		return false, fmt.Errorf("not allowed to update mount locations for layers at %q: %w", r.mountspath(), ErrStoreIsReadOnly)
 	}
 	r.mountsLockfile.Lock()
@@ -1093,7 +1083,7 @@ func (r *layerStore) Unmount(id string, force bool) (bool, error) {
 }
 
 func (r *layerStore) ParentOwners(id string) (uids, gids []int, err error) {
-	if !r.IsReadWrite() {
+	if !r.lockfile.IsReadWrite() {
 		return nil, nil, fmt.Errorf("no mount information for layers at %q: %w", r.mountspath(), ErrStoreIsReadOnly)
 	}
 	r.mountsLockfile.RLock()
@@ -1168,7 +1158,7 @@ func (r *layerStore) removeName(layer *Layer, name string) {
 }
 
 func (r *layerStore) updateNames(id string, names []string, op updateNameOperation) error {
-	if !r.IsReadWrite() {
+	if !r.lockfile.IsReadWrite() {
 		return fmt.Errorf("not allowed to change layer name assignments at %q: %w", r.layerspath(), ErrStoreIsReadOnly)
 	}
 	layer, ok := r.lookup(id)
@@ -1216,7 +1206,7 @@ func (r *layerStore) SetBigData(id, key string, data io.Reader) error {
 	if key == "" {
 		return fmt.Errorf("can't set empty name for layer big data item: %w", ErrInvalidBigDataName)
 	}
-	if !r.IsReadWrite() {
+	if !r.lockfile.IsReadWrite() {
 		return fmt.Errorf("not allowed to save data items associated with layers at %q: %w", r.layerspath(), ErrStoreIsReadOnly)
 	}
 	layer, ok := r.lookup(id)
@@ -1275,7 +1265,7 @@ func (r *layerStore) Metadata(id string) (string, error) {
 }
 
 func (r *layerStore) SetMetadata(id, metadata string) error {
-	if !r.IsReadWrite() {
+	if !r.lockfile.IsReadWrite() {
 		return fmt.Errorf("not allowed to modify layer metadata at %q: %w", r.layerspath(), ErrStoreIsReadOnly)
 	}
 	if layer, ok := r.lookup(id); ok {
@@ -1301,7 +1291,7 @@ func layerHasIncompleteFlag(layer *Layer) bool {
 }
 
 func (r *layerStore) deleteInternal(id string) error {
-	if !r.IsReadWrite() {
+	if !r.lockfile.IsReadWrite() {
 		return fmt.Errorf("not allowed to delete layers at %q: %w", r.layerspath(), ErrStoreIsReadOnly)
 	}
 	layer, ok := r.lookup(id)
@@ -1432,7 +1422,7 @@ func (r *layerStore) Get(id string) (*Layer, error) {
 }
 
 func (r *layerStore) Wipe() error {
-	if !r.IsReadWrite() {
+	if !r.lockfile.IsReadWrite() {
 		return fmt.Errorf("not allowed to delete layers at %q: %w", r.layerspath(), ErrStoreIsReadOnly)
 	}
 	ids := make([]string, 0, len(r.byid))
@@ -1697,7 +1687,7 @@ func (r *layerStore) ApplyDiff(to string, diff io.Reader) (size int64, err error
 }
 
 func (r *layerStore) applyDiffWithOptions(to string, layerOptions *LayerOptions, diff io.Reader) (size int64, err error) {
-	if !r.IsReadWrite() {
+	if !r.lockfile.IsReadWrite() {
 		return -1, fmt.Errorf("not allowed to modify layer contents at %q: %w", r.layerspath(), ErrStoreIsReadOnly)
 	}
 
@@ -1965,17 +1955,13 @@ func (r *layerStore) Unlock() {
 	r.lockfile.Unlock()
 }
 
-func (r *layerStore) Touch() error {
-	return r.lockfile.Touch()
-}
-
 func (r *layerStore) Modified() (bool, error) {
 	var mmodified, tmodified bool
 	lmodified, err := r.lockfile.Modified()
 	if err != nil {
 		return lmodified, err
 	}
-	if r.IsReadWrite() {
+	if r.lockfile.IsReadWrite() {
 		r.mountsLockfile.RLock()
 		defer r.mountsLockfile.Unlock()
 		mmodified, err = r.mountsLockfile.Modified()
@@ -1999,14 +1985,6 @@ func (r *layerStore) Modified() (bool, error) {
 	}
 
 	return tmodified, nil
-}
-
-func (r *layerStore) IsReadWrite() bool {
-	return r.lockfile.IsReadWrite()
-}
-
-func (r *layerStore) Locked() bool {
-	return r.lockfile.Locked()
 }
 
 func (r *layerStore) ReloadIfChanged() error {

--- a/layers.go
+++ b/layers.go
@@ -156,8 +156,12 @@ type roLayerStore interface {
 	// - if the lock counter is corrupted
 	Unlock()
 
-	// Acquire a reader lock.
-	RLock()
+	// startReading makes sure the store is fresh, and locks it for reading.
+	// If this succeeds, the caller MUST call stopReading().
+	startReading() error
+
+	// stopReading releases locks obtained by startReading.
+	stopReading()
 
 	// Touch records, for others sharing the lock, that the caller was the
 	// last writer.  It should only be called with the lock held.
@@ -344,6 +348,30 @@ func copyLayer(l *Layer) *Layer {
 		UIDs:               copyUint32Slice(l.UIDs),
 		GIDs:               copyUint32Slice(l.GIDs),
 	}
+}
+
+// startReading makes sure the store is fresh, and locks it for reading.
+// If this succeeds, the caller MUST call stopReading().
+func (r *layerStore) startReading() error {
+	r.lockfile.RLock()
+	succeeded := false
+	defer func() {
+		if !succeeded {
+			r.lockfile.Unlock()
+		}
+	}()
+
+	if err := r.ReloadIfChanged(); err != nil {
+		return err
+	}
+
+	succeeded = true
+	return nil
+}
+
+// stopReading releases locks obtained by startReading.
+func (r *layerStore) stopReading() {
+	r.lockfile.Unlock()
 }
 
 func (r *layerStore) Layers() ([]Layer, error) {

--- a/layers.go
+++ b/layers.go
@@ -159,9 +159,6 @@ type roLayerStore interface {
 	// last recorded writer.  It should only be called with the lock held.
 	Modified() (bool, error)
 
-	// TouchedSince() checks if the most recent writer modified the file (likely using Touch()) after the specified time.
-	TouchedSince(when time.Time) bool
-
 	// IsReadWrite() checks if the lock file is read-write
 	IsReadWrite() bool
 
@@ -2006,10 +2003,6 @@ func (r *layerStore) Modified() (bool, error) {
 
 func (r *layerStore) IsReadWrite() bool {
 	return r.lockfile.IsReadWrite()
-}
-
-func (r *layerStore) TouchedSince(when time.Time) bool {
-	return r.lockfile.TouchedSince(when)
 }
 
 func (r *layerStore) Locked() bool {

--- a/layers.go
+++ b/layers.go
@@ -151,10 +151,6 @@ type roLayerStore interface {
 	// stopReading releases locks obtained by startReading.
 	stopReading()
 
-	// Modified() checks if the most recent writer was a party other than the
-	// last recorded writer.  It should only be called with the lock held.
-	Modified() (bool, error)
-
 	// Load reloads the contents of the store from disk.  It should be called
 	// with the lock held.
 	Load() error
@@ -1955,6 +1951,8 @@ func (r *layerStore) Unlock() {
 	r.lockfile.Unlock()
 }
 
+// Modified() checks if the most recent writer was a party other than the
+// last recorded writer.  It should only be called with the lock held.
 func (r *layerStore) Modified() (bool, error) {
 	var mmodified, tmodified bool
 	lmodified, err := r.lockfile.Modified()

--- a/layers.go
+++ b/layers.go
@@ -151,13 +151,6 @@ type roLayerStore interface {
 	// stopReading releases locks obtained by startReading.
 	stopReading()
 
-	// Load reloads the contents of the store from disk.  It should be called
-	// with the lock held.
-	Load() error
-
-	// ReloadIfChanged reloads the contents of the store from disk if it is changed.
-	ReloadIfChanged() error
-
 	// Exists checks if a layer with the specified name or ID is known.
 	Exists(id string) bool
 
@@ -392,6 +385,8 @@ func (r *layerStore) layerspath() string {
 	return filepath.Join(r.layerdir, "layers.json")
 }
 
+// Load reloads the contents of the store from disk.  It should be called
+// with the lock held.
 func (r *layerStore) Load() error {
 	shouldSave := false
 	rpath := r.layerspath()
@@ -1985,6 +1980,7 @@ func (r *layerStore) Modified() (bool, error) {
 	return tmodified, nil
 }
 
+// ReloadIfChanged reloads the contents of the store from disk if it is changed.
 func (r *layerStore) ReloadIfChanged() error {
 	r.loadMut.Lock()
 	defer r.loadMut.Unlock()

--- a/layers.go
+++ b/layers.go
@@ -211,11 +211,6 @@ type rwLayerStore interface {
 	// stopWriting releases locks obtained by startWriting.
 	stopWriting()
 
-	// Save saves the contents of the store to disk.  It should be called with
-	// the lock held, and Touch() should be called afterward before releasing the
-	// lock.
-	Save() error
-
 	// Create creates a new layer, optionally giving it a specified ID rather than
 	// a randomly-generated one, either inheriting data from another specified
 	// layer or the empty base layer.  The new layer can optionally be given names
@@ -517,6 +512,8 @@ func (r *layerStore) loadMounts() error {
 	return err
 }
 
+// Save saves the contents of the store to disk.  It should be called with
+// the lock held.
 func (r *layerStore) Save() error {
 	r.mountsLockfile.Lock()
 	defer r.mountsLockfile.Unlock()

--- a/layers.go
+++ b/layers.go
@@ -144,13 +144,6 @@ type roLayerStore interface {
 	roMetadataStore
 	roLayerBigDataStore
 
-	// startWriting makes sure the store is fresh, and locks it for writing.
-	// If this succeeds, the caller MUST call stopWriting().
-	startWriting() error
-
-	// stopWriting releases locks obtained by startWriting.
-	stopWriting()
-
 	// startReading makes sure the store is fresh, and locks it for reading.
 	// If this succeeds, the caller MUST call stopReading().
 	startReading() error
@@ -234,6 +227,13 @@ type rwLayerStore interface {
 	rwMetadataStore
 	flaggableStore
 	rwLayerBigDataStore
+
+	// startWriting makes sure the store is fresh, and locks it for writing.
+	// If this succeeds, the caller MUST call stopWriting().
+	startWriting() error
+
+	// stopWriting releases locks obtained by startWriting.
+	stopWriting()
 
 	// Save saves the contents of the store to disk.  It should be called with
 	// the lock held, and Touch() should be called afterward before releasing the

--- a/store.go
+++ b/store.go
@@ -1664,11 +1664,10 @@ func (s *store) Metadata(id string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	cstore.RLock()
-	defer cstore.Unlock()
-	if err := cstore.ReloadIfChanged(); err != nil {
+	if err := cstore.startReading(); err != nil {
 		return "", err
 	}
+	defer cstore.stopReading()
 	if cstore.Exists(id) {
 		return cstore.Metadata(id)
 	}
@@ -1933,11 +1932,10 @@ func (s *store) ContainerSize(id string) (int64, error) {
 	if err != nil {
 		return -1, err
 	}
-	rcstore.RLock()
-	defer rcstore.Unlock()
-	if err := rcstore.ReloadIfChanged(); err != nil {
+	if err := rcstore.startReading(); err != nil {
 		return -1, err
 	}
+	defer rcstore.stopReading()
 
 	// Read the container record.
 	container, err := rcstore.Get(id)
@@ -1995,11 +1993,10 @@ func (s *store) ListContainerBigData(id string) ([]string, error) {
 		return nil, err
 	}
 
-	rcstore.RLock()
-	defer rcstore.Unlock()
-	if err := rcstore.ReloadIfChanged(); err != nil {
+	if err := rcstore.startReading(); err != nil {
 		return nil, err
 	}
+	defer rcstore.stopReading()
 
 	return rcstore.BigDataNames(id)
 }
@@ -2009,11 +2006,10 @@ func (s *store) ContainerBigDataSize(id, key string) (int64, error) {
 	if err != nil {
 		return -1, err
 	}
-	rcstore.RLock()
-	defer rcstore.Unlock()
-	if err := rcstore.ReloadIfChanged(); err != nil {
+	if err := rcstore.startReading(); err != nil {
 		return -1, err
 	}
+	defer rcstore.stopReading()
 	return rcstore.BigDataSize(id, key)
 }
 
@@ -2022,11 +2018,10 @@ func (s *store) ContainerBigDataDigest(id, key string) (digest.Digest, error) {
 	if err != nil {
 		return "", err
 	}
-	rcstore.RLock()
-	defer rcstore.Unlock()
-	if err := rcstore.ReloadIfChanged(); err != nil {
+	if err := rcstore.startReading(); err != nil {
 		return "", err
 	}
+	defer rcstore.stopReading()
 	return rcstore.BigDataDigest(id, key)
 }
 
@@ -2035,11 +2030,10 @@ func (s *store) ContainerBigData(id, key string) ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-	rcstore.RLock()
-	defer rcstore.Unlock()
-	if err := rcstore.ReloadIfChanged(); err != nil {
+	if err := rcstore.startReading(); err != nil {
 		return nil, err
 	}
+	defer rcstore.stopReading()
 	return rcstore.BigData(id, key)
 }
 
@@ -2076,11 +2070,10 @@ func (s *store) Exists(id string) bool {
 	if err != nil {
 		return false
 	}
-	rcstore.RLock()
-	defer rcstore.Unlock()
-	if err := rcstore.ReloadIfChanged(); err != nil {
+	if err := rcstore.startReading(); err != nil {
 		return false
 	}
+	defer rcstore.stopReading()
 	if rcstore.Exists(id) {
 		return true
 	}
@@ -2206,11 +2199,10 @@ func (s *store) Names(id string) ([]string, error) {
 	if err != nil {
 		return nil, err
 	}
-	rcstore.RLock()
-	defer rcstore.Unlock()
-	if err := rcstore.ReloadIfChanged(); err != nil {
+	if err := rcstore.startReading(); err != nil {
 		return nil, err
 	}
+	defer rcstore.stopReading()
 	if c, err := rcstore.Get(id); c != nil && err == nil {
 		return c.Names, nil
 	}
@@ -2244,11 +2236,10 @@ func (s *store) Lookup(name string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	cstore.RLock()
-	defer cstore.Unlock()
-	if err := cstore.ReloadIfChanged(); err != nil {
+	if err := cstore.startReading(); err != nil {
 		return "", err
 	}
+	defer cstore.stopReading()
 	if c, err := cstore.Get(name); c != nil && err == nil {
 		return c.ID, nil
 	}
@@ -2888,11 +2879,10 @@ func (s *store) ContainerParentOwners(id string) ([]int, []int, error) {
 	if err := rlstore.ReloadIfChanged(); err != nil {
 		return nil, nil, err
 	}
-	rcstore.RLock()
-	defer rcstore.Unlock()
-	if err := rcstore.ReloadIfChanged(); err != nil {
+	if err := rcstore.startReading(); err != nil {
 		return nil, nil, err
 	}
+	defer rcstore.stopReading()
 	container, err := rcstore.Get(id)
 	if err != nil {
 		return nil, nil, err
@@ -2939,11 +2929,10 @@ func (s *store) Containers() ([]Container, error) {
 		return nil, err
 	}
 
-	rcstore.RLock()
-	defer rcstore.Unlock()
-	if err := rcstore.ReloadIfChanged(); err != nil {
+	if err := rcstore.startReading(); err != nil {
 		return nil, err
 	}
+	defer rcstore.stopReading()
 
 	return rcstore.Containers()
 }
@@ -3104,11 +3093,10 @@ func (s *store) Container(id string) (*Container, error) {
 	if err != nil {
 		return nil, err
 	}
-	rcstore.RLock()
-	defer rcstore.Unlock()
-	if err := rcstore.ReloadIfChanged(); err != nil {
+	if err := rcstore.startReading(); err != nil {
 		return nil, err
 	}
+	defer rcstore.stopReading()
 
 	return rcstore.Get(id)
 }
@@ -3118,11 +3106,10 @@ func (s *store) ContainerLayerID(id string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	rcstore.RLock()
-	defer rcstore.Unlock()
-	if err := rcstore.ReloadIfChanged(); err != nil {
+	if err := rcstore.startReading(); err != nil {
 		return "", err
 	}
+	defer rcstore.stopReading()
 	container, err := rcstore.Get(id)
 	if err != nil {
 		return "", err
@@ -3139,11 +3126,10 @@ func (s *store) ContainerByLayer(id string) (*Container, error) {
 	if err != nil {
 		return nil, err
 	}
-	rcstore.RLock()
-	defer rcstore.Unlock()
-	if err := rcstore.ReloadIfChanged(); err != nil {
+	if err := rcstore.startReading(); err != nil {
 		return nil, err
 	}
+	defer rcstore.stopReading()
 	containerList, err := rcstore.Containers()
 	if err != nil {
 		return nil, err
@@ -3162,11 +3148,10 @@ func (s *store) ContainerDirectory(id string) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	rcstore.RLock()
-	defer rcstore.Unlock()
-	if err := rcstore.ReloadIfChanged(); err != nil {
+	if err := rcstore.startReading(); err != nil {
 		return "", err
 	}
+	defer rcstore.stopReading()
 
 	id, err = rcstore.Lookup(id)
 	if err != nil {
@@ -3187,11 +3172,10 @@ func (s *store) ContainerRunDirectory(id string) (string, error) {
 		return "", err
 	}
 
-	rcstore.RLock()
-	defer rcstore.Unlock()
-	if err := rcstore.ReloadIfChanged(); err != nil {
+	if err := rcstore.startReading(); err != nil {
 		return "", err
 	}
+	defer rcstore.stopReading()
 
 	id, err = rcstore.Lookup(id)
 	if err != nil {

--- a/store.go
+++ b/store.go
@@ -73,13 +73,6 @@ type rwFileBasedStore interface {
 	Save() error
 }
 
-// fileBasedStore wraps up the common methods of various types of file-based
-// data stores that we implement.
-type fileBasedStore interface {
-	roFileBasedStore
-	rwFileBasedStore
-}
-
 // roMetadataStore wraps a method for reading metadata associated with an ID.
 type roMetadataStore interface {
 	// Metadata reads metadata associated with an item with the specified ID.

--- a/store.go
+++ b/store.go
@@ -1119,11 +1119,10 @@ func (s *store) writeToContainerStore(fn func(store rwContainerStore) error) err
 		return err
 	}
 
-	store.Lock()
-	defer store.Unlock()
-	if err := store.ReloadIfChanged(); err != nil {
+	if err := store.startWriting(); err != nil {
 		return err
 	}
+	defer store.stopWriting()
 	return fn(store)
 }
 
@@ -1154,11 +1153,10 @@ func (s *store) writeToAllStores(fn func(rlstore rwLayerStore, ristore rwImageSt
 	if err := ristore.ReloadIfChanged(); err != nil {
 		return err
 	}
-	rcstore.Lock()
-	defer rcstore.Unlock()
-	if err := rcstore.ReloadIfChanged(); err != nil {
+	if err := rcstore.startWriting(); err != nil {
 		return err
 	}
+	defer rcstore.stopWriting()
 
 	return fn(rlstore, ristore, rcstore)
 }
@@ -1195,11 +1193,10 @@ func (s *store) PutLayer(id, parent string, names []string, mountLabel string, w
 	if err := rlstore.ReloadIfChanged(); err != nil {
 		return nil, -1, err
 	}
-	rcstore.Lock()
-	defer rcstore.Unlock()
-	if err := rcstore.ReloadIfChanged(); err != nil {
+	if err := rcstore.startWriting(); err != nil {
 		return nil, -1, err
 	}
+	defer rcstore.stopWriting()
 	if options == nil {
 		options = &LayerOptions{}
 	}

--- a/store.go
+++ b/store.go
@@ -50,29 +50,6 @@ var (
 	storesLock sync.Mutex
 )
 
-// roFileBasedStore wraps up the methods of the various types of file-based
-// data stores that we implement which are needed for both read-only and
-// read-write files.
-type roFileBasedStore interface {
-	Locker
-
-	// Load reloads the contents of the store from disk.  It should be called
-	// with the lock held.
-	Load() error
-
-	// ReloadIfChanged reloads the contents of the store from disk if it is changed.
-	ReloadIfChanged() error
-}
-
-// rwFileBasedStore wraps up the methods of various types of file-based data
-// stores that we implement using read-write files.
-type rwFileBasedStore interface {
-	// Save saves the contents of the store to disk.  It should be called with
-	// the lock held, and Touch() should be called afterward before releasing the
-	// lock.
-	Save() error
-}
-
 // roMetadataStore wraps a method for reading metadata associated with an ID.
 type roMetadataStore interface {
 	// Metadata reads metadata associated with an item with the specified ID.

--- a/store.go
+++ b/store.go
@@ -1092,11 +1092,10 @@ func (s *store) writeToImageStore(fn func(store rwImageStore) error) error {
 		return err
 	}
 
-	store.Lock()
-	defer store.Unlock()
-	if err := store.ReloadIfChanged(); err != nil {
+	if err := store.startWriting(); err != nil {
 		return err
 	}
+	defer store.stopWriting()
 	return fn(store)
 }
 
@@ -1147,11 +1146,10 @@ func (s *store) writeToAllStores(fn func(rlstore rwLayerStore, ristore rwImageSt
 	if err := rlstore.ReloadIfChanged(); err != nil {
 		return err
 	}
-	ristore.Lock()
-	defer ristore.Unlock()
-	if err := ristore.ReloadIfChanged(); err != nil {
+	if err := ristore.startWriting(); err != nil {
 		return err
 	}
+	defer ristore.stopWriting()
 	if err := rcstore.startWriting(); err != nil {
 		return err
 	}
@@ -1486,11 +1484,10 @@ func (s *store) CreateContainer(id string, names []string, image, layer, metadat
 		for _, s := range append([]roImageStore{istore}, istores...) {
 			store := s
 			if store == istore {
-				store.Lock()
-				defer store.Unlock()
-				if err := store.ReloadIfChanged(); err != nil {
+				if err := store.startWriting(); err != nil {
 					return nil, err
 				}
+				defer store.stopWriting()
 			} else {
 				if err := store.startReading(); err != nil {
 					return nil, err
@@ -2118,11 +2115,10 @@ func (s *store) updateNames(id string, names []string, op updateNameOperation) e
 	if err != nil {
 		return err
 	}
-	ristore.Lock()
-	defer ristore.Unlock()
-	if err := ristore.ReloadIfChanged(); err != nil {
+	if err := ristore.startWriting(); err != nil {
 		return err
 	}
+	defer ristore.stopWriting()
 	if ristore.Exists(id) {
 		return ristore.updateNames(id, deduped, op)
 	}

--- a/store.go
+++ b/store.go
@@ -2071,11 +2071,7 @@ func (s *store) Exists(id string) bool {
 		return false
 	}
 	defer rcstore.stopReading()
-	if rcstore.Exists(id) {
-		return true
-	}
-
-	return false
+	return rcstore.Exists(id)
 }
 
 func dedupeNames(names []string) []string {

--- a/store.go
+++ b/store.go
@@ -2142,9 +2142,6 @@ func (s *store) updateNames(id string, names []string, op updateNameOperation) e
 				deduped = deduped[1:]
 			}
 			_, err := ristore.Create(id, deduped, i.TopLayer, i.Metadata, i.Created, i.Digest)
-			if err == nil {
-				return ristore.Save()
-			}
 			return err
 		}
 	}


### PR DESCRIPTION
Final big part of the preparatory infrastructure work on locking.

Move the conceptual responsibility for locking/loading `containerStore`, `imageStore` and `layerStore` from the caller (`store`) into the three individual C/I/L objects. And in those objects, centralize it.

I.e. this goes from
```go
func (s *store) method(…) {
    …
    layerStore.Lock()
    defer layerStore.Unlock()
    if err := store.ReloadIfChanged(); err != nil { … }
```

to
```go
func (s *store) method(…) {
    …
    if err := layerStore.startWriting(); err != nil { … }
    defer layerStore.stopWriting()
```

that will, finally, allow us to change the design in a single place, `startReading` / `startWriting`. E.g. to:
- Do in-process locking correctly (#1332 )
- Clean up inconsistent state, and write it back to disk, even if the caller is a reader (#1136 )
- Avoid the need to call `Locked()` or `IsReadWrite` in the `Load` method, passing the values from the (now single) caller instead

---

This should not change observable behavior, apart from the “Remove a redundant rwImageStore.Save() call” commit.

See individual commit messages for details.

(The need to change every lock caller in `store` by this PR is the primary motivation for preparing #1383 / #1384 , which decreased the number of places to update.)

This is organized by the individual store, changing each one separately; i.e. each conceptual change is repeated three times. If desired, I can instead reorganize this to do same conceptual change in a single commit, across all three stores.

This ends up removing `roFileBasedStore` / `rwFileBasedStore`, and declaring the `{start,stop}{Reading,Writing}` methods in each individual store. If preferred, I could change this PR to keep (or re-introduce) those interfaces again.