### PR TITLE
Fix lockfiles never detecting changes

### DIFF
--- a/pkg/lockfile/lockfile_unix.go
+++ b/pkg/lockfile/lockfile_unix.go
@@ -246,7 +246,7 @@ func (l *lockfile) Modified() (bool, error) {
 		panic("attempted to check last-writer in lockfile without locking it first")
 	}
 	defer l.stateMutex.Unlock()
-	currentLW := make([]byte, len(l.lw))
+	currentLW := make([]byte, lastWriterIDSize)
 	n, err := unix.Pread(int(l.fd), currentLW, 0)
 	if err != nil {
 		return true, err


### PR DESCRIPTION
If we ever check the last-writer of a lock file and get back a zero value, don't only check if subsequent last-writer values match its first zero bytes, which is always true, as a test to see if the last-writer value has remained unchanged.

Related: https://github.com/containers/podman/pull/16211