### PR TITLE
Fix locking bugs

### DIFF
--- a/images.go
+++ b/images.go
@@ -221,7 +221,7 @@ func (r *imageStore) startWritingWithReload(canReload bool) error {
 // startWriting makes sure the store is fresh, and locks it for writing.
 // If this succeeds, the caller MUST call stopWriting().
 func (r *imageStore) startWriting() error {
-	return r.startWritingWithReload(false)
+	return r.startWritingWithReload(true)
 }
 
 // stopWriting releases locks obtained by startWriting.

--- a/layers.go
+++ b/layers.go
@@ -343,7 +343,7 @@ func (r *layerStore) startWritingWithReload(canReload bool) error {
 // startWriting makes sure the store is fresh, and locks it for writing.
 // If this succeeds, the caller MUST call stopWriting().
 func (r *layerStore) startWriting() error {
-	return r.startWritingWithReload(false)
+	return r.startWritingWithReload(true)
 }
 
 // stopWriting releases locks obtained by startWriting.

--- a/store.go
+++ b/store.go
@@ -1445,7 +1445,7 @@ func (s *store) CreateContainer(id string, names []string, image, layer, metadat
 			if err := store.startReading(); err != nil {
 				return nil, err
 			}
-			store.stopReading()
+			defer store.stopReading()
 		}
 		if err := istore.startWriting(); err != nil {
 			return nil, err


### PR DESCRIPTION
Don't immediately unlock the layer store after locking it.

Luckily it only matters for additional stores.