### PR TITLE
fix break during unmount

### DIFF
--- a/pkg/mount/unmount_unix.go
+++ b/pkg/mount/unmount_unix.go
@@ -22,9 +22,8 @@ func unmount(target string, flags int) error {
 			// can be returned if flags are invalid, so this code
 			// assumes that the flags value is always correct.
 			return nil
-		default:
-			break
 		}
+		break
 	}
 
 	return &mountError{


### PR DESCRIPTION
Move the break statement out of the switch to actually break out of the loop as intended.

Signed-off-by: Valentin Rothberg <vrothberg@redhat.com>