### PR TITLE
pkg/lockfile.TestLockfileMultiprocessModified(): check for wait errors

### DIFF
--- a/pkg/lockfile/lockfile_test.go
+++ b/pkg/lockfile/lockfile_test.go
@@ -639,7 +639,8 @@ func TestLockfileMultiprocessModified(t *testing.T) {
 	// Take a write lock somewhere, then see if we correctly detect changes.
 	cmd, wc, rc1, rc2, err := subTouch(lock)
 	wc.Close()
-	cmd.Wait()
+	err = cmd.Wait()
+	require.NoError(t, err)
 	rc1.Close()
 	rc2.Close()
 
@@ -652,7 +653,8 @@ func TestLockfileMultiprocessModified(t *testing.T) {
 	// Take a read lock somewhere, then see if we incorrectly detect changes.
 	cmd, wc, rc1, err = subLock(lock)
 	wc.Close()
-	cmd.Wait()
+	err = cmd.Wait()
+	require.NoError(t, err)
 	rc1.Close()
 
 	lock.Lock()


### PR DESCRIPTION
Check for errors from command Wait() methods.  Not sure how this inconsistency even landed in the first version of this test.  Addresses https://github.com/containers/storage/pull/1397#discussion_r998796886.