### PR TITLE
Only read storage.conf once

### DIFF
--- a/types/options.go
+++ b/types/options.go
@@ -35,6 +35,9 @@ const (
 var (
 	defaultStoreOptionsOnce    sync.Once
 	loadDefaultStoreOptionsErr error
+	once                       sync.Once
+	storeOptions               StoreOptions
+	storeError                 error
 )
 
 func loadDefaultStoreOptions() {
@@ -167,13 +170,28 @@ func defaultStoreOptionsIsolated(rootless bool, rootlessUID int, storageConf str
 	return storageOpts, nil
 }
 
-// DefaultStoreOptions returns the default storage ops for containers
-func DefaultStoreOptions(rootless bool, rootlessUID int) (StoreOptions, error) {
+// loadStoreOptions returns the default storage ops for containers
+func loadStoreOptions(rootless bool, rootlessUID int) (StoreOptions, error) {
 	storageConf, err := DefaultConfigFile(rootless && rootlessUID != 0)
 	if err != nil {
 		return defaultStoreOptions, err
 	}
 	return defaultStoreOptionsIsolated(rootless, rootlessUID, storageConf)
+}
+
+// UpdateOptions should be called iff container engine recieved a SIGHUP,
+// otherwise use DefaultStoreOptions
+func UpdateStoreOptions(rootless bool, rootlessUID int) (StoreOptions, error) {
+	storeOptions, storeError = loadStoreOptions(rootless, rootlessUID)
+	return storeOptions, storeError
+}
+
+// DefaultStoreOptions returns the default storage ops for containers
+func DefaultStoreOptions(rootless bool, rootlessUID int) (StoreOptions, error) {
+	once.Do(func() {
+		storeOptions, storeError = loadStoreOptions(rootless, rootlessUID)
+	})
+	return storeOptions, storeError
 }
 
 // StoreOptions is used for passing initialization options to GetStore(), for


### PR DESCRIPTION
Currently running a simple container runs and stats configuration storage.conf files multiple times on a simple container run.

This PR cuts the opens and stats in half by caching the first read. This speeds up start by about 10-20 microseconds.

If container engines want to react to storage files changing, added a new function UpdateStoreOptions to allow engines to reload options.

Fixes: https://github.com/containers/storage/issues/1403

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>