### PR TITLE
Clean up inconsistent stores also in readers

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -191,7 +191,7 @@ func (r *containerStore) startWritingWithReload(canReload bool) error {
 	}()
 
 	if canReload {
-		if err := r.reloadIfChanged(true); err != nil {
+		if _, err := r.reloadIfChanged(true); err != nil {
 			return err
 		}
 	}
@@ -215,18 +215,41 @@ func (r *containerStore) stopWriting() {
 // If this succeeds, the caller MUST call stopReading().
 func (r *containerStore) startReading() error {
 	r.lockfile.RLock()
-	succeeded := false
+	unlockFn := r.lockfile.Unlock // A function to call to clean up, or nil
 	defer func() {
-		if !succeeded {
-			r.lockfile.Unlock()
+		if unlockFn != nil {
+			unlockFn()
 		}
 	}()
 
-	if err := r.reloadIfChanged(false); err != nil {
-		return err
+	if tryLockedForWriting, err := r.reloadIfChanged(false); err != nil {
+		if !tryLockedForWriting {
+			return err
+		}
+		unlockFn()
+		unlockFn = nil
+
+		r.lockfile.Lock()
+		unlockFn = r.lockfile.Unlock
+		if _, err := r.load(true); err != nil {
+			return err
+		}
+		unlockFn()
+		unlockFn = nil
+
+		r.lockfile.RLock()
+		unlockFn = r.lockfile.Unlock
+		// We need to check for a reload reload once more because the on-disk state could have been modified
+		// after we released the lock.
+		// If that, _again_, finds inconsistent state, just give up.
+		// We could, plausibly, retry a few times, but that inconsistent state (duplicate container names)
+		// shouldn’t be saved (by correct implementations) in the first place.
+		if _, err := r.reloadIfChanged(false); err != nil {
+			return fmt.Errorf("(even after successfully cleaning up once:) %w", err)
+		}
 	}
 
-	succeeded = true
+	unlockFn = nil
 	return nil
 }
 
@@ -239,18 +262,23 @@ func (r *containerStore) stopReading() {
 //
 // The caller must hold r.lockfile for reading _or_ writing; lockedForWriting is true
 // if it is held for writing.
-func (r *containerStore) reloadIfChanged(lockedForWriting bool) error {
+//
+// If !lockedForWriting and this function fails, the return value indicates whether
+// load() with lockedForWriting could succeed. In that case the caller MUST
+// call load(), not reloadIfChanged() (because the “if changed” state will not
+// be detected again).
+func (r *containerStore) reloadIfChanged(lockedForWriting bool) (bool, error) {
 	r.loadMut.Lock()
 	defer r.loadMut.Unlock()
 
 	modified, err := r.lockfile.Modified()
 	if err != nil {
-		return err
+		return false, err
 	}
 	if modified {
 		return r.load(lockedForWriting)
 	}
-	return nil
+	return false, nil
 }
 
 func (r *containerStore) Containers() ([]Container, error) {
@@ -277,17 +305,20 @@ func (r *containerStore) datapath(id, key string) string {
 //
 // The caller must hold r.lockfile for reading _or_ writing; lockedForWriting is true
 // if it is held for writing.
-func (r *containerStore) load(lockedForWriting bool) error {
+//
+// If !lockedForWriting and this function fails, the return value indicates whether
+// retrying with lockedForWriting could succeed.
+func (r *containerStore) load(lockedForWriting bool) (bool, error) {
 	rpath := r.containerspath()
 	data, err := os.ReadFile(rpath)
 	if err != nil && !os.IsNotExist(err) {
-		return err
+		return false, err
 	}
 
 	containers := []*Container{}
 	if len(data) != 0 {
 		if err := json.Unmarshal(data, &containers); err != nil {
-			return fmt.Errorf("loading %q: %w", rpath, err)
+			return false, fmt.Errorf("loading %q: %w", rpath, err)
 		}
 	}
 	idlist := make([]string, 0, len(containers))
@@ -315,12 +346,11 @@ func (r *containerStore) load(lockedForWriting bool) error {
 	r.byname = names
 	if errorToResolveBySaving != nil {
 		if !lockedForWriting {
-			// Eventually, the callers should be modified to retry with a write lock, instead.
-			return errorToResolveBySaving
+			return true, errorToResolveBySaving
 		}
-		return r.Save()
+		return false, r.Save()
 	}
-	return nil
+	return false, nil
 }
 
 // Save saves the contents of the store to disk.  It should be called with
@@ -361,7 +391,7 @@ func newContainerStore(dir string) (rwContainerStore, error) {
 		return nil, err
 	}
 	defer cstore.stopWriting()
-	if err := cstore.load(true); err != nil {
+	if _, err := cstore.load(true); err != nil {
 		return nil, err
 	}
 	return &cstore, nil

--- a/containers.go
+++ b/containers.go
@@ -244,10 +244,13 @@ func (r *containerStore) reloadIfChanged(lockedForWriting bool) error {
 	defer r.loadMut.Unlock()
 
 	modified, err := r.lockfile.Modified()
-	if err == nil && modified {
+	if err != nil {
+		return err
+	}
+	if modified {
 		return r.load(lockedForWriting)
 	}
-	return err
+	return nil
 }
 
 func (r *containerStore) Containers() ([]Container, error) {

--- a/images.go
+++ b/images.go
@@ -208,7 +208,7 @@ func (r *imageStore) startWritingWithReload(canReload bool) error {
 	}()
 
 	if canReload {
-		if err := r.reloadIfChanged(true); err != nil {
+		if _, err := r.reloadIfChanged(true); err != nil {
 			return err
 		}
 	}
@@ -235,20 +235,43 @@ func (r *imageStore) stopWriting() {
 // should use startReading() instead.
 func (r *imageStore) startReadingWithReload(canReload bool) error {
 	r.lockfile.RLock()
-	succeeded := false
+	unlockFn := r.lockfile.Unlock // A function to call to clean up, or nil
 	defer func() {
-		if !succeeded {
-			r.lockfile.Unlock()
+		if unlockFn != nil {
+			unlockFn()
 		}
 	}()
 
 	if canReload {
-		if err := r.reloadIfChanged(false); err != nil {
-			return err
+		if tryLockedForWriting, err := r.reloadIfChanged(false); err != nil {
+			if !tryLockedForWriting {
+				return err
+			}
+			unlockFn()
+			unlockFn = nil
+
+			r.lockfile.Lock()
+			unlockFn = r.lockfile.Unlock
+			if _, err := r.load(true); err != nil {
+				return err
+			}
+			unlockFn()
+			unlockFn = nil
+
+			r.lockfile.RLock()
+			unlockFn = r.lockfile.Unlock
+			// We need to check for a reload reload once more because the on-disk state could have been modified
+			// after we released the lock.
+			// If that, _again_, finds inconsistent state, just give up.
+			// We could, plausibly, retry a few times, but that inconsistent state (duplicate image names)
+			// shouldn’t be saved (by correct implementations) in the first place.
+			if _, err := r.reloadIfChanged(false); err != nil {
+				return fmt.Errorf("(even after successfully cleaning up once:) %w", err)
+			}
 		}
 	}
 
-	succeeded = true
+	unlockFn = nil
 	return nil
 }
 
@@ -267,18 +290,23 @@ func (r *imageStore) stopReading() {
 //
 // The caller must hold r.lockfile for reading _or_ writing; lockedForWriting is true
 // if it is held for writing.
-func (r *imageStore) reloadIfChanged(lockedForWriting bool) error {
+//
+// If !lockedForWriting and this function fails, the return value indicates whether
+// retrying with lockedForWriting could succeed. In that case the caller MUST
+// call load(), not reloadIfChanged() (because the “if changed” state will not
+// be detected again).
+func (r *imageStore) reloadIfChanged(lockedForWriting bool) (bool, error) {
 	r.loadMut.Lock()
 	defer r.loadMut.Unlock()
 
 	modified, err := r.lockfile.Modified()
 	if err != nil {
-		return err
+		return false, err
 	}
 	if modified {
 		return r.load(lockedForWriting)
 	}
-	return nil
+	return false, nil
 }
 
 func (r *imageStore) Images() ([]Image, error) {
@@ -345,17 +373,20 @@ func (i *Image) recomputeDigests() error {
 //
 // The caller must hold r.lockfile for reading _or_ writing; lockedForWriting is true
 // if it is held for writing.
-func (r *imageStore) load(lockedForWriting bool) error {
+//
+// If !lockedForWriting and this function fails, the return value indicates whether
+// retrying with lockedForWriting could succeed.
+func (r *imageStore) load(lockedForWriting bool) (bool, error) {
 	rpath := r.imagespath()
 	data, err := os.ReadFile(rpath)
 	if err != nil && !os.IsNotExist(err) {
-		return err
+		return false, err
 	}
 
 	images := []*Image{}
 	if len(data) != 0 {
 		if err := json.Unmarshal(data, &images); err != nil {
-			return fmt.Errorf("loading %q: %w", rpath, err)
+			return false, fmt.Errorf("loading %q: %w", rpath, err)
 		}
 	}
 	idlist := make([]string, 0, len(images))
@@ -374,7 +405,7 @@ func (r *imageStore) load(lockedForWriting bool) error {
 		}
 		// Compute the digest list.
 		if err := image.recomputeDigests(); err != nil {
-			return fmt.Errorf("computing digests for image with ID %q (%v): %w", image.ID, image.Names, err)
+			return false, fmt.Errorf("computing digests for image with ID %q (%v): %w", image.ID, image.Names, err)
 		}
 		for _, name := range image.Names {
 			names[name] = image
@@ -386,9 +417,13 @@ func (r *imageStore) load(lockedForWriting bool) error {
 		image.ReadOnly = !r.lockfile.IsReadWrite()
 	}
 
-	if errorToResolveBySaving != nil && (!r.lockfile.IsReadWrite() || !lockedForWriting) {
-		// Eventually, the callers should be modified to retry with a write lock if IsReadWrite && !lockedForWriting, instead.
-		return errorToResolveBySaving
+	if errorToResolveBySaving != nil {
+		if !r.lockfile.IsReadWrite() {
+			return false, errorToResolveBySaving
+		}
+		if !lockedForWriting {
+			return true, errorToResolveBySaving
+		}
 	}
 	r.images = images
 	r.idindex = truncindex.NewTruncIndex(idlist) // Invalid values in idlist are ignored: they are not a reason to refuse processing the whole store.
@@ -396,9 +431,9 @@ func (r *imageStore) load(lockedForWriting bool) error {
 	r.byname = names
 	r.bydigest = digests
 	if errorToResolveBySaving != nil {
-		return r.Save()
+		return false, r.Save()
 	}
-	return nil
+	return false, nil
 }
 
 // Save saves the contents of the store to disk.  It should be called with
@@ -442,7 +477,7 @@ func newImageStore(dir string) (rwImageStore, error) {
 		return nil, err
 	}
 	defer istore.stopWriting()
-	if err := istore.load(true); err != nil {
+	if _, err := istore.load(true); err != nil {
 		return nil, err
 	}
 	return &istore, nil
@@ -465,7 +500,7 @@ func newROImageStore(dir string) (roImageStore, error) {
 		return nil, err
 	}
 	defer istore.stopReading()
-	if err := istore.load(false); err != nil {
+	if _, err := istore.load(false); err != nil {
 		return nil, err
 	}
 	return &istore, nil

--- a/images.go
+++ b/images.go
@@ -272,10 +272,13 @@ func (r *imageStore) reloadIfChanged(lockedForWriting bool) error {
 	defer r.loadMut.Unlock()
 
 	modified, err := r.lockfile.Modified()
-	if err == nil && modified {
+	if err != nil {
+		return err
+	}
+	if modified {
 		return r.load(lockedForWriting)
 	}
-	return err
+	return nil
 }
 
 func (r *imageStore) Images() ([]Image, error) {

--- a/layers.go
+++ b/layers.go
@@ -429,10 +429,13 @@ func (r *layerStore) reloadIfChanged(lockedForWriting bool) error {
 	defer r.loadMut.Unlock()
 
 	modified, err := r.Modified()
-	if err == nil && modified {
+	if err != nil {
+		return err
+	}
+	if modified {
 		return r.load(lockedForWriting)
 	}
-	return err
+	return nil
 }
 
 func (r *layerStore) Layers() ([]Layer, error) {

--- a/layers.go
+++ b/layers.go
@@ -36,6 +36,10 @@ import (
 const (
 	tarSplitSuffix = ".tar-split.gz"
 	incompleteFlag = "incomplete"
+	// maxLayerStoreCleanupIterations is the number of times we try to clean up inconsistent layer store state
+	// in readers (which, for implementation reasons, gives other writers the opportunity to create more inconsistent state)
+	// until we just give up.
+	maxLayerStoreCleanupIterations = 3
 )
 
 // A Layer is a record of a copy-on-write layer that's stored by the lower
@@ -331,7 +335,7 @@ func (r *layerStore) startWritingWithReload(canReload bool) error {
 	}()
 
 	if canReload {
-		if err := r.reloadIfChanged(true); err != nil {
+		if _, err := r.reloadIfChanged(true); err != nil {
 			return err
 		}
 	}
@@ -358,20 +362,46 @@ func (r *layerStore) stopWriting() {
 // should use startReading() instead.
 func (r *layerStore) startReadingWithReload(canReload bool) error {
 	r.lockfile.RLock()
-	succeeded := false
+	unlockFn := r.lockfile.Unlock // A function to call to clean up, or nil
 	defer func() {
-		if !succeeded {
-			r.lockfile.Unlock()
+		if unlockFn != nil {
+			unlockFn()
 		}
 	}()
 
 	if canReload {
-		if err := r.reloadIfChanged(false); err != nil {
-			return err
+		cleanupsDone := 0
+		for {
+			tryLockedForWriting, err := r.reloadIfChanged(false)
+			if err == nil {
+				break
+			}
+			if !tryLockedForWriting {
+				return err
+			}
+			if cleanupsDone >= maxLayerStoreCleanupIterations {
+				return fmt.Errorf("(even after %d cleanup attempts:) %w", cleanupsDone, err)
+			}
+			unlockFn()
+			unlockFn = nil
+
+			r.lockfile.Lock()
+			unlockFn = r.lockfile.Unlock
+			if _, err := r.load(true); err != nil {
+				return err
+			}
+			unlockFn()
+			unlockFn = nil
+
+			r.lockfile.RLock()
+			unlockFn = r.lockfile.Unlock
+			// We need to check for a reload reload again because the on-disk state could have been modified
+			// after we released the lock.
+			cleanupsDone++
 		}
 	}
 
-	succeeded = true
+	unlockFn = nil
 	return nil
 }
 
@@ -424,18 +454,23 @@ func (r *layerStore) Modified() (bool, error) {
 //
 // The caller must hold r.lockfile for reading _or_ writing; lockedForWriting is true
 // if it is held for writing.
-func (r *layerStore) reloadIfChanged(lockedForWriting bool) error {
+//
+// If !lockedForWriting and this function fails, the return value indicates whether
+// retrying with lockedForWriting could succeed. In that case the caller MUST
+// call load(), not reloadIfChanged() (because the “if changed” state will not
+// be detected again).
+func (r *layerStore) reloadIfChanged(lockedForWriting bool) (bool, error) {
 	r.loadMut.Lock()
 	defer r.loadMut.Unlock()
 
 	modified, err := r.Modified()
 	if err != nil {
-		return err
+		return false, err
 	}
 	if modified {
 		return r.load(lockedForWriting)
 	}
-	return nil
+	return false, nil
 }
 
 func (r *layerStore) Layers() ([]Layer, error) {
@@ -458,25 +493,28 @@ func (r *layerStore) layerspath() string {
 //
 // The caller must hold r.lockfile for reading _or_ writing; lockedForWriting is true
 // if it is held for writing.
-func (r *layerStore) load(lockedForWriting bool) error {
+//
+// If !lockedForWriting and this function fails, the return value indicates whether
+// retrying with lockedForWriting could succeed.
+func (r *layerStore) load(lockedForWriting bool) (bool, error) {
 	rpath := r.layerspath()
 	info, err := os.Stat(rpath)
 	if err != nil {
 		if !os.IsNotExist(err) {
-			return err
+			return false, err
 		}
 	} else {
 		r.layerspathModified = info.ModTime()
 	}
 	data, err := os.ReadFile(rpath)
 	if err != nil && !os.IsNotExist(err) {
-		return err
+		return false, err
 	}
 
 	layers := []*Layer{}
 	if len(data) != 0 {
 		if err := json.Unmarshal(data, &layers); err != nil {
-			return fmt.Errorf("loading %q: %w", rpath, err)
+			return false, fmt.Errorf("loading %q: %w", rpath, err)
 		}
 	}
 	idlist := make([]string, 0, len(layers))
@@ -517,9 +555,13 @@ func (r *layerStore) load(lockedForWriting bool) error {
 		}
 	}
 
-	if errorToResolveBySaving != nil && (!r.lockfile.IsReadWrite() || !lockedForWriting) {
-		// Eventually, the callers should be modified to retry with a write lock if IsReadWrite && !lockedForWriting, instead.
-		return errorToResolveBySaving
+	if errorToResolveBySaving != nil {
+		if !r.lockfile.IsReadWrite() {
+			return false, errorToResolveBySaving
+		}
+		if !lockedForWriting {
+			return true, errorToResolveBySaving
+		}
 	}
 	r.layers = layers
 	r.idindex = truncindex.NewTruncIndex(idlist) // Invalid values in idlist are ignored: they are not a reason to refuse processing the whole store.
@@ -533,13 +575,13 @@ func (r *layerStore) load(lockedForWriting bool) error {
 		r.mountsLockfile.RLock()
 		defer r.mountsLockfile.Unlock()
 		if err := r.loadMounts(); err != nil {
-			return err
+			return false, err
 		}
 	}
 
 	if errorToResolveBySaving != nil {
 		if !r.lockfile.IsReadWrite() {
-			return fmt.Errorf("internal error: layerStore.load has shouldSave but !r.lockfile.IsReadWrite")
+			return false, fmt.Errorf("internal error: layerStore.load has shouldSave but !r.lockfile.IsReadWrite")
 		}
 		// Last step: try to remove anything that a previous
 		// user of this storage area marked for deletion but didn't manage to
@@ -562,13 +604,13 @@ func (r *layerStore) load(lockedForWriting bool) error {
 			}
 		}
 		if err := r.saveLayers(); err != nil {
-			return err
+			return false, err
 		}
 		if incompleteDeletionErrors != nil {
-			return incompleteDeletionErrors
+			return false, incompleteDeletionErrors
 		}
 	}
-	return nil
+	return false, nil
 }
 
 func (r *layerStore) loadMounts() error {
@@ -699,7 +741,7 @@ func (s *store) newLayerStore(rundir string, layerdir string, driver drivers.Dri
 		return nil, err
 	}
 	defer rlstore.stopWriting()
-	if err := rlstore.load(true); err != nil {
+	if _, err := rlstore.load(true); err != nil {
 		return nil, err
 	}
 	return &rlstore, nil
@@ -724,7 +766,7 @@ func newROLayerStore(rundir string, layerdir string, driver drivers.Driver) (roL
 		return nil, err
 	}
 	defer rlstore.stopReading()
-	if err := rlstore.load(false); err != nil {
+	if _, err := rlstore.load(false); err != nil {
 		return nil, err
 	}
 	return &rlstore, nil

--- a/pkg/parsers/kernel/uname_unsupported.go
+++ b/pkg/parsers/kernel/uname_unsupported.go
@@ -5,7 +5,7 @@ package kernel
 
 import (
 	"fmt"
-	"runtime'
+	"runtime"
 )
 
 // A stub called by kernel_unix.go .


### PR DESCRIPTION
When we reload the store in a reader, drop the lock, lock for writing, reload again to trigger cleanup, and then lock again for reading and proceed with the originally intended operation.

This should fix #1136 , although that’s not yet proven. (It only took 6 weeks of work to get this far…)

<s>Built on top of #1399 and #1406 .</s>