### PR TITLE
Fix some warnings again

### DIFF
--- a/pkg/lockfile/lockfile_test.go
+++ b/pkg/lockfile/lockfile_test.go
@@ -633,6 +633,7 @@ func TestLockfileMultiprocessModified(t *testing.T) {
 
 	// Take a read lock somewhere, then see if we incorrectly detect changes.
 	cmd, wc, rc1, err := subLock(lock)
+	require.NoError(t, err)
 	wc.Close()
 	err = cmd.Wait()
 	require.NoError(t, err)
@@ -646,6 +647,7 @@ func TestLockfileMultiprocessModified(t *testing.T) {
 
 	// Take a write lock somewhere, then see if we correctly detect changes.
 	cmd, wc, rc1, rc2, err := subTouch(lock)
+	require.NoError(t, err)
 	wc.Close()
 	err = cmd.Wait()
 	require.NoError(t, err)
@@ -660,6 +662,7 @@ func TestLockfileMultiprocessModified(t *testing.T) {
 
 	// Take a read lock somewhere, then see if we incorrectly detect changes.
 	cmd, wc, rc1, err = subLock(lock)
+	require.NoError(t, err)
 	wc.Close()
 	err = cmd.Wait()
 	require.NoError(t, err)

--- a/pkg/system/stat_common.go
+++ b/pkg/system/stat_common.go
@@ -8,5 +8,6 @@ type platformStatT struct {
 
 // Flags return file flags if supported or zero otherwise
 func (s StatT) Flags() uint32 {
+	_ = s.platformStatT // Silence warnings that StatT.platformStatT is unused (on these platforms)
 	return 0
 }

--- a/pkg/system/stat_windows.go
+++ b/pkg/system/stat_windows.go
@@ -11,6 +11,7 @@ type StatT struct {
 	mode os.FileMode
 	size int64
 	mtim time.Time
+	platformStatT
 }
 
 // Size returns file's size.


### PR DESCRIPTION
This is my penance for not actually finishing the warning cleanup, so that I could bump the `golangci-lint` version and make these things enforced on every pull request.

So, I get to run the recent version of `golangci-lint` locally, ignore the things I didn’t fix yet, and fix the newly introduced issues after the fact.