### PR TITLE
unshare: fix creating a userns when running as root

### DIFF
--- a/pkg/unshare/unshare_linux.go
+++ b/pkg/unshare/unshare_linux.go
@@ -465,7 +465,7 @@ func bailOnError(err error, format string, a ...interface{}) { // nolint: golint
 // MaybeReexecUsingUserNamespace re-exec the process in a new namespace
 func MaybeReexecUsingUserNamespace(evenForRoot bool) {
 	// If we've already been through this once, no need to try again.
-	if os.Geteuid() == 0 && IsRootless() {
+	if os.Geteuid() == 0 && GetRootlessUID() > 0 {
 		return
 	}
 


### PR DESCRIPTION
this check would prevent the function to ever be used when running as root, since we won't check what capabilities are currently available to the process.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>