### PR TITLE
fix inconsitent go build tags

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -114,7 +114,7 @@ lint_task:
       echo "deb http://deb.debian.org/debian stretch-backports main" > /etc/apt/sources.list.d/backports.list
       apt-get update
       apt-get install -y libbtrfs-dev libdevmapper-dev
-    test_script: make lint
+    test_script: make local-validate && make lint
 
 
 # Update metadata on VM images referenced by this repository state

--- a/Makefile
+++ b/Makefile
@@ -92,7 +92,7 @@ local-test-integration: local-binary ## run the integration tests on the host (r
 test-integration: local-binary ## run the integration tests using VMs
 	$(RUNINVM) $(MAKE) local-$@
 
-local-validate: ## validate DCO and gofmt on the host
+local-validate: install.tools ## validate DCO and gofmt on the host
 	@./hack/git-validation.sh
 	@./hack/gofmt.sh
 

--- a/drivers/aufs/mount.go
+++ b/drivers/aufs/mount.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package aufs

--- a/drivers/btrfs/btrfs_test.go
+++ b/drivers/btrfs/btrfs_test.go
@@ -1,3 +1,4 @@
+//go:build linux && cgo
 // +build linux,cgo
 
 package btrfs

--- a/drivers/btrfs/dummy_unsupported.go
+++ b/drivers/btrfs/dummy_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux || !cgo
 // +build !linux !cgo
 
 package btrfs

--- a/drivers/btrfs/version.go
+++ b/drivers/btrfs/version.go
@@ -1,3 +1,4 @@
+//go:build linux && !btrfs_noversion && cgo
 // +build linux,!btrfs_noversion,cgo
 
 package btrfs

--- a/drivers/btrfs/version_test.go
+++ b/drivers/btrfs/version_test.go
@@ -1,3 +1,4 @@
+//go:build linux && !btrfs_noversion
 // +build linux,!btrfs_noversion
 
 package btrfs

--- a/drivers/devmapper/devmapper_doc.go
+++ b/drivers/devmapper/devmapper_doc.go
@@ -1,3 +1,4 @@
+//go:build linux && cgo
 // +build linux,cgo
 
 package devmapper

--- a/drivers/devmapper/devmapper_test.go
+++ b/drivers/devmapper/devmapper_test.go
@@ -1,3 +1,4 @@
+//go:build linux && cgo
 // +build linux,cgo
 
 package devmapper

--- a/drivers/devmapper/mount.go
+++ b/drivers/devmapper/mount.go
@@ -1,3 +1,4 @@
+//go:build linux && cgo
 // +build linux,cgo
 
 package devmapper

--- a/drivers/driver_solaris.go
+++ b/drivers/driver_solaris.go
@@ -1,3 +1,4 @@
+//go:build solaris && cgo
 // +build solaris,cgo
 
 package graphdriver

--- a/drivers/driver_unsupported.go
+++ b/drivers/driver_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux && !windows && !freebsd && !solaris && !darwin
 // +build !linux,!windows,!freebsd,!solaris,!darwin
 
 package graphdriver

--- a/drivers/overlay/overlay_cgo.go
+++ b/drivers/overlay/overlay_cgo.go
@@ -1,3 +1,4 @@
+//go:build linux && cgo
 // +build linux,cgo
 
 package overlay

--- a/drivers/overlay/overlay_nocgo.go
+++ b/drivers/overlay/overlay_nocgo.go
@@ -1,3 +1,4 @@
+//go:build linux && !cgo
 // +build linux,!cgo
 
 package overlay

--- a/drivers/overlay/overlay_unsupported.go
+++ b/drivers/overlay/overlay_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package overlay

--- a/drivers/register/register_aufs.go
+++ b/drivers/register/register_aufs.go
@@ -1,3 +1,4 @@
+//go:build !exclude_graphdriver_aufs && linux
 // +build !exclude_graphdriver_aufs,linux
 
 package register

--- a/drivers/register/register_btrfs.go
+++ b/drivers/register/register_btrfs.go
@@ -1,3 +1,4 @@
+//go:build !exclude_graphdriver_btrfs && linux
 // +build !exclude_graphdriver_btrfs,linux
 
 package register

--- a/drivers/register/register_devicemapper.go
+++ b/drivers/register/register_devicemapper.go
@@ -1,3 +1,4 @@
+//go:build !exclude_graphdriver_devicemapper && linux && cgo
 // +build !exclude_graphdriver_devicemapper,linux,cgo
 
 package register

--- a/drivers/register/register_overlay.go
+++ b/drivers/register/register_overlay.go
@@ -1,3 +1,4 @@
+//go:build !exclude_graphdriver_overlay && linux && cgo
 // +build !exclude_graphdriver_overlay,linux,cgo
 
 package register

--- a/drivers/register/register_zfs.go
+++ b/drivers/register/register_zfs.go
@@ -1,3 +1,4 @@
+//go:build (!exclude_graphdriver_zfs && linux) || (!exclude_graphdriver_zfs && freebsd) || solaris
 // +build !exclude_graphdriver_zfs,linux !exclude_graphdriver_zfs,freebsd solaris
 
 package register

--- a/drivers/vfs/copy_unsupported.go
+++ b/drivers/vfs/copy_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package vfs // import "github.com/containers/storage/drivers/vfs"

--- a/drivers/vfs/vfs_test.go
+++ b/drivers/vfs/vfs_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package vfs

--- a/drivers/zfs/zfs_test.go
+++ b/drivers/zfs/zfs_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package zfs

--- a/hack/git-validation.sh
+++ b/hack/git-validation.sh
@@ -1,13 +1,9 @@
 #!/usr/bin/env bash
-export PATH=${GOPATH%%:*}/bin:${PATH}
 export GIT_VALIDATION=tests/tools/build/git-validation
 if [ ! -x "$GIT_VALIDATION" ]; then
 	echo git-validation is not installed.
 	echo Try installing it with \"make install.tools\"
 	exit 1
 fi
-if test "$TRAVIS" != true ; then
-	#GITVALIDATE_EPOCH=":/git-validation epoch"
-    GITVALIDATE_EPOCH="9b6484f0058d38a1b85d8b0a3e2ca83684d02e8b"
-fi
-exec "$GIT_VALIDATION" -q -run DCO,short-subject ${GITVALIDATE_EPOCH:+-range "${GITVALIDATE_EPOCH}""..${GITVALIDATE_TIP:-@}"} ${GITVALIDATE_FLAGS}
+EPOCH_TEST_COMMIT=$(git merge-base ${DEST_BRANCH:-main} HEAD)
+exec "$GIT_VALIDATION" -q -run DCO,short-subject -range "${EPOCH_TEST_COMMIT}..HEAD"

--- a/internal/opts/opts_unix.go
+++ b/internal/opts/opts_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package opts

--- a/pkg/archive/archive_110.go
+++ b/pkg/archive/archive_110.go
@@ -1,3 +1,4 @@
+//go:build go1.10
 // +build go1.10
 
 package archive

--- a/pkg/archive/archive_19.go
+++ b/pkg/archive/archive_19.go
@@ -1,3 +1,4 @@
+//go:build !go1.10
 // +build !go1.10
 
 package archive

--- a/pkg/archive/archive_other.go
+++ b/pkg/archive/archive_other.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package archive

--- a/pkg/archive/copy_unix.go
+++ b/pkg/archive/copy_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package archive

--- a/pkg/archive/time_unsupported.go
+++ b/pkg/archive/time_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package archive

--- a/pkg/chrootarchive/chroot_unix.go
+++ b/pkg/chrootarchive/chroot_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows && !linux && !darwin
 // +build !windows,!linux,!darwin
 
 package chrootarchive

--- a/pkg/devicemapper/devmapper_log.go
+++ b/pkg/devicemapper/devmapper_log.go
@@ -1,3 +1,4 @@
+//go:build linux && cgo
 // +build linux,cgo
 
 package devicemapper

--- a/pkg/devicemapper/devmapper_wrapper.go
+++ b/pkg/devicemapper/devmapper_wrapper.go
@@ -1,3 +1,4 @@
+//go:build linux && cgo
 // +build linux,cgo
 
 package devicemapper

--- a/pkg/devicemapper/devmapper_wrapper_deferred_remove.go
+++ b/pkg/devicemapper/devmapper_wrapper_deferred_remove.go
@@ -1,3 +1,4 @@
+//go:build linux && cgo && !libdm_no_deferred_remove
 // +build linux,cgo,!libdm_no_deferred_remove
 
 package devicemapper

--- a/pkg/devicemapper/devmapper_wrapper_dynamic.go
+++ b/pkg/devicemapper/devmapper_wrapper_dynamic.go
@@ -1,3 +1,4 @@
+//go:build linux && cgo && !static_build
 // +build linux,cgo,!static_build
 
 package devicemapper

--- a/pkg/devicemapper/devmapper_wrapper_no_deferred_remove.go
+++ b/pkg/devicemapper/devmapper_wrapper_no_deferred_remove.go
@@ -1,3 +1,4 @@
+//go:build linux && cgo && libdm_no_deferred_remove
 // +build linux,cgo,libdm_no_deferred_remove
 
 package devicemapper

--- a/pkg/devicemapper/devmapper_wrapper_static.go
+++ b/pkg/devicemapper/devmapper_wrapper_static.go
@@ -1,3 +1,4 @@
+//go:build linux && cgo && static_build
 // +build linux,cgo,static_build
 
 package devicemapper

--- a/pkg/devicemapper/ioctl.go
+++ b/pkg/devicemapper/ioctl.go
@@ -1,3 +1,4 @@
+//go:build linux && cgo
 // +build linux,cgo
 
 package devicemapper

--- a/pkg/dmesg/dmesg_linux.go
+++ b/pkg/dmesg/dmesg_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package dmesg

--- a/pkg/homedir/homedir_others.go
+++ b/pkg/homedir/homedir_others.go
@@ -1,3 +1,4 @@
+//go:build !linux && !darwin && !freebsd
 // +build !linux,!darwin,!freebsd
 
 package homedir

--- a/pkg/idtools/idtools_unsupported.go
+++ b/pkg/idtools/idtools_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux || !libsubid || !cgo
 // +build !linux !libsubid !cgo
 
 package idtools

--- a/pkg/idtools/idtools_windows.go
+++ b/pkg/idtools/idtools_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package idtools

--- a/pkg/idtools/parser_test.go
+++ b/pkg/idtools/parser_test.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package idtools

--- a/pkg/ioutils/fswriters_unsupported.go
+++ b/pkg/ioutils/fswriters_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux
 // +build !linux
 
 package ioutils

--- a/pkg/loopback/attach_loopback.go
+++ b/pkg/loopback/attach_loopback.go
@@ -1,3 +1,4 @@
+//go:build linux && cgo
 // +build linux,cgo
 
 package loopback

--- a/pkg/loopback/ioctl.go
+++ b/pkg/loopback/ioctl.go
@@ -1,3 +1,4 @@
+//go:build linux && cgo
 // +build linux,cgo
 
 package loopback

--- a/pkg/loopback/loop_wrapper.go
+++ b/pkg/loopback/loop_wrapper.go
@@ -1,3 +1,4 @@
+//go:build linux && cgo
 // +build linux,cgo
 
 package loopback

--- a/pkg/loopback/loopback.go
+++ b/pkg/loopback/loopback.go
@@ -1,3 +1,4 @@
+//go:build linux && cgo
 // +build linux,cgo
 
 package loopback

--- a/pkg/mount/mount_unix_test.go
+++ b/pkg/mount/mount_unix_test.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package mount

--- a/pkg/mount/unmount_unsupported.go
+++ b/pkg/mount/unmount_unsupported.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package mount

--- a/pkg/parsers/kernel/kernel.go
+++ b/pkg/parsers/kernel/kernel.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 // Package kernel provides helper function to get, parse and compare kernel

--- a/pkg/parsers/kernel/kernel_unix.go
+++ b/pkg/parsers/kernel/kernel_unix.go
@@ -1,3 +1,4 @@
+//go:build linux || freebsd || solaris || openbsd
 // +build linux freebsd solaris openbsd
 
 // Package kernel provides helper function to get, parse and compare kernel

--- a/pkg/parsers/kernel/kernel_windows.go
+++ b/pkg/parsers/kernel/kernel_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package kernel

--- a/pkg/reexec/command_freebsd.go
+++ b/pkg/reexec/command_freebsd.go
@@ -1,3 +1,4 @@
+//go:build freebsd
 // +build freebsd
 
 package reexec

--- a/pkg/reexec/command_linux.go
+++ b/pkg/reexec/command_linux.go
@@ -1,3 +1,4 @@
+//go:build linux
 // +build linux
 
 package reexec

--- a/pkg/reexec/command_unsupported.go
+++ b/pkg/reexec/command_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux && !windows && !freebsd && !solaris && !darwin
 // +build !linux,!windows,!freebsd,!solaris,!darwin
 
 package reexec

--- a/pkg/reexec/command_windows.go
+++ b/pkg/reexec/command_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package reexec

--- a/pkg/system/chtimes_unix.go
+++ b/pkg/system/chtimes_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package system

--- a/pkg/system/chtimes_windows.go
+++ b/pkg/system/chtimes_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package system

--- a/pkg/system/lcow_unix.go
+++ b/pkg/system/lcow_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package system

--- a/pkg/system/mknod_windows.go
+++ b/pkg/system/mknod_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package system

--- a/pkg/system/path_unix.go
+++ b/pkg/system/path_unix.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package system

--- a/pkg/system/path_windows_test.go
+++ b/pkg/system/path_windows_test.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package system

--- a/pkg/system/process_unix.go
+++ b/pkg/system/process_unix.go
@@ -1,3 +1,4 @@
+//go:build linux || freebsd || solaris || darwin
 // +build linux freebsd solaris darwin
 
 package system

--- a/pkg/system/umask.go
+++ b/pkg/system/umask.go
@@ -1,3 +1,4 @@
+//go:build !windows
 // +build !windows
 
 package system

--- a/pkg/system/umask_windows.go
+++ b/pkg/system/umask_windows.go
@@ -1,3 +1,4 @@
+//go:build windows
 // +build windows
 
 package system

--- a/pkg/system/utimes_unsupported.go
+++ b/pkg/system/utimes_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux && !freebsd
 // +build !linux,!freebsd
 
 package system

--- a/pkg/system/xattrs_unsupported.go
+++ b/pkg/system/xattrs_unsupported.go
@@ -1,3 +1,4 @@
+//go:build !linux && !darwin
 // +build !linux,!darwin
 
 package system

--- a/pkg/unshare/getenv_linux_cgo.go
+++ b/pkg/unshare/getenv_linux_cgo.go
@@ -1,3 +1,4 @@
+//go:build linux && cgo
 // +build linux,cgo
 
 package unshare

--- a/pkg/unshare/getenv_linux_nocgo.go
+++ b/pkg/unshare/getenv_linux_nocgo.go
@@ -1,3 +1,4 @@
+//go:build linux && !cgo
 // +build linux,!cgo
 
 package unshare

--- a/pkg/unshare/unshare_darwin.go
+++ b/pkg/unshare/unshare_darwin.go
@@ -1,3 +1,4 @@
+//go:build darwin
 // +build darwin
 
 package unshare

--- a/pkg/unshare/unshare_gccgo.go
+++ b/pkg/unshare/unshare_gccgo.go
@@ -1,3 +1,4 @@
+//go:build linux && cgo && gccgo
 // +build linux,cgo,gccgo
 
 package unshare

--- a/tests/tools/tools.go
+++ b/tests/tools/tools.go
@@ -1,3 +1,4 @@
+//go:build tools
 // +build tools
 
 package tools


### PR DESCRIPTION
Run `go fmt ./...` which automatically adds the new build tag syntax.
This change is backwards compatible.


CI: run make local-validate

Make sure all PRs are formated with `go fmt` correctly.
I added it to the existing lint job as this seems to make the most
sense to me.