### PR TITLE
chunked: use io.github.containers

### DIFF
--- a/pkg/chunked/compression_linux.go
+++ b/pkg/chunked/compression_linux.go
@@ -148,7 +148,7 @@ func readEstargzChunkedManifest(blobStream ImageSourceSeekable, blobSize int64, 
 
 // readZstdChunkedManifest reads the zstd:chunked manifest from the seekable stream blobStream.  The blob total size must
 // be specified.
-// This function uses the io.containers.zstd-chunked. annotations when specified.
+// This function uses the io.github.containers.zstd-chunked. annotations when specified.
 func readZstdChunkedManifest(blobStream ImageSourceSeekable, blobSize int64, annotations map[string]string) ([]byte, int64, error) {
 	footerSize := int64(internal.FooterSizeSupported)
 	if blobSize <= footerSize {

--- a/pkg/chunked/internal/compression.go
+++ b/pkg/chunked/internal/compression.go
@@ -88,8 +88,8 @@ func GetType(t byte) (string, error) {
 }
 
 const (
-	ManifestChecksumKey = "io.containers.zstd-chunked.manifest-checksum"
-	ManifestInfoKey     = "io.containers.zstd-chunked.manifest-position"
+	ManifestChecksumKey = "io.github.containers.zstd-chunked.manifest-checksum"
+	ManifestInfoKey     = "io.github.containers.zstd-chunked.manifest-position"
 
 	// ManifestTypeCRFS is a manifest file compatible with the CRFS TOC file.
 	ManifestTypeCRFS = 1


### PR DESCRIPTION
we do not own containers.io so let's use io.github.containers, since the project is part of the containers organization under github.

@ktock FYI

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>