### PR TITLE
[release-1.42] overlay: fix call to clone on s390x

### DIFF
--- a/drivers/overlay/idmapped_utils.go
+++ b/drivers/overlay/idmapped_utils.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/ioutil"
 	"os"
+	"runtime"
 	"syscall"
 	"unsafe"
 
@@ -124,7 +125,14 @@ func createIDMappedMount(source, target string, pid int) error {
 // createUsernsProcess forks the current process and creates a user namespace using the specified
 // mappings.  It returns the pid of the new process.
 func createUsernsProcess(uidMaps []idtools.IDMap, gidMaps []idtools.IDMap) (int, func(), error) {
-	pid, _, err := syscall.Syscall6(uintptr(unix.SYS_CLONE), unix.CLONE_NEWUSER|uintptr(unix.SIGCHLD), 0, 0, 0, 0, 0)
+	var pid uintptr
+	var err syscall.Errno
+
+	if runtime.GOARCH == "s390x" {
+		pid, _, err = syscall.Syscall6(uintptr(unix.SYS_CLONE), 0, unix.CLONE_NEWUSER|uintptr(unix.SIGCHLD), 0, 0, 0, 0)
+	} else {
+		pid, _, err = syscall.Syscall6(uintptr(unix.SYS_CLONE), unix.CLONE_NEWUSER|uintptr(unix.SIGCHLD), 0, 0, 0, 0, 0)
+	}
 	if err != 0 {
 		return -1, nil, err
 	}


### PR DESCRIPTION
the two arguments to clone are swapped on s390x. This patch fixes the call when running on s390x.  Cherry-picked from #1418.