### PR TITLE
pkg/parsers: Enable GetKernelVersion on FreeBSD

### DIFF
--- a/pkg/parsers/kernel/uname_freebsd.go
+++ b/pkg/parsers/kernel/uname_freebsd.go
@@ -1,0 +1,17 @@
+package kernel
+
+import "golang.org/x/sys/unix"
+
+// Utsname represents the system name structure.
+// It is passthrough for unix.Utsname in order to make it portable with
+// other platforms where it is not available.
+type Utsname unix.Utsname
+
+func uname() (*unix.Utsname, error) {
+	uts := &unix.Utsname{}
+
+	if err := unix.Uname(uts); err != nil {
+		return nil, err
+	}
+	return uts, nil
+}

--- a/pkg/parsers/kernel/uname_unsupported.go
+++ b/pkg/parsers/kernel/uname_unsupported.go
@@ -1,13 +1,14 @@
-//go:build freebsd || openbsd
-// +build freebsd openbsd
+//go:build openbsd
+// +build openbsd
 
 package kernel
 
 import (
-	"errors"
+	"fmt"
+	"runtime'
 )
 
 // A stub called by kernel_unix.go .
 func uname() (*Utsname, error) {
-	return nil, errors.New("Kernel version detection is available only on linux")
+	return nil, fmt.Errorf("Kernel version detection is not available on %s", runtime.GOOS)
 }

--- a/pkg/parsers/kernel/uname_unsupported_type.go
+++ b/pkg/parsers/kernel/uname_unsupported_type.go
@@ -1,5 +1,5 @@
-//go:build !linux && !solaris
-// +build !linux,!solaris
+//go:build !linux && !solaris && !freebsd
+// +build !linux,!solaris,!freebsd
 
 package kernel
 


### PR DESCRIPTION
This is needed by podman/test/utils.

[NO NEW TESTS NEEDED]

Signed-off-by: Doug Rabson <dfr@rabson.org>