### PR TITLE
Fix a typo that breaks build / vedoring

### DIFF
--- a/pkg/parsers/kernel/uname_unsupported.go
+++ b/pkg/parsers/kernel/uname_unsupported.go
@@ -5,7 +5,7 @@ package kernel
 
 import (
 	"fmt"
-	"runtime'
+	"runtime"
 )
 
 // A stub called by kernel_unix.go .


### PR DESCRIPTION
In Buildah:
```
GO111MODULE=on go mod vendor
internal error: failed to find embedded files of github.com/containers/storage/pkg/parsers/kernel: /Users/mitr/Go/pkg/mod/github.com/mtrmac/storage@v0.0.0-20221110150436-c5fb20795713/pkg/parsers/kernel/uname_unsupported.go:8:2: string literal not terminated
```