### PR TITLE
More small locking fixes

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -629,6 +629,7 @@ func (r *containerStore) BigDataSize(id, key string) (int64, error) {
 	return -1, ErrSizeUnknown
 }
 
+// Requires startWriting. Yes, really, WRITING (see SetBigData).
 func (r *containerStore) BigDataDigest(id, key string) (digest.Digest, error) {
 	if key == "" {
 		return "", fmt.Errorf("can't retrieve digest of container big data value with empty name: %w", ErrInvalidBigDataName)

--- a/containers.go
+++ b/containers.go
@@ -601,6 +601,7 @@ func (r *containerStore) BigData(id, key string) ([]byte, error) {
 	return os.ReadFile(r.datapath(c.ID, key))
 }
 
+// Requires startWriting. Yes, really, WRITING (see SetBigData).
 func (r *containerStore) BigDataSize(id, key string) (int64, error) {
 	if key == "" {
 		return -1, fmt.Errorf("can't retrieve size of container big data with empty name: %w", ErrInvalidBigDataName)

--- a/containers.go
+++ b/containers.go
@@ -609,10 +609,7 @@ func (r *containerStore) BigDataSize(id, key string) (int64, error) {
 	if !ok {
 		return -1, ErrContainerUnknown
 	}
-	if c.BigDataSizes == nil {
-		c.BigDataSizes = make(map[string]int64)
-	}
-	if size, ok := c.BigDataSizes[key]; ok {
+	if size, ok := c.BigDataSizes[key]; ok { // This is valid, and returns ok == false, for BigDataSizes == nil.
 		return size, nil
 	}
 	if data, err := r.BigData(id, key); err == nil && data != nil {
@@ -639,10 +636,7 @@ func (r *containerStore) BigDataDigest(id, key string) (digest.Digest, error) {
 	if !ok {
 		return "", ErrContainerUnknown
 	}
-	if c.BigDataDigests == nil {
-		c.BigDataDigests = make(map[string]digest.Digest)
-	}
-	if d, ok := c.BigDataDigests[key]; ok {
+	if d, ok := c.BigDataDigests[key]; ok { // This is valid, and returns ok == false, for BigDataSizes == nil.
 		return d, nil
 	}
 	if data, err := r.BigData(id, key); err == nil && data != nil {

--- a/images.go
+++ b/images.go
@@ -763,10 +763,7 @@ func (r *imageStore) BigDataSize(id, key string) (int64, error) {
 	if !ok {
 		return -1, fmt.Errorf("locating image with ID %q: %w", id, ErrImageUnknown)
 	}
-	if image.BigDataSizes == nil {
-		image.BigDataSizes = make(map[string]int64)
-	}
-	if size, ok := image.BigDataSizes[key]; ok {
+	if size, ok := image.BigDataSizes[key]; ok { // This is valid, and returns ok == false, for BigDataSizes == nil.
 		return size, nil
 	}
 	if data, err := r.BigData(id, key); err == nil && data != nil {
@@ -783,10 +780,7 @@ func (r *imageStore) BigDataDigest(id, key string) (digest.Digest, error) {
 	if !ok {
 		return "", fmt.Errorf("locating image with ID %q: %w", id, ErrImageUnknown)
 	}
-	if image.BigDataDigests == nil {
-		image.BigDataDigests = make(map[string]digest.Digest)
-	}
-	if d, ok := image.BigDataDigests[key]; ok {
+	if d, ok := image.BigDataDigests[key]; ok { // This is valid, and returns ok == false, for BigDataDigests == nil.
 		return d, nil
 	}
 	return "", ErrDigestUnknown

--- a/images.go
+++ b/images.go
@@ -148,6 +148,9 @@ type rwImageStore interface {
 	// Delete removes the record of the image.
 	Delete(id string) error
 
+	addMappedTopLayer(id, layer string) error
+	removeMappedTopLayer(id, layer string) error
+
 	// Wipe removes records of all images.
 	Wipe() error
 }

--- a/store.go
+++ b/store.go
@@ -1968,15 +1968,13 @@ func (s *store) ContainerBigDataSize(id, key string) (int64, error) {
 }
 
 func (s *store) ContainerBigDataDigest(id, key string) (digest.Digest, error) {
-	rcstore, err := s.getContainerStore()
-	if err != nil {
-		return "", err
-	}
-	if err := rcstore.startReading(); err != nil {
-		return "", err
-	}
-	defer rcstore.stopReading()
-	return rcstore.BigDataDigest(id, key)
+	var res digest.Digest
+	err := s.writeToContainerStore(func(store rwContainerStore) error { // Yes, BigDataDigest requires a write lock.
+		var err error
+		res, err = store.BigDataDigest(id, key)
+		return err
+	})
+	return res, err
 }
 
 func (s *store) ContainerBigData(id, key string) ([]byte, error) {


### PR DESCRIPTION
- Don’t write to `BigDataDigests` and `BigDataSizes` in methods that only have a read lock — either avoid that, or use a write lock
- Stop using type checks to see if an image store is primary, or read-write; it just doesn’t work like that.

---

\*Grumble\* I’m getting increasingly desperate for #1389 . Staring at locking code trying to not make a mistake feels like writing C memory allocation code manually — however good a human can get at it, machines do it faster, and they never get tired or inattentive.