### PR TITLE
overlay: allow overlaying on top of zfs

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -356,9 +356,9 @@ func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) 
 		if opts.forceMask != nil {
 			return nil, errors.New("'force_mask' is supported only with 'mount_program'")
 		}
-		// check if they are running over btrfs, aufs, zfs, overlay, or ecryptfs
+		// check if they are running over btrfs, aufs, overlay, or ecryptfs
 		switch fsMagic {
-		case graphdriver.FsMagicAufs, graphdriver.FsMagicZfs, graphdriver.FsMagicOverlay, graphdriver.FsMagicEcryptfs:
+		case graphdriver.FsMagicAufs, graphdriver.FsMagicOverlay, graphdriver.FsMagicEcryptfs:
 			return nil, fmt.Errorf("'overlay' is not supported over %s, a mount_program is required: %w", backingFs, graphdriver.ErrIncompatibleFS)
 		}
 		if unshare.IsRootless() && isNetworkFileSystem(fsMagic) {


### PR DESCRIPTION
OpenZFS works fine as backing fs for overlayfs after the following commits:
https://github.com/openzfs/zfs/commit/e015d6cc0b60d4675c9b6d2433eed2c8ef0863e8
https://github.com/openzfs/zfs/commit/86db35c447aa3f4cc848497d78d54ec9c985d1ed
https://github.com/openzfs/zfs/commit/dbf6108b4df92341eea40d0b41792ac16eabc514

Right now this only works with OpenZFS master, but it will find its way to 2.2 eventually, and right now testing it is entirely blocked by this check.