### PR TITLE
Don't cross mount points when building change lists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,7 +60,7 @@ local-gccgo: ## build using gccgo on the host
 	GCCGO=$(PWD)/hack/gccgo-wrapper.sh $(GO) build $(MOD_VENDOR) -compiler gccgo $(BUILDFLAGS) -o containers-storage.gccgo ./cmd/containers-storage
 
 local-cross: ## cross build the binaries for arm, darwin, and freebsd
-	@for target in linux/amd64 linux/386 linux/arm linux/arm64 linux/ppc64 linux/ppc64le darwin/amd64 windows/amd64 freebsd/amd64 freebsd/arm64 ; do \
+	@for target in linux/amd64 linux/386 linux/arm linux/arm64 linux/ppc64 linux/ppc64le linux/s390x linux/mips linux/mipsle linux/mips64 linux/mips64le darwin/amd64 windows/amd64 freebsd/amd64 freebsd/arm64 ; do \
 		os=`echo $${target} | cut -f1 -d/` ; \
 		arch=`echo $${target} | cut -f2 -d/` ; \
 		suffix=$${os}.$${arch} ; \

--- a/pkg/system/stat_freebsd.go
+++ b/pkg/system/stat_freebsd.go
@@ -18,7 +18,9 @@ func fromStatT(s *syscall.Stat_t) (*StatT, error) {
 		uid:  s.Uid,
 		gid:  s.Gid,
 		rdev: uint64(s.Rdev),
-		mtim: s.Mtimespec}
+		mtim: s.Mtimespec,
+		dev:  s.Dev}
 	st.flags = s.Flags
+	st.dev = s.Dev
 	return st, nil
 }

--- a/pkg/system/stat_linux.go
+++ b/pkg/system/stat_linux.go
@@ -9,7 +9,8 @@ func fromStatT(s *syscall.Stat_t) (*StatT, error) {
 		uid:  s.Uid,
 		gid:  s.Gid,
 		rdev: uint64(s.Rdev),
-		mtim: s.Mtim}, nil
+		mtim: s.Mtim,
+		dev:  uint64(s.Dev)}, nil
 }
 
 // FromStatT converts a syscall.Stat_t type to a system.Stat_t type

--- a/pkg/system/stat_unix.go
+++ b/pkg/system/stat_unix.go
@@ -18,6 +18,7 @@ type StatT struct {
 	rdev uint64
 	size int64
 	mtim syscall.Timespec
+	dev  uint64
 	platformStatT
 }
 
@@ -49,6 +50,11 @@ func (s StatT) Size() int64 {
 // Mtim returns file's last modification time.
 func (s StatT) Mtim() syscall.Timespec {
 	return s.mtim
+}
+
+// Dev returns a unique identifier for owning filesystem
+func (s StatT) Dev() uint64 {
+	return s.dev
 }
 
 // Stat takes a path to a file and returns

--- a/pkg/system/stat_windows.go
+++ b/pkg/system/stat_windows.go
@@ -43,6 +43,11 @@ func (s StatT) GID() uint32 {
 	return 0
 }
 
+// Dev returns a unique identifier for owning filesystem
+func (s StatT) Dev() uint64 {
+	return 0
+}
+
 // Stat takes a path to a file and returns
 // a system.StatT type pertaining to that file.
 //


### PR DESCRIPTION
This is needed on FreeBSD to avoid traversing into /dev or mounted volumes when compiling diff sets for running containers. I'm not sure this approach is the best one but I can't think of a scenario where crossing mount points is intended when comparing storage layers.
