### PR TITLE
Document and improve store locking

### DIFF
--- a/layers.go
+++ b/layers.go
@@ -299,6 +299,9 @@ type rwLayerStore interface {
 
 	// Clean up unreferenced layers
 	GarbageCollect() error
+
+	// supportsShifting() returns true if the driver.Driver.SupportsShifting().
+	supportsShifting() bool
 }
 
 type layerStore struct {
@@ -2232,6 +2235,10 @@ func (r *layerStore) LayersByCompressedDigest(d digest.Digest) ([]Layer, error) 
 
 func (r *layerStore) LayersByUncompressedDigest(d digest.Digest) ([]Layer, error) {
 	return r.layersByDigestMap(r.byuncompressedsum, d)
+}
+
+func (r *layerStore) supportsShifting() bool {
+	return r.driver.SupportsShifting()
 }
 
 func closeAll(closes ...func() error) (rErr error) {

--- a/store.go
+++ b/store.go
@@ -580,6 +580,15 @@ type ContainerOptions struct {
 }
 
 type store struct {
+	// # Locking hierarchy:
+	// These locks do not all need to be held simultaneously, but if some code does need to lock more than one, it MUST do so in this order:
+	// - graphLock
+	// - layerStore.start{Reading,Writing}
+	// - roLayerStores[].startReading (in the order of the items of the roLayerStores array)
+	// - imageStore.start{Reading,Writing}
+	// - roImageStores[].startReading (in the order of the items of the roImageStores array)
+	// - containerStore.start{Reading,Writing}
+
 	// The following fields are only set when constructing store, and must never be modified afterwards.
 	// They are safe to access without any other locking.
 	runRoot         string

--- a/store.go
+++ b/store.go
@@ -1332,10 +1332,10 @@ func (s *store) CreateImage(id string, names []string, layer, metadata string, o
 // imageTopLayerForMapping does ???
 // On entry:
 // - ristore must be locked EITHER for reading or writing
-// - primaryImageStore must be locked for writing; it might be identical to ristore.
+// - s.imageStore must be locked for writing; it might be identical to ristore.
 // - rlstore must be locked for writing
 // - lstores must all be locked for reading
-func (s *store) imageTopLayerForMapping(image *Image, ristore roImageStore, primaryImageStore rwImageStore, rlstore rwLayerStore, lstores []roLayerStore, options types.IDMappingOptions) (*Layer, error) {
+func (s *store) imageTopLayerForMapping(image *Image, ristore roImageStore, rlstore rwLayerStore, lstores []roLayerStore, options types.IDMappingOptions) (*Layer, error) {
 	layerMatchesMappingOptions := func(layer *Layer, options types.IDMappingOptions) bool {
 		// If the driver supports shifting and the layer has no mappings, we can use it.
 		if canUseShifting(rlstore, options.UIDMap, options.GIDMap) && len(layer.UIDMap) == 0 && len(layer.GIDMap) == 0 {
@@ -1354,7 +1354,7 @@ func (s *store) imageTopLayerForMapping(image *Image, ristore roImageStore, prim
 	var layer, parentLayer *Layer
 	allStores := append([]roLayerStore{rlstore}, lstores...)
 	// Locate the image's top layer and its parent, if it has one.
-	createMappedLayer := ristore == primaryImageStore
+	createMappedLayer := ristore == s.imageStore
 	for _, s := range allStores {
 		store := s
 		// Walk the top layer list.
@@ -1429,8 +1429,8 @@ func (s *store) imageTopLayerForMapping(image *Image, ristore roImageStore, prim
 	if err != nil {
 		return nil, fmt.Errorf("creating an ID-mapped copy of layer %q: %w", layer.ID, err)
 	}
-	// By construction, createMappedLayer can only be true if ristore == primaryImageStore.
-	if err = primaryImageStore.addMappedTopLayer(image.ID, mappedLayer.ID); err != nil {
+	// By construction, createMappedLayer can only be true if ristore == s.imageStore.
+	if err = s.imageStore.addMappedTopLayer(image.ID, mappedLayer.ID); err != nil {
 		if err2 := rlstore.Delete(mappedLayer.ID); err2 != nil {
 			err = fmt.Errorf("deleting layer %q: %v: %w", mappedLayer.ID, err2, err)
 		}
@@ -1523,7 +1523,7 @@ func (s *store) CreateContainer(id string, names []string, image, layer, metadat
 	idMappingsOptions := options.IDMappingOptions
 	if image != "" {
 		if cimage.TopLayer != "" {
-			ilayer, err := s.imageTopLayerForMapping(cimage, imageHomeStore, s.imageStore, rlstore, lstores, idMappingsOptions)
+			ilayer, err := s.imageTopLayerForMapping(cimage, imageHomeStore, rlstore, lstores, idMappingsOptions)
 			if err != nil {
 				return nil, err
 			}

--- a/store.go
+++ b/store.go
@@ -1101,8 +1101,8 @@ func (s *store) writeToLayerStore(fn func(store rwLayerStore) error) error {
 
 // allImageStores returns a list of all image store objects used by the Store.
 // This is a convenience method for read-only users of the Store.
-func (s *store) allImageStores() ([]roImageStore, error) {
-	return append([]roImageStore{s.imageStore}, s.roImageStores...), nil
+func (s *store) allImageStores() []roImageStore {
+	return append([]roImageStore{s.imageStore}, s.roImageStores...)
 }
 
 // readAllImageStores processes allImageStores() in order:
@@ -1125,11 +1125,7 @@ func (s *store) allImageStores() ([]roImageStore, error) {
 //		return res, err
 //	}
 func (s *store) readAllImageStores(fn func(store roImageStore) (bool, error)) (bool, error) {
-	ImageStores, err := s.allImageStores()
-	if err != nil {
-		return true, err
-	}
-	for _, s := range ImageStores {
+	for _, s := range s.allImageStores() {
 		store := s
 		if err := store.startReading(); err != nil {
 			return true, err
@@ -1821,14 +1817,10 @@ func (s *store) ImageSize(id string) (int64, error) {
 		defer store.stopReading()
 	}
 
-	imageStores, err := s.allImageStores()
-	if err != nil {
-		return -1, err
-	}
 	// Look for the image's record.
 	var imageStore roBigDataStore
 	var image *Image
-	for _, s := range imageStores {
+	for _, s := range s.allImageStores() {
 		store := s
 		if err := store.startReading(); err != nil {
 			return -1, err

--- a/store.go
+++ b/store.go
@@ -721,18 +721,6 @@ func GetStore(options types.StoreOptions) (Store, error) {
 		additionalUIDs: nil,
 		additionalGIDs: nil,
 	}
-	if err := func() error { // A scope for defer
-		s.graphLock.Lock()
-		defer s.graphLock.Unlock()
-		lastWrite, err := s.graphLock.GetLastWrite()
-		if err != nil {
-			return err
-		}
-		s.graphLockLastWrite = lastWrite
-		return nil
-	}(); err != nil {
-		return nil, err
-	}
 	if err := s.load(); err != nil {
 		return nil, err
 	}
@@ -808,8 +796,11 @@ func (s *store) load() error {
 	if err := func() error { // A scope for defer
 		s.graphLock.Lock()
 		defer s.graphLock.Unlock()
-
-		var err error
+		lastWrite, err := s.graphLock.GetLastWrite()
+		if err != nil {
+			return err
+		}
+		s.graphLockLastWrite = lastWrite
 		driver, err = s.createGraphDriverLocked()
 		if err != nil {
 			return err


### PR DESCRIPTION
Motivated by #1433 seeing unexpected layer store refreshes / existence of parallel layer stores for the same directory in a single process, this:
- Attempts to document the concurrency design and rules for accessing `store` fields and `store.graphLock`. I’m not at all sure it’s correct, at least I want to establish the precedent that the design is expected to be documented
- Consolidates the uses of `store.graphLock` to guard against `Shutdown` calls to `store.startUsingGraphDriver` / `store.stopUsingGraphDriver` helpers, instead of copy&pasted and code slowly deviating over time. This is similar to the CIL`Store.startWriting` approach.
- Fixes users that specifically rely on `store.graphLock` and can trigger a graph driver reload to actually use the reloaded graph driver for their `layerStore` operations, instead of using an obsolete `layerStore` (and graph driver) instance immediately after the reload.
- Introduces a larger set of helpers to obtain the `layerStore` instances for the primary and additional stores, so that every operation only locks `graphLock` once instead of up to three times.
- OTOH, removes helpers to obtain `imageStore` and `containerStore` instances; the users can just refer to a constant field, so they are modified to do that, removing many error checks and local variables
- Fixes various individual instances of missing locking in `store`.

<s>This is on top of unmerged #1436.</s> See individual commit messages for details.

@nalind @giuseppe PTAL, it’s quite likely I’m missing something about the current locking implementation

Cc: @alexlarsson : this might significantly reduce the number of locking operations on `storage.lock`. I have no idea if it is noticeably _faster_, but it’s probably a noticeable change to the `strace` at least, so it might be necessary to track this separately from other changes if you are quantifying other work.