### PR TITLE
[release-1.34] Recreate missing backingFsBlockDev on setting xfs project quota

### DIFF
--- a/drivers/quota/projectquota.go
+++ b/drivers/quota/projectquota.go
@@ -1,3 +1,4 @@
+//go:build linux && !exclude_disk_quota && cgo
 // +build linux,!exclude_disk_quota,cgo
 
 //
@@ -50,6 +51,7 @@ struct fsxattr {
 */
 import "C"
 import (
+	"errors"
 	"fmt"
 	"io/ioutil"
 	"math"
@@ -78,6 +80,7 @@ type Control struct {
 	backingFsBlockDev string
 	nextProjectID     uint32
 	quotas            map[string]uint32
+	basePath          string
 }
 
 // Attempt to generate a unigue projectid.  Multiple directories
@@ -122,11 +125,9 @@ func generateUniqueProjectID(path string) (uint32, error) {
 // This is a way to prevent xfs_quota management from conflicting with
 // containers/storage.
 
-//
 // Then try to create a test directory with the next project id and set a quota
 // on it. If that works, continue to scan existing containers to map allocated
 // project ids.
-//
 func NewControl(basePath string) (*Control, error) {
 	//
 	// Get project id of parent dir as minimal id to be used by driver
@@ -160,20 +161,22 @@ func NewControl(basePath string) (*Control, error) {
 		Size:   0,
 		Inodes: 0,
 	}
-	if err := setProjectQuota(backingFsBlockDev, minProjectID, quota); err != nil {
-		return nil, err
-	}
 
 	q := Control{
 		backingFsBlockDev: backingFsBlockDev,
 		nextProjectID:     minProjectID + 1,
 		quotas:            make(map[string]uint32),
+		basePath:          basePath,
+	}
+
+	if err := q.setProjectQuota(minProjectID, quota); err != nil {
+		return nil, err
 	}
 
 	//
 	// get first project id to be used for next container
 	//
-	err = q.findNextProjectID(basePath)
+	err = q.findNextProjectID()
 	if err != nil {
 		return nil, err
 	}
@@ -206,11 +209,11 @@ func (q *Control) SetQuota(targetPath string, quota Quota) error {
 	// set the quota limit for the container's project id
 	//
 	logrus.Debugf("SetQuota path=%s, size=%d, inodes=%d, projectID=%d", targetPath, quota.Size, quota.Inodes, projectID)
-	return setProjectQuota(q.backingFsBlockDev, projectID, quota)
+	return q.setProjectQuota(projectID, quota)
 }
 
 // setProjectQuota - set the quota for project id on xfs block device
-func setProjectQuota(backingFsBlockDev string, projectID uint32, quota Quota) error {
+func (q *Control) setProjectQuota(projectID uint32, quota Quota) error {
 	var d C.fs_disk_quota_t
 	d.d_version = C.FS_DQUOT_VERSION
 	d.d_id = C.__u32(projectID)
@@ -227,15 +230,35 @@ func setProjectQuota(backingFsBlockDev string, projectID uint32, quota Quota) er
 		d.d_ino_softlimit = d.d_ino_hardlimit
 	}
 
-	var cs = C.CString(backingFsBlockDev)
+	var cs = C.CString(q.backingFsBlockDev)
 	defer C.free(unsafe.Pointer(cs))
 
-	_, _, errno := unix.Syscall6(unix.SYS_QUOTACTL, C.Q_XSETPQLIM,
-		uintptr(unsafe.Pointer(cs)), uintptr(d.d_id),
-		uintptr(unsafe.Pointer(&d)), 0, 0)
-	if errno != 0 {
-		return fmt.Errorf("Failed to set quota limit for projid %d on %s: %v",
-			projectID, backingFsBlockDev, errno.Error())
+	runQuotactl := func() syscall.Errno {
+		_, _, errno := unix.Syscall6(unix.SYS_QUOTACTL, C.Q_XSETPQLIM,
+			uintptr(unsafe.Pointer(cs)), uintptr(d.d_id),
+			uintptr(unsafe.Pointer(&d)), 0, 0)
+		return errno
+	}
+
+	errno := runQuotactl()
+
+	// If the backingFsBlockDev does not exist any more then try to recreate it.
+	if errors.Is(errno, unix.ENOENT) {
+		if _, err := makeBackingFsDev(q.basePath); err != nil {
+			return fmt.Errorf(
+				"failed to recreate missing backingFsBlockDev %s for projid %d: %w",
+				q.backingFsBlockDev, projectID, err,
+			)
+		}
+
+		if errno := runQuotactl(); errno != 0 {
+			return fmt.Errorf("failed to set quota limit for projid %d on %s after backingFsBlockDev recreation: %w",
+				projectID, q.backingFsBlockDev, errno)
+		}
+
+	} else if errno != 0 {
+		return fmt.Errorf("failed to set quota limit for projid %d on %s: %w",
+			projectID, q.backingFsBlockDev, errno)
 	}
 
 	return nil
@@ -334,16 +357,16 @@ func setProjectID(targetPath string, projectID uint32) error {
 
 // findNextProjectID - find the next project id to be used for containers
 // by scanning driver home directory to find used project ids
-func (q *Control) findNextProjectID(home string) error {
-	files, err := ioutil.ReadDir(home)
+func (q *Control) findNextProjectID() error {
+	files, err := ioutil.ReadDir(q.basePath)
 	if err != nil {
-		return fmt.Errorf("read directory failed : %s", home)
+		return fmt.Errorf("read directory failed : %s", q.basePath)
 	}
 	for _, file := range files {
 		if !file.IsDir() {
 			continue
 		}
-		path := filepath.Join(home, file.Name())
+		path := filepath.Join(q.basePath, file.Name())
 		projid, err := getProjectID(path)
 		if err != nil {
 			return err


### PR DESCRIPTION
Cherry-pick of https://github.com/containers/storage/pull/1325/commits/aa0d39469a7e4de2c30e29ea596b767e1ff36ce1 into `release-1.37` for CRI-O 1.22.

I would need a new v1.34.2 release after that got merged.

@containers/storage-maintainers PTAL