### PR TITLE
userns: stop printing size as escaped string in error and instead use `%v`

### DIFF
--- a/userns.go
+++ b/userns.go
@@ -264,7 +264,7 @@ func (s *store) getAutoUserNS(options *types.AutoUserNsOptions, image *Image, rl
 			}
 		}
 		if s.autoNsMaxSize > 0 && size > s.autoNsMaxSize {
-			return nil, nil, fmt.Errorf("the container needs a user namespace with size %q that is bigger than the maximum value allowed with userns=auto %q", size, s.autoNsMaxSize)
+			return nil, nil, fmt.Errorf("the container needs a user namespace with size %v that is bigger than the maximum value allowed with userns=auto %v", size, s.autoNsMaxSize)
 		}
 	}
 


### PR DESCRIPTION
Using `%q` as format specifier for size prints non-meaningful error messages instead use `%v` which will print in default format.

Example Bad error message
```console
Error: identifier is not a container: preparing container for next step:
creating build container: creating container: the container needs a user
namespace with size '𘛋' that is bigger than the maximum value allowed
with userns=auto '𐀀'
```

See error msg here: https://github.com/containers/podman/issues/16795