### PR TITLE
Fix some leaks in maps

### DIFF
--- a/drivers/counter.go
+++ b/drivers/counter.go
@@ -58,6 +58,11 @@ func (c *RefCounter) incdec(path string, infoOp func(minfo *minfo)) int {
 	}
 	infoOp(m)
 	count := m.count
+	if count <= 0 {
+		// If the mounted path has been decremented enough have no references,
+		// then its entry can be removed.
+		delete(c.counts, path)
+	}
 	c.mu.Unlock()
 	return count
 }

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -1202,6 +1202,9 @@ func (d *Driver) Remove(id string) error {
 	if err := system.EnsureRemoveAll(dir); err != nil && !os.IsNotExist(err) {
 		return err
 	}
+	if d.quotaCtl != nil {
+		d.quotaCtl.ClearQuota(dir)
+	}
 	return nil
 }
 

--- a/drivers/quota/projectquota.go
+++ b/drivers/quota/projectquota.go
@@ -211,6 +211,12 @@ func (q *Control) SetQuota(targetPath string, quota Quota) error {
 	return q.setProjectQuota(projectID, quota)
 }
 
+// ClearQuota removes the map entry in the quotas map for targetPath.
+// It does so to prevent the map leaking entries as directories are deleted.
+func (q *Control) ClearQuota(targetPath string) {
+	delete(q.quotas, targetPath)
+}
+
 // setProjectQuota - set the quota for project id on xfs block device
 func (q *Control) setProjectQuota(projectID uint32, quota Quota) error {
 	var d C.fs_disk_quota_t


### PR DESCRIPTION
There are two leaks identified in https://issues.redhat.com/browse/OCPBUGS-3652 that affect long-running processes (CRI-O). Fix them here, with more details in commits.