### PR TITLE
[release-1.42] Fix accessing to layer without lock

### DIFF
--- a/layers.go
+++ b/layers.go
@@ -556,6 +556,8 @@ func (s *store) newLayerStore(rundir string, layerdir string, driver drivers.Dri
 		uidMap:         copyIDMap(s.uidMap),
 		gidMap:         copyIDMap(s.gidMap),
 	}
+	rlstore.Lock()
+	defer rlstore.Unlock()
 	if err := rlstore.Load(); err != nil {
 		return nil, err
 	}
@@ -577,6 +579,8 @@ func newROLayerStore(rundir string, layerdir string, driver drivers.Driver) (ROL
 		bymount:        make(map[string]*Layer),
 		byname:         make(map[string]*Layer),
 	}
+	rlstore.RLock()
+	defer rlstore.Unlock()
 	if err := rlstore.Load(); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
There was a possibility to panic due to such behavior: attempted to update last-writer in lockfile without the write lock

Fixes: https://github.com/containers/storage/issues/1324

Closes: https://bugzilla.redhat.com/show_bug.cgi?id=2153883

Signed-off-by: Mikhail Khachayants <tyler92@inbox.ru>
(cherry picked from commit e35b061b8515b8f266ec0b0f6bafe7e1796a7d69)
Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>