### PR TITLE
drivers/btrfs: workaround field rename in `btrfs-progs 6.1`

### DIFF
--- a/drivers/btrfs/btrfs.go
+++ b/drivers/btrfs/btrfs.go
@@ -6,6 +6,9 @@ package btrfs
 /*
 #include <stdlib.h>
 #include <dirent.h>
+
+// keep struct field name compatible with btrfs-progs < 6.1.
+#define max_referenced max_rfer
 #include <btrfs/ioctl.h>
 #include <btrfs/ctree.h>
 
@@ -382,7 +385,7 @@ func subvolLimitQgroup(path string, size uint64) error {
 	defer closeDir(dir)
 
 	var args C.struct_btrfs_ioctl_qgroup_limit_args
-	args.lim.max_referenced = C.__u64(size)
+	args.lim.max_rfer = C.__u64(size)
 	args.lim.flags = C.BTRFS_QGROUP_LIMIT_MAX_RFER
 	_, _, errno := unix.Syscall(unix.SYS_IOCTL, getDirFd(dir), C.BTRFS_IOC_QGROUP_LIMIT,
 		uintptr(unsafe.Pointer(&args)))


### PR DESCRIPTION
Field name `args.lim.max_referenced` is renamed to `args.lim.max_rfer` in newer versions.

See: https://docs.huihoo.com/doxygen/linux/kernel/3.7/structbtrfs__ioctl__qgroup__limit__args.html 
PR is similar to: https://github.com/moby/moby/pull/44707 
Closes: https://github.com/containers/storage/issues/1454
