### PR TITLE
Make the priority for picking the storage driver configurable

### DIFF
--- a/docs/containers-storage.conf.5.md
+++ b/docs/containers-storage.conf.5.md
@@ -59,6 +59,11 @@ A common use case for this field is to provide a local storage directory when us
   container storage run dir (default: "/run/containers/storage")
 Default directory to store all temporary writable content created by container storage programs. The rootless runroot path supports environment variable substitutions (ie. `$HOME/containers/storage`)
 
+**driver_priority**=[]
+  Priority list for the storage drivers that will be tested one after the other to pick the storage driver if it is not defined. The first storage driver in this list that can be used, will be picked as the new one and all subsequent ones will not be tried. If all drivers in this list are not viable, then **all** known drivers will be tried and the first working one will be picked.
+By default, the storage driver is set via the `driver` option. If it is not defined, then the best driver will be picked according to the current platform. This option allows you to override this internal priority list with a custom one to prefer certain drivers.
+Setting this option only has an effect if the local storage has not been initialized yet and the driver name is not set.
+
 ### STORAGE OPTIONS TABLE
 
 The `storage.options` table supports the following options:

--- a/types/options.go
+++ b/types/options.go
@@ -19,6 +19,7 @@ import (
 type TomlConfig struct {
 	Storage struct {
 		Driver              string            `toml:"driver,omitempty"`
+		DriverPriority      []string          `toml:"driver_priority,omitempty"`
 		RunRoot             string            `toml:"runroot,omitempty"`
 		GraphRoot           string            `toml:"graphroot,omitempty"`
 		RootlessStoragePath string            `toml:"rootless_storage_path,omitempty"`
@@ -213,10 +214,16 @@ type StoreOptions struct {
 	// RootlessStoragePath is the storage path for rootless users
 	// default $HOME/.local/share/containers/storage
 	RootlessStoragePath string `toml:"rootless_storage_path"`
-	// GraphDriverName is the underlying storage driver that we'll be
-	// using.  It only needs to be specified the first time a Store is
-	// initialized for a given RunRoot and GraphRoot.
+	// If the driver is not specified, the best suited driver will be picked
+	// either from GraphDriverPriority, if specified, or from the platform
+	// dependent priority list (in that order).
 	GraphDriverName string `json:"driver,omitempty"`
+	// GraphDriverPriority is a list of storage drivers that will be tried
+	// to initialize the Store for a given RunRoot and GraphRoot unless a
+	// GraphDriverName is set.
+	// This list can be used to define a custom order in which the drivers
+	// will be tried.
+	GraphDriverPriority []string `json:"driver-priority,omitempty"`
 	// GraphDriverOptions are driver-specific options.
 	GraphDriverOptions []string `json:"driver-options,omitempty"`
 	// UIDMap and GIDMap are used for setting up a container's root filesystem
@@ -383,6 +390,7 @@ func ReloadConfigurationFile(configFile string, storeOptions *StoreOptions) erro
 	if storeOptions.GraphDriverName == "" {
 		logrus.Errorf("The storage 'driver' option must be set in %s to guarantee proper operation", configFile)
 	}
+	storeOptions.GraphDriverPriority = config.Storage.DriverPriority
 	if config.Storage.RunRoot != "" {
 		storeOptions.RunRoot = config.Storage.RunRoot
 	}

--- a/types/options.go
+++ b/types/options.go
@@ -387,10 +387,10 @@ func ReloadConfigurationFile(configFile string, storeOptions *StoreOptions) erro
 		logrus.Warnf("Switching default driver from overlay2 to the equivalent overlay driver")
 		storeOptions.GraphDriverName = overlayDriver
 	}
-	if storeOptions.GraphDriverName == "" {
-		logrus.Errorf("The storage 'driver' option must be set in %s to guarantee proper operation", configFile)
-	}
 	storeOptions.GraphDriverPriority = config.Storage.DriverPriority
+	if storeOptions.GraphDriverName == "" && len(storeOptions.GraphDriverPriority) == 0 {
+		logrus.Warnf("The storage 'driver' option should be set in %s. A driver was picked automatically.", configFile)
+	}
 	if config.Storage.RunRoot != "" {
 		storeOptions.RunRoot = config.Storage.RunRoot
 	}


### PR DESCRIPTION
This fixes https://github.com/containers/storage/issues/1457

I have tested this locally by vendoring the specific PR into podman and then setting the following `~/.config/containers/storage.conf`:
```toml
[storage]

driver_priority = [
                "zfs",
                "btrfs",
                "overlay"
]
```
podman then tried zfs (but failed as I don't have any zfs partitions) and picked btrfs as the next viable candidate.

Removing the setting causes podman to correctly pick up overlay as the driver.