### PR TITLE
Define error type for ErrNoAvailableIDs

### DIFF
--- a/idset.go
+++ b/idset.go
@@ -1,11 +1,11 @@
 package storage
 
 import (
-	"errors"
 	"fmt"
 	"strings"
 
 	"github.com/containers/storage/pkg/idtools"
+	"github.com/containers/storage/types"
 	"github.com/google/go-intervals/intervalset"
 )
 
@@ -116,7 +116,7 @@ func (s *idSet) findAvailable(n int) (*idSet, error) {
 		n -= i.length()
 	}
 	if n > 0 {
-		return nil, errors.New("could not find enough available IDs")
+		return nil, types.ErrNoAvailableIDs
 	}
 	return &idSet{set: intervalset.NewImmutableSet(intervals)}, nil
 }

--- a/types/errors.go
+++ b/types/errors.go
@@ -57,4 +57,6 @@ var (
 	ErrNotSupported = errors.New("not supported")
 	// ErrInvalidMappings is returned when the specified mappings are invalid.
 	ErrInvalidMappings = errors.New("invalid mappings specified")
+	// ErrNoAvailableIDs is returned when there are not enough unused IDS within the user namespace.
+	ErrNoAvailableIDs = errors.New("not enough unused IDs in user namespace")
 )


### PR DESCRIPTION
Want to allow Podman to print helpful error message when users runs out of UIDs to use with podman run --userns=auto.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>