### PR TITLE
Compile regex on demand not in init

### DIFF
--- a/internal/opts/opts.go
+++ b/internal/opts/opts.go
@@ -3,13 +3,7 @@ package opts
 import (
 	"fmt"
 	"net"
-	"regexp"
 	"strings"
-)
-
-var (
-	alphaRegexp  = regexp.MustCompile(`[a-zA-Z]`)
-	domainRegexp = regexp.MustCompile(`^(:?(:?[a-zA-Z0-9]|(:?[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9]))(:?\.(:?[a-zA-Z0-9]|(:?[a-zA-Z0-9][a-zA-Z0-9\-]*[a-zA-Z0-9])))*)\.?\s*$`)
 )
 
 // ListOpts holds a list of values and a validation function.
@@ -134,7 +128,7 @@ func (o *NamedListOpts) Name() string {
 	return o.name
 }
 
-//MapOpts holds a map of values and a validation function.
+// MapOpts holds a map of values and a validation function.
 type MapOpts struct {
 	values    map[string]string
 	validator ValidatorFctType
@@ -220,26 +214,6 @@ func ValidateIPAddress(val string) (string, error) {
 		return ip.String(), nil
 	}
 	return "", fmt.Errorf("%s is not an ip address", val)
-}
-
-// ValidateDNSSearch validates domain for resolvconf search configuration.
-// A zero length domain is represented by a dot (.).
-func ValidateDNSSearch(val string) (string, error) {
-	if val = strings.Trim(val, " "); val == "." {
-		return val, nil
-	}
-	return validateDomain(val)
-}
-
-func validateDomain(val string) (string, error) {
-	if alphaRegexp.FindString(val) == "" {
-		return "", fmt.Errorf("%s is not a valid domain", val)
-	}
-	ns := domainRegexp.FindSubmatch([]byte(val))
-	if len(ns) > 0 && len(ns[1]) < 255 {
-		return string(ns[1]), nil
-	}
-	return "", fmt.Errorf("%s is not a valid domain", val)
 }
 
 // ValidateLabel validates that the specified string is a valid label, and returns it.

--- a/internal/opts/opts_test.go
+++ b/internal/opts/opts_test.go
@@ -127,63 +127,6 @@ func TestListOptsWithValidator(t *testing.T) {
 	}
 }
 
-func TestValidateDNSSearch(t *testing.T) {
-	valid := []string{
-		`.`,
-		`a`,
-		`a.`,
-		`1.foo`,
-		`17.foo`,
-		`foo.bar`,
-		`foo.bar.baz`,
-		`foo.bar.`,
-		`foo.bar.baz`,
-		`foo1.bar2`,
-		`foo1.bar2.baz`,
-		`1foo.2bar.`,
-		`1foo.2bar.baz`,
-		`foo-1.bar-2`,
-		`foo-1.bar-2.baz`,
-		`foo-1.bar-2.`,
-		`foo-1.bar-2.baz`,
-		`1-foo.2-bar`,
-		`1-foo.2-bar.baz`,
-		`1-foo.2-bar.`,
-		`1-foo.2-bar.baz`,
-	}
-
-	invalid := []string{
-		``,
-		` `,
-		`  `,
-		`17`,
-		`17.`,
-		`.17`,
-		`17-.`,
-		`17-.foo`,
-		`.foo`,
-		`foo-.bar`,
-		`-foo.bar`,
-		`foo.bar-`,
-		`foo.bar-.baz`,
-		`foo.-bar`,
-		`foo.-bar.baz`,
-		`foo.bar.baz.this.should.fail.on.long.name.because.it.is.longer.thanisshouldbethis.should.fail.on.long.name.because.it.is.longer.thanisshouldbethis.should.fail.on.long.name.because.it.is.longer.thanisshouldbethis.should.fail.on.long.name.because.it.is.longer.thanisshouldbe`,
-	}
-
-	for _, domain := range valid {
-		if ret, err := ValidateDNSSearch(domain); err != nil || ret == "" {
-			t.Fatalf("ValidateDNSSearch(`"+domain+"`) got %s %s", ret, err)
-		}
-	}
-
-	for _, domain := range invalid {
-		if ret, err := ValidateDNSSearch(domain); err == nil || ret != "" {
-			t.Fatalf("ValidateDNSSearch(`"+domain+"`) got %s %s", ret, err)
-		}
-	}
-}
-
 func TestValidateLabel(t *testing.T) {
 	if _, err := ValidateLabel("label"); err == nil || err.Error() != "bad attribute format: label" {
 		t.Fatalf("Expected an error [bad attribute format: label], go %v", err)

--- a/pkg/idtools/usergroupadd_linux.go
+++ b/pkg/idtools/usergroupadd_linux.go
@@ -24,7 +24,8 @@ var (
 		"usermod": "-%s %d-%d %s",
 	}
 
-	idOutRegexp = regexp.MustCompile(`uid=([0-9]+).*gid=([0-9]+)`)
+	idOutOnce   sync.Once
+	idOutRegexp *regexp.Regexp
 	// default length for a UID/GID subordinate range
 	defaultRangeLen   = 65536
 	defaultRangeStart = 100000
@@ -36,6 +37,10 @@ var (
 // /etc/sub{uid,gid} ranges which will be used for user namespace
 // mapping ranges in containers.
 func AddNamespaceRangesUser(name string) (int, int, error) {
+	idOutOnce.Do(func() {
+		idOutRegexp = regexp.MustCompile(`uid=([0-9]+).*gid=([0-9]+)`)
+	})
+
 	if err := addUser(name); err != nil {
 		return -1, -1, fmt.Errorf("adding user %q: %w", name, err)
 	}


### PR DESCRIPTION
Every app is paying the price for these compilations on startup so make only the users of the functions pay the price.

ValidateDNSSearch is not used anywhere so remove it.

Signed-off-by: Daniel J Walsh <dwalsh@redhat.com>