### PR TITLE
Only override the graphdriver to vfs if the priority is unset

### DIFF
--- a/types/options.go
+++ b/types/options.go
@@ -300,7 +300,11 @@ func getRootlessStorageOpts(rootlessUID int, systemOpts StoreOptions) (StoreOpti
 		}
 	}
 	if opts.GraphDriverName == "" {
-		opts.GraphDriverName = "vfs"
+		if len(systemOpts.GraphDriverPriority) == 0 {
+			opts.GraphDriverName = "vfs"
+		} else {
+			opts.GraphDriverPriority = systemOpts.GraphDriverPriority
+		}
 	}
 
 	if os.Getenv("STORAGE_OPTS") != "" {


### PR DESCRIPTION
This is an amend to https://github.com/containers/storage/pull/1460 That PR was not addressing the case when the system wide config had the driver_priority option configured and the user had no config file of their own. Then `getRootlessStorageOpts` would be called and it would override the graph driver to "vfs".

With this commit we only override the graph driver if driver priority is empty. Otherwise we propagate the driver priority into the storage options, so that the driver autodetection works as expected.