### PR TITLE
store: prefer /etc/containers/storage.conf

### DIFF
--- a/types/utils.go
+++ b/types/utils.go
@@ -173,6 +173,9 @@ func DefaultConfigFile(rootless bool) (string, error) {
 		return path, nil
 	}
 	if !rootless {
+		if _, err := os.Stat(defaultOverrideConfigFile); err == nil {
+			return defaultOverrideConfigFile, nil
+		}
 		return defaultConfigFile, nil
 	}
 


### PR DESCRIPTION
when running in rootful mode, if it is present, prefer the override path /etc/containers/storage.conf instead of using the  default storage.conf provided by the package under the /usr/share/containers/ directory.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>