### PR TITLE
Test btrfs in CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -78,6 +78,8 @@ fedora_testing_task: &fedora_testing
             TEST_DRIVER: "fuse-overlay"
         - env:
             TEST_DRIVER: "fuse-overlay-whiteout"
+        - env:
+            TEST_DRIVER: "btrfs"
 
     # Separate scripts for separate outputs, makes debugging easier.
     setup_script: '${CIRRUS_WORKING_DIR}/${SCRIPT_BASE}/setup.sh |& ${_TIMESTAMP}'
@@ -90,6 +92,7 @@ fedora_testing_task: &fedora_testing
         journal_log_script: '${_JOURNALCMD} || true'
 
 
+# aufs was dropped between 20.04 and 22.04, can't test it
 ubuntu_testing_task: &ubuntu_testing
     <<: *fedora_testing
     alias: ubuntu_testing
@@ -102,6 +105,12 @@ ubuntu_testing_task: &ubuntu_testing
             TEST_DRIVER: "vfs"
         - env:
             TEST_DRIVER: "overlay"
+        - env:
+            TEST_DRIVER: "fuse-overlay"
+        - env:
+            TEST_DRIVER: "fuse-overlay-whiteout"
+        - env:
+            TEST_DRIVER: "btrfs"
 
 
 lint_task:

--- a/contrib/cirrus/lib.sh
+++ b/contrib/cirrus/lib.sh
@@ -115,3 +115,14 @@ install_bats_from_git(){
     mkdir -p ~/.parallel
     touch ~/.parallel/will-cite
 }
+
+check_filesystem_supported(){
+    if ! grep -q "	$1\$" /proc/filesystems ; then
+        modprobe $1 > /dev/null 2> /dev/null || :en
+        if ! grep -q "	$1\$" /proc/filesystems ; then
+            echo "This CI VM does not support $TEST_DRIVER in its kernel"
+	    false
+        fi
+    fi
+    true
+}


### PR DESCRIPTION
Make a file and mount it over loopback to ensure that we can test btrfs, assuming we were built with the libraries and the kernel supports it.