### PR TITLE
pkg/idmap: add boilerplate for unsupported

### DIFF
--- a/pkg/idmap/idmapped_utils_unsupported.go
+++ b/pkg/idmap/idmapped_utils_unsupported.go
@@ -1,0 +1,22 @@
+//go:build !linux
+// +build !linux
+
+package idmap
+
+import (
+	"fmt"
+
+	"github.com/containers/storage/pkg/idtools"
+)
+
+// CreateIDMappedMount creates a IDMapped bind mount from SOURCE to TARGET using the user namespace
+// for the PID process.
+func CreateIDMappedMount(source, target string, pid int) error {
+	return fmt.Errorf("IDMapped mounts are not supported")
+}
+
+// CreateUsernsProcess forks the current process and creates a user namespace using the specified
+// mappings.  It returns the pid of the new process.
+func CreateUsernsProcess(uidMaps []idtools.IDMap, gidMaps []idtools.IDMap) (int, func(), error) {
+	return -1, nil, fmt.Errorf("IDMapped mounts are not supported")
+}


### PR DESCRIPTION
we need it to build on freebsd.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>