### PR TITLE
Test zfs in CI

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -112,6 +112,8 @@ ubuntu_testing_task: &ubuntu_testing
             TEST_DRIVER: "fuse-overlay-whiteout"
         - env:
             TEST_DRIVER: "btrfs"
+        - env:
+            TEST_DRIVER: "zfs"
 
 
 lint_task:

--- a/contrib/cirrus/setup.sh
+++ b/contrib/cirrus/setup.sh
@@ -20,7 +20,7 @@ case "$OS_RELEASE_ID" in
         [[ -z "$DEBS_CONFLICTING" ]] || \
             $SHORT_APTGET -q remove $DEBS_CONFLICTING
         $SHORT_APTGET -q update
-        $SHORT_APTGET -q install zstd
+        $SHORT_APTGET -q install zstd zfsutils-linux
         ;;
     *)
         bad_os_id_ver


### PR DESCRIPTION
Make a file, and then make a pool out of it to ensure that we can test zfs, assuming we have the binaries and the kernel supports it.