### PR TITLE
options: reject empty runroot or graphroot

### DIFF
--- a/types/options.go
+++ b/types/options.go
@@ -152,20 +152,24 @@ func defaultStoreOptionsIsolated(rootless bool, rootlessUID int, storageConf str
 			}
 		}
 	}
-	if storageOpts.RunRoot != "" {
-		runRoot, err := expandEnvPath(storageOpts.RunRoot, rootlessUID)
-		if err != nil {
-			return storageOpts, err
-		}
-		storageOpts.RunRoot = runRoot
+	if storageOpts.RunRoot == "" {
+		return storageOpts, fmt.Errorf("runroot must be set")
 	}
-	if storageOpts.GraphRoot != "" {
-		graphRoot, err := expandEnvPath(storageOpts.GraphRoot, rootlessUID)
-		if err != nil {
-			return storageOpts, err
-		}
-		storageOpts.GraphRoot = graphRoot
+	runRoot, err := expandEnvPath(storageOpts.RunRoot, rootlessUID)
+	if err != nil {
+		return storageOpts, err
 	}
+	storageOpts.RunRoot = runRoot
+
+	if storageOpts.GraphRoot == "" {
+		return storageOpts, fmt.Errorf("graphroot must be set")
+	}
+	graphRoot, err := expandEnvPath(storageOpts.GraphRoot, rootlessUID)
+	if err != nil {
+		return storageOpts, err
+	}
+	storageOpts.GraphRoot = graphRoot
+
 	if storageOpts.RootlessStoragePath != "" {
 		storagePath, err := expandEnvPath(storageOpts.RootlessStoragePath, rootlessUID)
 		if err != nil {


### PR DESCRIPTION
make sure that the runroot and graphroot are not empty otherwise we will end up using an empty directory as path prefix and create files in the current directory.