### PR TITLE
overlay: allow unknown backing fs with mountProgram

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -315,7 +315,10 @@ func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) 
 	}
 	fsName, ok := graphdriver.FsNames[fsMagic]
 	if !ok {
-		return nil, fmt.Errorf("filesystem type %#x reported for %s is not supported with 'overlay': %w", fsMagic, filepath.Dir(home), graphdriver.ErrIncompatibleFS)
+		if opts.mountProgram == "" {
+			return nil, fmt.Errorf("filesystem type %#x reported for %s is not supported with 'overlay': %w", fsMagic, filepath.Dir(home), graphdriver.ErrIncompatibleFS)
+		}
+		fsName = "<unknown>"
 	}
 	backingFs = fsName
 


### PR DESCRIPTION
if a mountProgram is specified, let it deal with an unknown backing file system instead of failing early.  The error is kept when we use native overlay.

Closes: https://github.com/containers/storage/issues/1511