### PR TITLE
[1.45] overlay: allow unknown backing fs with mountProgram

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -314,7 +314,10 @@ func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) 
 	}
 	fsName, ok := graphdriver.FsNames[fsMagic]
 	if !ok {
-		return nil, fmt.Errorf("filesystem type %#x reported for %s is not supported with 'overlay': %w", fsMagic, filepath.Dir(home), graphdriver.ErrIncompatibleFS)
+		if opts.mountProgram == "" {
+			return nil, fmt.Errorf("filesystem type %#x reported for %s is not supported with 'overlay': %w", fsMagic, filepath.Dir(home), graphdriver.ErrIncompatibleFS)
+		}
+		fsName = "<unknown>"
 	}
 	backingFs = fsName
 


### PR DESCRIPTION
if a mountProgram is specified, let it deal with an unknown backing file system instead of failing early.  The error is kept when we use native overlay.

Closes: https://github.com/containers/storage/issues/1511

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
(cherry picked from commit b9f1697c1714f4ff2141ef3f308154f3968e6fda)

backport of: https://github.com/containers/storage/pull/1512