### PR TITLE
fix(quota): added missed ClearQuota method to fix go-builds without cgo

### DIFF
--- a/drivers/quota/projectquota_unsupported.go
+++ b/drivers/quota/projectquota_unsupported.go
@@ -32,3 +32,7 @@ func (q *Control) SetQuota(targetPath string, quota Quota) error {
 func (q *Control) GetQuota(targetPath string, quota *Quota) error {
 	return errors.New("filesystem does not support, or has not enabled quotas")
 }
+
+// ClearQuota removes the map entry in the quotas map for targetPath.
+// It does so to prevent the map leaking entries as directories are deleted.
+func (q *Control) ClearQuota(targetPath string) {}


### PR DESCRIPTION
Fixed building of the containers/storage for linux without usage of CGO (tags="linux exclude_disk_quota" & CGO_ENABLED=0): added missing method for the stub Controller implementation.

Refs https://github.com/containers/storage/commit/891593970ae79687f139871f2ae105582060a04b.