### PR TITLE
overlay: change error to debug log for unsupported fs

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -314,9 +314,6 @@ func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) 
 	}
 	fsName, ok := graphdriver.FsNames[fsMagic]
 	if !ok {
-		if opts.mountProgram == "" {
-			return nil, fmt.Errorf("filesystem type %#x reported for %s is not supported with 'overlay': %w", fsMagic, filepath.Dir(home), graphdriver.ErrIncompatibleFS)
-		}
 		fsName = "<unknown>"
 	}
 	backingFs = fsName


### PR DESCRIPTION
The overlay driver previously raised an error when encountering an unsupported filesystem. This commit changes the error message to a debug log, allowing the overlay driver to continue its operation even with unsupported filesystems, without causing a failure.

[NO NEW TESTS NEEDED]

Introduced-by: https://github.com/containers/storage/pull/1374

Closes: https://github.com/containers/storage/issues/1546