### PR TITLE
Drop nameLooksLikeID()

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -411,7 +411,7 @@ func (r *containerStore) GarbageCollect() error {
 	for _, entry := range entries {
 		id := entry.Name()
 		// Does it look like a datadir directory?
-		if !entry.IsDir() || !nameLooksLikeID(id) {
+		if !entry.IsDir() || stringid.ValidateID(id) != nil {
 			continue
 		}
 

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -17,7 +17,6 @@ import (
 	"strings"
 	"sync"
 	"syscall"
-	"unicode"
 
 	graphdriver "github.com/containers/storage/drivers"
 	"github.com/containers/storage/drivers/overlayutils"
@@ -30,6 +29,7 @@ import (
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/mount"
 	"github.com/containers/storage/pkg/parsers"
+	"github.com/containers/storage/pkg/stringid"
 	"github.com/containers/storage/pkg/system"
 	"github.com/containers/storage/pkg/unshare"
 	units "github.com/docker/go-units"
@@ -1717,18 +1717,6 @@ func (d *Driver) Exists(id string) bool {
 	return err == nil
 }
 
-func nameLooksLikeID(name string) bool {
-	if len(name) != 64 {
-		return false
-	}
-	for _, c := range name {
-		if !unicode.Is(unicode.ASCII_Hex_Digit, c) {
-			return false
-		}
-	}
-	return true
-}
-
 // List layers (not including additional image stores)
 func (d *Driver) ListLayers() ([]string, error) {
 	entries, err := os.ReadDir(d.home)
@@ -1741,7 +1729,7 @@ func (d *Driver) ListLayers() ([]string, error) {
 	for _, entry := range entries {
 		id := entry.Name()
 		// Does it look like a datadir directory?
-		if !entry.IsDir() || !nameLooksLikeID(id) {
+		if !entry.IsDir() || stringid.ValidateID(id) != nil {
 			continue
 		}
 

--- a/drivers/vfs/driver.go
+++ b/drivers/vfs/driver.go
@@ -8,13 +8,13 @@ import (
 	"runtime"
 	"strconv"
 	"strings"
-	"unicode"
 
 	graphdriver "github.com/containers/storage/drivers"
 	"github.com/containers/storage/pkg/archive"
 	"github.com/containers/storage/pkg/directory"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/parsers"
+	"github.com/containers/storage/pkg/stringid"
 	"github.com/containers/storage/pkg/system"
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/sirupsen/logrus"
@@ -266,18 +266,6 @@ func (d *Driver) Exists(id string) bool {
 	return err == nil
 }
 
-func nameLooksLikeID(name string) bool {
-	if len(name) != 64 {
-		return false
-	}
-	for _, c := range name {
-		if !unicode.Is(unicode.ASCII_Hex_Digit, c) {
-			return false
-		}
-	}
-	return true
-}
-
 // List layers (not including additional image stores)
 func (d *Driver) ListLayers() ([]string, error) {
 	entries, err := os.ReadDir(d.homes[0])
@@ -290,7 +278,7 @@ func (d *Driver) ListLayers() ([]string, error) {
 	for _, entry := range entries {
 		id := entry.Name()
 		// Does it look like a datadir directory?
-		if !entry.IsDir() || !nameLooksLikeID(id) {
+		if !entry.IsDir() || stringid.ValidateID(id) != nil {
 			continue
 		}
 

--- a/images.go
+++ b/images.go
@@ -414,7 +414,7 @@ func (r *imageStore) GarbageCollect() error {
 	for _, entry := range entries {
 		id := entry.Name()
 		// Does it look like a datadir directory?
-		if !entry.IsDir() || !nameLooksLikeID(id) {
+		if !entry.IsDir() || stringid.ValidateID(id) != nil {
 			continue
 		}
 

--- a/utils.go
+++ b/utils.go
@@ -2,7 +2,6 @@ package storage
 
 import (
 	"fmt"
-	"unicode"
 
 	"github.com/containers/storage/types"
 )
@@ -72,16 +71,4 @@ func applyNameOperation(oldNames []string, opParameters []string, op updateNameO
 		return result, errInvalidUpdateNameOperation
 	}
 	return dedupeNames(result), nil
-}
-
-func nameLooksLikeID(name string) bool {
-	if len(name) != 64 {
-		return false
-	}
-	for _, c := range name {
-		if !unicode.Is(unicode.ASCII_Hex_Digit, c) {
-			return false
-		}
-	}
-	return true
 }


### PR DESCRIPTION
Replace the newer nameLooksLikeID() function with calls to stringid.Validate(), which does the same thing.