### PR TITLE
"pull up" images when creating them, too

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -666,7 +666,7 @@ func (r *containerStore) create(id string, names []string, image, layer string, 
 	if _, idInUse := r.byid[id]; idInUse {
 		return nil, ErrDuplicateID
 	}
-	names = dedupeNames(names)
+	names = dedupeStrings(names)
 	for _, name := range names {
 		if _, nameInUse := r.byname[name]; nameInUse {
 			return nil, fmt.Errorf("the container name %q is already in use by %s. You have to remove that container to be able to reuse that name: %w", name, r.byname[name].ID, ErrDuplicateName)

--- a/images.go
+++ b/images.go
@@ -703,7 +703,7 @@ func (r *imageStore) create(id string, names []string, layer string, options Ima
 	if _, idInUse := r.byid[id]; idInUse {
 		return nil, fmt.Errorf("an image with ID %q already exists: %w", id, ErrDuplicateID)
 	}
-	names = dedupeNames(names)
+	names = dedupeStrings(names)
 	for _, name := range names {
 		if image, nameInUse := r.byname[name]; nameInUse {
 			return nil, fmt.Errorf("image name %q is already associated with image %q: %w", name, image.ID, ErrDuplicateName)
@@ -712,7 +712,7 @@ func (r *imageStore) create(id string, names []string, layer string, options Ima
 	image = &Image{
 		ID:             id,
 		Digest:         options.Digest,
-		Digests:        copyDigestSlice(options.Digests),
+		Digests:        dedupeDigests(options.Digests),
 		Names:          names,
 		NamesHistory:   copyStringSlice(options.NamesHistory),
 		TopLayer:       layer,
@@ -820,7 +820,7 @@ func (r *imageStore) removeName(image *Image, name string) {
 
 // The caller must hold r.inProcessLock for writing.
 func (i *Image) addNameToHistory(name string) {
-	i.NamesHistory = dedupeNames(append([]string{name}, i.NamesHistory...))
+	i.NamesHistory = dedupeStrings(append([]string{name}, i.NamesHistory...))
 }
 
 // Requires startWriting.

--- a/layers.go
+++ b/layers.go
@@ -1230,7 +1230,7 @@ func (r *layerStore) create(id string, parentLayer *Layer, names []string, mount
 	if duplicateLayer, idInUse := r.byid[id]; idInUse {
 		return duplicateLayer, -1, ErrDuplicateID
 	}
-	names = dedupeNames(names)
+	names = dedupeStrings(names)
 	for _, name := range names {
 		if _, nameInUse := r.byname[name]; nameInUse {
 			return nil, -1, ErrDuplicateName

--- a/utils.go
+++ b/utils.go
@@ -70,5 +70,5 @@ func applyNameOperation(oldNames []string, opParameters []string, op updateNameO
 	default:
 		return result, errInvalidUpdateNameOperation
 	}
-	return dedupeNames(result), nil
+	return dedupeStrings(result), nil
 }


### PR DESCRIPTION
We previously started "pulling up" images when we changed their names, and started denying the presence of images in read-only stores which shared their ID with an image in the read-write store, so that it would be possible to "remove" names from an image in read-only storage.

Do the same when we're asked to create an image, since denying the presence of images with the same ID in read-only stores would prevent us from finding the image by any of the names that it "had" just a moment before we created the new record.