### PR TITLE
Test helper: add "unshare"/"create-storage-layer"/"storage-layers"

### DIFF
--- a/cmd/containers-storage/copy.go
+++ b/cmd/containers-storage/copy.go
@@ -104,7 +104,7 @@ func init() {
 		maxArgs:     -1,
 		action:      copyContent,
 		addFlags: func(flags *mflag.FlagSet, cmd *command) {
-			flags.StringVar(&chownOptions, []string{"-chown", ""}, chownOptions, "Set owner on new copies")
+			flags.StringVar(&chownOptions, []string{"-chown", "o"}, chownOptions, "Set owner on new copies")
 			flags.BoolVar(&jsonOutput, []string{"-json", "j"}, jsonOutput, "Prefer JSON output")
 		},
 	})

--- a/cmd/containers-storage/mount.go
+++ b/cmd/containers-storage/mount.go
@@ -138,7 +138,7 @@ func init() {
 		addFlags: func(flags *mflag.FlagSet, cmd *command) {
 			flags.StringVar(&paramMountOptions, []string{"-opt", "o"}, "", "Mount Options")
 			flags.StringVar(&paramMountLabel, []string{"-label", "l"}, "", "Mount Label")
-			flags.BoolVar(&paramReadOnly, []string{"-ro", "r"}, paramReadOnly, "Mount image readonly")
+			flags.BoolVar(&paramReadOnly, []string{"-read-only", "-ro", "r"}, paramReadOnly, "Mount image readonly")
 			flags.BoolVar(&jsonOutput, []string{"-json", "j"}, jsonOutput, "Prefer JSON output")
 		},
 	})

--- a/cmd/containers-storage/unshare.go
+++ b/cmd/containers-storage/unshare.go
@@ -1,0 +1,38 @@
+package main
+
+import (
+	"os"
+	"os/exec"
+
+	"github.com/containers/storage"
+	"github.com/containers/storage/pkg/mflag"
+	"github.com/containers/storage/pkg/unshare"
+)
+
+func unshareFn(flags *mflag.FlagSet, action string, m storage.Store, args []string) (int, error) {
+	unshare.MaybeReexecUsingUserNamespace(true)
+	if len(args) == 0 {
+		shell := os.Getenv("SHELL")
+		if shell == "" {
+			shell = "/bin/sh"
+		}
+		args = []string{shell}
+	}
+	cmd := exec.Command(args[0], args[1:]...)
+	cmd.Stdin, cmd.Stdout, cmd.Stderr = os.Stdin, os.Stdout, os.Stderr
+	if err := cmd.Run(); err != nil {
+		return 1, err
+	}
+	return 0, nil
+}
+
+func init() {
+	commands = append(commands, command{
+		names:       []string{"unshare"},
+		usage:       "Run a command in a user namespace",
+		optionsHelp: "[command [...]]",
+		minArgs:     0,
+		maxArgs:     -1,
+		action:      unshareFn,
+	})
+}

--- a/docs/containers-storage-create-layer.md
+++ b/docs/containers-storage-create-layer.md
@@ -20,14 +20,6 @@ returned.
 
 Sets the ID for the layer.  If none is specified, one is generated.
 
-**-m | --metadata** *metadata-value*
-
-Sets the metadata for the layer to the specified value.
-
-**-f | --metadata-file** *metadata-file*
-
-Sets the metadata for the layer to the contents of the specified file.
-
 **-l | --label** *mount-label*
 
 Sets the label which should be assigned as an SELinux context when mounting the

--- a/docs/containers-storage-create-storage-layer.md
+++ b/docs/containers-storage-create-storage-layer.md
@@ -1,0 +1,29 @@
+## containers-storage-create-storage-layer 1 "September 2022"
+
+## NAME
+containers-storage create-storage-layer - Create a layer in a lower-level storage driver
+
+## SYNOPSIS
+**containers-storage** **create-storage-layer** [*options* [...]] [*parentLayerNameOrID*]
+
+## DESCRIPTION
+Creates a new layer using the lower-level storage driver which either has a
+specified layer as its parent, or if no parent is specified, is empty.
+
+## OPTIONS
+**-i | --id** *ID*
+
+Sets the ID for the layer.  If none is specified, one is generated.
+
+**-l | --label** *mount-label*
+
+Sets the label which should be assigned as an SELinux context when mounting the
+layer.
+
+## EXAMPLE
+**containers-storage create-storage-layer somelayer**
+
+## SEE ALSO
+containers-storage-create-container(1)
+containers-storage-create-image(1)
+containers-storage-delete-layer(1)

--- a/docs/containers-storage-unshare.md
+++ b/docs/containers-storage-unshare.md
@@ -1,0 +1,17 @@
+## containers-storage-unshare 1 "September 2022"
+
+## NAME
+containers-storage unshare - Run a command in a user namespace
+
+## SYNOPSIS
+**containers-storage** **unshare** [command [...]]
+
+## DESCRIPTION
+Sets up a user namespace using mappings configured for the current user and runs
+either a specified command or the current user's shell.
+
+## EXAMPLE
+**containers-storage unshare id**
+
+## SEE ALSO
+containers-storage-status(1)

--- a/docs/containers-storage.md
+++ b/docs/containers-storage.md
@@ -68,6 +68,8 @@ The *containers-storage* command's features are broken down into several subcomm
 
  **containers-storage create-layer(1)**        Create a new layer
 
+ **containers-storage create-storage-layer(1)** Create a new layer in the lower-level storage driver
+
  **containers-storage delete(1)**              Delete a layer or image or container, with no safety checks
 
  **containers-storage delete-container(1)**    Delete a container, with safety checks
@@ -116,6 +118,8 @@ The *containers-storage* command's features are broken down into several subcomm
 
  **containers-storage unmount(1)**             Unmount a layer or container
 
+ **containers-storage unshare(1)**             Run a command in a user namespace
+
  **containers-storage version(1)**             Return containers-storage version information
 
  **containers-storage wipe(1)**                Wipe all layers, images, and containers
@@ -154,6 +158,11 @@ Set options which will be passed to the storage driver.  If not set, but
 *$STORAGE_OPTS* is set in the environment, its value is treated as a
 comma-separated list and used instead.  If the storage tree has previously been
 initialized, these need not be provided.
+
+**--unshare, -U**
+
+When started by a non-root user, run inside of a new user namespace configured
+using the system's default ID mappings for the non-root user.
 
 ## ENVIRONMENT OVERRIDES
 **CONTAINERS_STORAGE_CONF** 


### PR DESCRIPTION
* Add "unshare", "create-storage-layer", and "storage-layers" commands to the test helper, along with a "-U" flag to have it unshare when handling a given command.
* Add "-o" as an alias for the "--owner" flag to "copy".
* Add "-r" as an alias for the "--ro" flag to "mount".
* Add a "-q" ~flat~ flag to "layers" so that we can list just the IDs.
* Drop mention of a couple of not-implemented options from docs/containers-storage-create-layer.md.
