### PR TITLE
Extend driver.ListLayers()

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,7 @@ docs: install.tools ## build the docs on the host
 local-test: local-binary local-test-unit local-test-integration ## build the binaries and run the tests
 
 local-test-unit test-unit: local-binary ## run the unit tests on the host (requires\nsuperuser privileges)
-	@$(GO) test $(MOD_VENDOR) $(BUILDFLAGS) $(TESTFLAGS) $(shell $(GO) list ./... | grep -v ^$(PACKAGE)/vendor)
+	@$(GO) test -count 1 $(MOD_VENDOR) $(BUILDFLAGS) $(TESTFLAGS) $(shell $(GO) list ./... | grep -v ^$(PACKAGE)/vendor)
 
 local-test-integration test-integration: local-binary ## run the integration tests on the host (requires\nsuperuser privileges)
 	@cd tests; ./test_runner.bash

--- a/drivers/aufs/aufs.go
+++ b/drivers/aufs/aufs.go
@@ -251,9 +251,21 @@ func (a *Driver) Exists(id string) bool {
 	return true
 }
 
-// List layers (not including additional image stores)
+// ListLayers() returns all of the layers known to the driver.
 func (a *Driver) ListLayers() ([]string, error) {
-	return nil, graphdriver.ErrNotSupported
+	diffsDir := filepath.Join(a.rootPath(), "diff")
+	entries, err := os.ReadDir(diffsDir)
+	if err != nil {
+		return nil, err
+	}
+	results := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		results = append(results, entry.Name())
+	}
+	return results, nil
 }
 
 // AdditionalImageStores returns additional image stores supported by the driver

--- a/drivers/aufs/aufs_test.go
+++ b/drivers/aufs/aufs_test.go
@@ -824,3 +824,7 @@ func TestAufsCreateFromTemplate(t *testing.T) {
 func TestAufsEcho(t *testing.T) {
 	graphtest.DriverTestEcho(t, "aufs")
 }
+
+func TestAufsListLayers(t *testing.T) {
+	graphtest.DriverTestListLayers(t, "aufs")
+}

--- a/drivers/btrfs/btrfs_test.go
+++ b/drivers/btrfs/btrfs_test.go
@@ -68,6 +68,10 @@ func TestBtrfsEcho(t *testing.T) {
 	graphtest.DriverTestEcho(t, "btrfs")
 }
 
+func TestBtrfsListLayers(t *testing.T) {
+	graphtest.DriverTestListLayers(t, "btrfs")
+}
+
 func TestBtrfsTeardown(t *testing.T) {
 	graphtest.PutDriver(t)
 }

--- a/drivers/devmapper/devmapper_test.go
+++ b/drivers/devmapper/devmapper_test.go
@@ -91,12 +91,16 @@ func TestDevmapperCreateFromTemplate(t *testing.T) {
 	graphtest.DriverTestCreateFromTemplate(t, "devicemapper", "test=1")
 }
 
-func TestDevmapperTeardown(t *testing.T) {
-	graphtest.PutDriver(t)
-}
-
 func TestDevmapperEcho(t *testing.T) {
 	graphtest.DriverTestEcho(t, "devicemapper", "test=1")
+}
+
+func TestDevmapperListLayers(t *testing.T) {
+	graphtest.DriverTestListLayers(t, "devicemapper", "test=1")
+}
+
+func TestDevmapperTeardown(t *testing.T) {
+	graphtest.PutDriver(t)
 }
 
 func TestDevmapperReduceLoopBackSize(t *testing.T) {
@@ -130,7 +134,7 @@ func testChangeLoopBackSize(t *testing.T, delta, expectDataSize, expectMetaDataS
 	}
 	driver = d.(*graphdriver.NaiveDiffDriver).ProtoDriver.(*Driver)
 	if s := driver.DeviceSet.Status(); s.Data.Total != uint64(expectDataSize) || s.Metadata.Total != uint64(expectMetaDataSize) {
-		t.Fatal("data or metadata loop back size is incorrect")
+		t.Fatalf("data or metadata loop back size is incorrect (data actual/expected=%d/%d, metadata actual/expected = %d/%d)", s.Data.Total, expectDataSize, s.Metadata.Total, expectMetaDataSize)
 	}
 	if err := driver.Cleanup(); err != nil {
 		t.Fatal(err)

--- a/drivers/devmapper/driver.go
+++ b/drivers/devmapper/driver.go
@@ -55,7 +55,6 @@ func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) 
 		ctr:       graphdriver.NewRefCounter(graphdriver.NewDefaultChecker()),
 		locker:    locker.New(),
 	}
-
 	return graphdriver.NewNaiveDiffDriver(d, graphdriver.NewNaiveLayerIDMapUpdater(d)), nil
 }
 
@@ -265,11 +264,6 @@ func (d *Driver) ReadWriteDiskUsage(id string) (*directory.DiskUsage, error) {
 // Exists checks to see if the device exists.
 func (d *Driver) Exists(id string) bool {
 	return d.DeviceSet.HasDevice(id)
-}
-
-// List layers (not including additional image stores)
-func (d *Driver) ListLayers() ([]string, error) {
-	return nil, graphdriver.ErrNotSupported
 }
 
 // AdditionalImageStores returns additional image stores supported by the driver

--- a/drivers/graphtest/graphbench_unix.go
+++ b/drivers/graphtest/graphbench_unix.go
@@ -198,7 +198,7 @@ func DriverBenchDeepLayerDiff(b *testing.B, layerCount int, drivername string, d
 		b.Fatal(err)
 	}
 
-	topLayer, err := addManyLayers(driver, base, layerCount)
+	topLayer, err := addManyLayers(b, driver, base, layerCount)
 	if err != nil {
 		b.Fatal(err)
 	}
@@ -232,7 +232,7 @@ func DriverBenchDeepLayerRead(b *testing.B, layerCount int, drivername string, d
 		b.Fatal(err)
 	}
 
-	topLayer, err := addManyLayers(driver, base, layerCount)
+	topLayer, err := addManyLayers(b, driver, base, layerCount)
 	if err != nil {
 		b.Fatal(err)
 	}

--- a/drivers/overlay/overlay_test.go
+++ b/drivers/overlay/overlay_test.go
@@ -67,12 +67,16 @@ func TestOverlayChanges(t *testing.T) {
 	graphtest.DriverTestChanges(t, driverName)
 }
 
-func TestOverlayTeardown(t *testing.T) {
-	graphtest.PutDriver(t)
-}
-
 func TestOverlayEcho(t *testing.T) {
 	graphtest.DriverTestEcho(t, driverName)
+}
+
+func TestOverlayListLayers(t *testing.T) {
+	graphtest.DriverTestListLayers(t, driverName)
+}
+
+func TestOverlayTeardown(t *testing.T) {
+	graphtest.PutDriver(t)
 }
 
 // Benchmarks should always setup new driver

--- a/drivers/quota/projectquota.go
+++ b/drivers/quota/projectquota.go
@@ -67,6 +67,10 @@ import (
 
 const projectIDsAllocatedPerQuotaHome = 10000
 
+// BackingFsBlockDeviceLink is the name of a file that we place in
+// the home directory of a driver that uses this package.
+const BackingFsBlockDeviceLink = "backingFsBlockDev"
+
 // Quota limit params - currently we only control blocks hard limit and inodes
 type Quota struct {
 	Size   uint64
@@ -421,7 +425,7 @@ func makeBackingFsDev(home string) (string, error) {
 		return "", err
 	}
 
-	backingFsBlockDev := path.Join(home, "backingFsBlockDev")
+	backingFsBlockDev := path.Join(home, BackingFsBlockDeviceLink)
 	backingFsBlockDevTmp := backingFsBlockDev + ".tmp"
 	// Re-create just in case someone copied the home directory over to a new device
 	if err := unix.Mknod(backingFsBlockDevTmp, unix.S_IFBLK|0600, int(stat.Dev)); err != nil {

--- a/drivers/template.go
+++ b/drivers/template.go
@@ -34,6 +34,7 @@ func NaiveCreateFromTemplate(d TemplateDriver, id, template string, templateIDMa
 		}
 		return err
 	}
+	defer diff.Close()
 
 	applyOptions := ApplyDiffOpts{
 		Diff:              diff,

--- a/drivers/vfs/driver.go
+++ b/drivers/vfs/driver.go
@@ -14,16 +14,10 @@ import (
 	"github.com/containers/storage/pkg/directory"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/parsers"
-	"github.com/containers/storage/pkg/stringid"
 	"github.com/containers/storage/pkg/system"
 	"github.com/opencontainers/selinux/go-selinux/label"
 	"github.com/sirupsen/logrus"
 	"github.com/vbatts/tar-split/tar/storage"
-)
-
-var (
-	// CopyDir defines the copy method to use.
-	CopyDir = dirCopy
 )
 
 const defaultPerms = os.FileMode(0555)
@@ -42,11 +36,10 @@ func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) 
 	}
 
 	rootIDs := d.idMappings.RootPair()
-	if err := idtools.MkdirAllAndChown(home, 0700, rootIDs); err != nil {
+	if err := idtools.MkdirAllAndChown(filepath.Join(home, "dir"), 0700, rootIDs); err != nil {
 		return nil, err
 	}
 	for _, option := range options.DriverOptions {
-
 		key, val, err := parsers.ParseKeyValueOpt(option)
 		if err != nil {
 			return nil, err
@@ -268,7 +261,7 @@ func (d *Driver) Exists(id string) bool {
 
 // List layers (not including additional image stores)
 func (d *Driver) ListLayers() ([]string, error) {
-	entries, err := os.ReadDir(d.homes[0])
+	entries, err := os.ReadDir(filepath.Join(d.homes[0], "dir"))
 	if err != nil {
 		return nil, err
 	}
@@ -278,7 +271,7 @@ func (d *Driver) ListLayers() ([]string, error) {
 	for _, entry := range entries {
 		id := entry.Name()
 		// Does it look like a datadir directory?
-		if !entry.IsDir() || stringid.ValidateID(id) != nil {
+		if !entry.IsDir() {
 			continue
 		}
 

--- a/drivers/vfs/vfs_test.go
+++ b/drivers/vfs/vfs_test.go
@@ -37,10 +37,6 @@ func TestVfsCreateFromTemplate(t *testing.T) {
 	graphtest.DriverTestCreateFromTemplate(t, "vfs")
 }
 
-func TestVfsTeardown(t *testing.T) {
-	graphtest.PutDriver(t)
-}
-
 func TestVfsDiffApply100Files(t *testing.T) {
 	graphtest.DriverTestDiffApply(t, 100, "vfs")
 }
@@ -51,4 +47,12 @@ func TestVfsChanges(t *testing.T) {
 
 func TestVfsEcho(t *testing.T) {
 	graphtest.DriverTestEcho(t, "vfs")
+}
+
+func TestVfsListLayers(t *testing.T) {
+	graphtest.DriverTestListLayers(t, "vfs")
+}
+
+func TestVfsTeardown(t *testing.T) {
+	graphtest.PutDriver(t)
 }

--- a/drivers/zfs/zfs.go
+++ b/drivers/zfs/zfs.go
@@ -409,7 +409,6 @@ func (d *Driver) Remove(id string) error {
 
 // Get returns the mountpoint for the given id after creating the target directories if necessary.
 func (d *Driver) Get(id string, options graphdriver.MountOpts) (_ string, retErr error) {
-
 	mountpoint := d.mountPath(id)
 	if count := d.ctr.Increment(mountpoint); count > 1 {
 		return mountpoint, nil
@@ -506,7 +505,9 @@ func (d *Driver) Exists(id string) bool {
 	return d.filesystemsCache[d.zfsPath(id)]
 }
 
-// List layers (not including additional image stores)
+// List layers (not including additional image stores).  Our layers aren't all
+// dependent on a single well-known dataset, so we can't reliably tell which
+// datasets are ours and which ones just look like they could be ours.
 func (d *Driver) ListLayers() ([]string, error) {
 	return nil, graphdriver.ErrNotSupported
 }

--- a/layers.go
+++ b/layers.go
@@ -1922,6 +1922,18 @@ func (r *layerStore) Wipe() error {
 			return err
 		}
 	}
+	ids, err := r.driver.ListLayers()
+	if err != nil {
+		if !errors.Is(err, drivers.ErrNotSupported) {
+			return err
+		}
+		ids = nil
+	}
+	for _, id := range ids {
+		if err := r.driver.Remove(id); err != nil {
+			return err
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
* Implement ListLayers() for the aufs, btrfs, and devicemapper drivers, along with a unit test for them.
* Stop filtering out directories with names that aren't 64-hex chars the overlay and vfs ListLayers() implementations, which is more a convention than a hard rule.
* Close() a dangling ReadCloser in NaiveCreateFromTemplate.
* Have layerStore.Wipe() try to remove remaining listed layers after it removes the layers that the layerStore knew of.
* Switch from using plain defer to using t.Cleanup() to handle deleting layers that tests create, have the addManyLayers() test function do so as well.
* Remove vfs.CopyDir, which near as I can tell isn't referenced anywhere.