### PR TITLE
drivers: chown root mount to root in the userns

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -1478,7 +1478,7 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 		absLowers = append(absLowers, path.Join(dir, "empty"))
 	}
 	// user namespace requires this to move a directory from lower to upper.
-	rootUID, rootGID, err := idtools.GetRootUIDGID(d.uidMaps, d.gidMaps)
+	rootUID, rootGID, err := idtools.GetRootUIDGID(options.UidMaps, options.GidMaps)
 	if err != nil {
 		return "", err
 	}

--- a/drivers/vfs/driver.go
+++ b/drivers/vfs/driver.go
@@ -304,7 +304,16 @@ func (d *Driver) SupportsShifting() bool {
 // UpdateLayerIDMap updates ID mappings in a from matching the ones specified
 // by toContainer to those specified by toHost.
 func (d *Driver) UpdateLayerIDMap(id string, toContainer, toHost *idtools.IDMappings, mountLabel string) error {
-	return d.updater.UpdateLayerIDMap(id, toContainer, toHost, mountLabel)
+	if err := d.updater.UpdateLayerIDMap(id, toContainer, toHost, mountLabel); err != nil {
+		return err
+	}
+	dir := d.dir(id)
+	rootIDs, err := toHost.ToHost(idtools.IDPair{UID: 0, GID: 0})
+	if err != nil {
+		return err
+	}
+	return os.Chown(dir, rootIDs.UID, rootIDs.GID)
+
 }
 
 // Changes produces a list of changes between the specified layer

--- a/tests/idmaps.bats
+++ b/tests/idmaps.bats
@@ -853,6 +853,10 @@ load helpers
 		[ "$output" != "" ]
 		mount="$output"
 
+		uid=$(stat -c %u ${mount})
+		gid=$(stat -c %g ${mount})
+		test ${uid}:${gid} = ${uidrange[$i]}:${gidrange[$i]}
+
 		for j in $(seq $n) ; do
 			ownerids=$(stat -c %u:%g ${mount}/file$j)
 			echo on-disk IDs: "$ownerids"


### PR DESCRIPTION
chown the root mount to root in the userns so that it can be used by the container.