### PR TITLE
Initial implementation of consistency checks

### DIFF
--- a/check.go
+++ b/check.go
@@ -1,0 +1,1086 @@
+package storage
+
+import (
+	"archive/tar"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"sort"
+	"strings"
+	"sync"
+	"time"
+
+	drivers "github.com/containers/storage/drivers"
+	"github.com/containers/storage/pkg/archive"
+	"github.com/containers/storage/pkg/ioutils"
+	"github.com/containers/storage/types"
+	"github.com/sirupsen/logrus"
+)
+
+var (
+	// ErrLayerUnaccounted describes a layer that is present in the lower-level storage driver,
+	// but which is not known to or managed by the higher-level driver-agnostic logic.
+	ErrLayerUnaccounted = types.ErrLayerUnaccounted
+	// ErrLayerUnreferenced describes a layer which is not used by any image or container.
+	ErrLayerUnreferenced = types.ErrLayerUnreferenced
+	// ErrLayerIncorrectContentDigest describes a layer for which the contents of one or more
+	// files which were added in the layer appear to have changed.  It may instead look like an
+	// unnamed "file integrity checksum failed" error.
+	ErrLayerIncorrectContentDigest = types.ErrLayerIncorrectContentDigest
+	// ErrLayerIncorrectContentSize describes a layer for which regenerating the diff that was
+	// used to populate the layer produced a diff of a different size.  We check the digest
+	// first, so it's highly unlikely you'll ever see this error.
+	ErrLayerIncorrectContentSize = types.ErrLayerIncorrectContentSize
+	// ErrLayerContentModified describes a layer which contains contents which should not be
+	// there, or for which ownership/permissions/dates have been changed.
+	ErrLayerContentModified = types.ErrLayerContentModified
+	// ErrLayerDataMissing describes a layer which is missing a big data item.
+	ErrLayerDataMissing = types.ErrLayerDataMissing
+	// ErrLayerMissing describes a layer which is the missing parent of a layer.
+	ErrLayerMissing = types.ErrLayerMissing
+	// ErrImageLayerMissing describes an image which claims to have a layer that we don't know
+	// about.
+	ErrImageLayerMissing = types.ErrImageLayerMissing
+	// ErrImageDataMissing describes an image which is missing a big data item.
+	ErrImageDataMissing = types.ErrImageDataMissing
+	// ErrImageDataIncorrectSize describes an image which has a big data item which looks like
+	// its size has changed, likely because it's been modified somehow.
+	ErrImageDataIncorrectSize = types.ErrImageDataIncorrectSize
+	// ErrContainerImageMissing describes a container which claims to be based on an image that
+	// we don't know about.
+	ErrContainerImageMissing = types.ErrContainerImageMissing
+	// ErrContainerDataMissing describes a container which is missing a big data item.
+	ErrContainerDataMissing = types.ErrContainerDataMissing
+	// ErrContainerDataIncorrectSize describes a container which has a big data item which looks
+	// like its size has changed, likely because it's been modified somehow.
+	ErrContainerDataIncorrectSize = types.ErrContainerDataIncorrectSize
+)
+
+const (
+	defaultMaximumUnreferencedLayerAge = 24 * time.Hour
+)
+
+// CheckOptions is the set of options for Check(), specifying which tests to perform.
+type CheckOptions struct {
+	LayerUnreferencedMaximumAge *time.Duration // maximum allowed age of unreferenced layers
+	LayerDigests                bool           // check that contents of image layer diffs can still be reconstructed
+	LayerMountable              bool           // check that layers are mountable
+	LayerContents               bool           // check that contents of image layers match their diffs, with no unexpected changes, requires LayerMountable
+	LayerData                   bool           // check that associated "big" data items are present and can be read
+	ImageData                   bool           // check that associated "big" data items are present, can be read, and match the recorded size
+	ContainerData               bool           // check that associated "big" data items are present and can be read
+}
+
+// CheckMost returns a CheckOptions with mostly just "quick" checks enabled.
+func CheckMost() *CheckOptions {
+	return &CheckOptions{
+		LayerDigests:   true,
+		LayerMountable: true,
+		LayerContents:  false,
+		LayerData:      true,
+		ImageData:      true,
+		ContainerData:  true,
+	}
+}
+
+// CheckEverything returns a CheckOptions with every check enabled.
+func CheckEverything() *CheckOptions {
+	return &CheckOptions{
+		LayerDigests:   true,
+		LayerMountable: true,
+		LayerContents:  true,
+		LayerData:      true,
+		ImageData:      true,
+		ContainerData:  true,
+	}
+}
+
+// CheckReport is a list of detected problems.
+type CheckReport struct {
+	Layers                map[string][]error // damaged read-write layers
+	ROLayers              map[string][]error // damaged read-only layers
+	layerParentsByLayerID map[string]string
+	layerOrder            map[string]int
+	Images                map[string][]error // damaged read-write images (including those with damaged layers)
+	ROImages              map[string][]error // damaged read-only images (including those with damaged layers)
+	Containers            map[string][]error // damaged containers (including those based on damaged images)
+}
+
+// RepairOptions is the set of options for Repair().
+type RepairOptions struct {
+	RemoveContainers bool // Remove damaged containers
+}
+
+// RepairEverything returns a RepairOptions with every optional remediation
+// enabled.
+func RepairEverything() *RepairOptions {
+	return &RepairOptions{
+		RemoveContainers: true,
+	}
+}
+
+// Check returns a list of problems with what's in the store, as a whole.  It can be very expensive
+// to call.
+func (s *store) Check(options *CheckOptions) (CheckReport, error) {
+	var ignoreChownErrors bool
+	for _, o := range s.graphOptions {
+		if strings.Contains(o, "ignore_chown_errors") {
+			ignoreChownErrors = true
+		}
+	}
+
+	if options == nil {
+		options = CheckMost()
+	}
+
+	report := CheckReport{
+		Layers:                make(map[string][]error),
+		ROLayers:              make(map[string][]error),
+		layerParentsByLayerID: make(map[string]string), // layers ID -> their parent's ID, if there is one
+		layerOrder:            make(map[string]int),    // layers ID -> order for removal, if we needed to remove them all
+		Images:                make(map[string][]error),
+		ROImages:              make(map[string][]error),
+		Containers:            make(map[string][]error),
+	}
+
+	// This map will track known layer IDs.  If we have multiple stores, read-only ones can
+	// contain copies of layers that are in the read-write store, but we'll only ever be
+	// mounting or extracting contents from the read-write versions, since we always search it
+	// first.  The boolean will track if the layer is referenced by at least one image or
+	// container.
+	referencedLayers := make(map[string]bool)
+	referencedROLayers := make(map[string]bool)
+
+	// This map caches the headers for items included in layer diffs.
+	diffHeadersByLayer := make(map[string][]*tar.Header)
+	var diffHeadersByLayerMutex sync.Mutex
+
+	// Walk the list of layer stores, looking at each layer that we didn't see in a
+	// previously-visited store.
+	if errored, err := s.readAllLayerStores(func(store roLayerStore) (bool, error) {
+		layers, err := store.Layers()
+		if err != nil {
+			return true, err
+		}
+		isReadWrite := roLayerStoreIsReallyReadWrite(store)
+		readWriteDesc := ""
+		if !isReadWrite {
+			readWriteDesc = "read-only "
+		}
+		// Examine each layer in turn.
+		for i := range layers {
+			layer := layers[i]
+			id := layer.ID
+			// If we've already seen a layer with this ID, no need to process it again.
+			if _, checked := referencedLayers[id]; checked {
+				continue
+			}
+			if _, checked := referencedROLayers[id]; checked {
+				continue
+			}
+			// Note the parent of this layer, and add it to the map of known layers so
+			// that we know that we've visited it, but we haven't confirmed that it's
+			// used by anything.
+			report.layerParentsByLayerID[id] = layer.Parent
+			if isReadWrite {
+				referencedLayers[id] = false
+			} else {
+				referencedROLayers[id] = false
+			}
+			logrus.Debugf("checking %slayer %s", readWriteDesc, id)
+			// Check that all of the big data items are present and can be read.  We
+			// have no digest or size information to compare the contents to (grumble),
+			// so we can't verify that the contents haven't been changed since they
+			// were stored.
+			if options.LayerData {
+				for _, name := range layer.BigDataNames {
+					func() {
+						rc, err := store.BigData(id, name)
+						if err != nil {
+							if errors.Is(err, os.ErrNotExist) {
+								err := fmt.Errorf("%slayer %s: data item %q: %w", readWriteDesc, id, name, ErrLayerDataMissing)
+								if isReadWrite {
+									report.Layers[id] = append(report.Layers[id], err)
+								} else {
+									report.ROLayers[id] = append(report.ROLayers[id], err)
+								}
+								return
+							}
+							err = fmt.Errorf("%slayer %s: data item %q: %w", readWriteDesc, id, name, err)
+							if isReadWrite {
+								report.Layers[id] = append(report.Layers[id], err)
+							} else {
+								report.ROLayers[id] = append(report.ROLayers[id], err)
+							}
+							return
+						}
+						defer rc.Close()
+						if _, err = io.Copy(io.Discard, rc); err != nil {
+							err = fmt.Errorf("%slayer %s: data item %q: %w", readWriteDesc, id, name, err)
+							if isReadWrite {
+								report.Layers[id] = append(report.Layers[id], err)
+							} else {
+								report.ROLayers[id] = append(report.ROLayers[id], err)
+							}
+							return
+						}
+					}()
+				}
+			}
+			// Check that the content we get back when extracting the layer's contents
+			// match the recorded digest and size.  A layer for which they're not given
+			// isn't a part of an image, and is likely the read-write layer for a
+			// container, and we can't vouch for the integrity of its contents.
+			// For each layer with known contents, record the headers for the layer's
+			// diff, which we can use to reconstruct the expected contents for the tree
+			// we see when the layer is mounted.
+			if options.LayerDigests && layer.UncompressedDigest != "" {
+				func() {
+					expectedDigest := layer.UncompressedDigest
+					// Double-check that the digest isn't invalid somehow.
+					if err := layer.UncompressedDigest.Validate(); err != nil {
+						err := fmt.Errorf("%slayer %s: %w", readWriteDesc, id, err)
+						if isReadWrite {
+							report.Layers[id] = append(report.Layers[id], err)
+						} else {
+							report.ROLayers[id] = append(report.ROLayers[id], err)
+						}
+						return
+					}
+					// Extract the diff.
+					uncompressed := archive.Uncompressed
+					diffOptions := DiffOptions{
+						Compression: &uncompressed,
+					}
+					diff, err := store.Diff("", id, &diffOptions)
+					if err != nil {
+						err := fmt.Errorf("%slayer %s: %w", readWriteDesc, id, err)
+						if isReadWrite {
+							report.Layers[id] = append(report.Layers[id], err)
+						} else {
+							report.ROLayers[id] = append(report.ROLayers[id], err)
+						}
+						return
+					}
+					// Digest and count the length of the diff.
+					digester := expectedDigest.Algorithm().Digester()
+					counter := ioutils.NewWriteCounter(digester.Hash())
+					reader := io.TeeReader(diff, counter)
+					var wg sync.WaitGroup
+					var archiveErr error
+					wg.Add(1)
+					go func(layerID string, diffReader io.Reader) {
+						// Read the diff, one item at a time.
+						tr := tar.NewReader(diffReader)
+						hdr, err := tr.Next()
+						for err == nil {
+							diffHeadersByLayerMutex.Lock()
+							diffHeadersByLayer[layerID] = append(diffHeadersByLayer[layerID], hdr)
+							diffHeadersByLayerMutex.Unlock()
+							hdr, err = tr.Next()
+						}
+						if !errors.Is(err, io.EOF) {
+							archiveErr = err
+						}
+						// consume any trailer after the EOF marker
+						io.Copy(io.Discard, diffReader)
+						wg.Done()
+					}(id, reader)
+					wg.Wait()
+					diff.Close()
+					if archiveErr != nil {
+						// Reading the diff didn't end as expected
+						diffHeadersByLayerMutex.Lock()
+						delete(diffHeadersByLayer, id)
+						diffHeadersByLayerMutex.Unlock()
+						archiveErr = fmt.Errorf("%slayer %s: %w", readWriteDesc, id, archiveErr)
+						if isReadWrite {
+							report.Layers[id] = append(report.Layers[id], archiveErr)
+						} else {
+							report.ROLayers[id] = append(report.ROLayers[id], archiveErr)
+						}
+						return
+					}
+					if digester.Digest() != layer.UncompressedDigest {
+						// The diff digest didn't match.
+						diffHeadersByLayerMutex.Lock()
+						delete(diffHeadersByLayer, id)
+						diffHeadersByLayerMutex.Unlock()
+						err := fmt.Errorf("%slayer %s: %w", readWriteDesc, id, ErrLayerIncorrectContentDigest)
+						if isReadWrite {
+							report.Layers[id] = append(report.Layers[id], err)
+						} else {
+							report.ROLayers[id] = append(report.ROLayers[id], err)
+						}
+						return
+					}
+					if layer.UncompressedSize != -1 && counter.Count != layer.UncompressedSize {
+						// We expected the diff to have a specific size, and
+						// it didn't match.
+						diffHeadersByLayerMutex.Lock()
+						delete(diffHeadersByLayer, id)
+						diffHeadersByLayerMutex.Unlock()
+						err := fmt.Errorf("%slayer %s: read %d bytes instead of %d bytes: %w", readWriteDesc, id, counter.Count, layer.UncompressedSize, ErrLayerIncorrectContentSize)
+						if isReadWrite {
+							report.Layers[id] = append(report.Layers[id], err)
+						} else {
+							report.ROLayers[id] = append(report.ROLayers[id], err)
+						}
+						return
+					}
+				}()
+			}
+		}
+		// At this point we're out of things that we can be sure will work in read-only
+		// stores, so skip the rest for any stores that aren't also read-write stores.
+		if !isReadWrite {
+			return false, nil
+		}
+		// Content and mount checks are also things that we can only be sure will work in
+		// read-write stores.
+		for i := range layers {
+			layer := layers[i]
+			id := layer.ID
+			// Compare to what we see when we mount the layer and walk the tree, and
+			// flag cases where content is in the layer that shouldn't be there.  The
+			// tar-split implementation of Diff() won't catch this problem by itself.
+			if options.LayerMountable {
+				func() {
+					// Mount the layer.
+					mountPoint, err := s.graphDriver.Get(id, drivers.MountOpts{MountLabel: layer.MountLabel})
+					if err != nil {
+						err := fmt.Errorf("%slayer %s: %w", readWriteDesc, id, err)
+						if isReadWrite {
+							report.Layers[id] = append(report.Layers[id], err)
+						} else {
+							report.ROLayers[id] = append(report.ROLayers[id], err)
+						}
+						return
+					}
+					// Unmount the layer when we're done in here.
+					defer func() {
+						if err := s.graphDriver.Put(id); err != nil {
+							err := fmt.Errorf("%slayer %s: %w", readWriteDesc, id, err)
+							if isReadWrite {
+								report.Layers[id] = append(report.Layers[id], err)
+							} else {
+								report.ROLayers[id] = append(report.ROLayers[id], err)
+							}
+							return
+						}
+					}()
+					// If we're not looking at layer contents, or we didn't
+					// look at the diff for this layer, we're done here.
+					if !options.LayerDigests || layer.UncompressedDigest == "" || !options.LayerContents {
+						return
+					}
+					// Build a list of all of the changes in all of the layers
+					// that make up the tree we're looking at.
+					diffHeaderSet := [][]*tar.Header{}
+					// If we don't know _all_ of the changes that produced this
+					// layer, it's not part of an image, so we're done here.
+					for layerID := id; layerID != ""; layerID = report.layerParentsByLayerID[layerID] {
+						diffHeadersByLayerMutex.Lock()
+						layerChanges, haveChanges := diffHeadersByLayer[layerID]
+						diffHeadersByLayerMutex.Unlock()
+						if !haveChanges {
+							return
+						}
+						// The diff headers for this layer go _before_ those of
+						// layers that inherited some of its contents.
+						diffHeaderSet = append([][]*tar.Header{layerChanges}, diffHeaderSet...)
+					}
+					expectedCheckDirectory := newCheckDirectoryDefaults()
+					for _, diffHeaders := range diffHeaderSet {
+						expectedCheckDirectory.headers(diffHeaders)
+					}
+					// Scan the directory tree under the mount point.
+					actualCheckDirectory, err := newCheckDirectoryFromDirectory(mountPoint)
+					if err != nil {
+						err := fmt.Errorf("scanning contents of %slayer %s: %w", readWriteDesc, id, err)
+						if isReadWrite {
+							report.Layers[id] = append(report.Layers[id], err)
+						} else {
+							report.ROLayers[id] = append(report.ROLayers[id], err)
+						}
+						return
+					}
+					// Every departure from our expectations is an error.
+					diffs := compareCheckDirectory(expectedCheckDirectory, actualCheckDirectory, ignoreChownErrors)
+					for _, diff := range diffs {
+						err := fmt.Errorf("%slayer %s: %s, %w", readWriteDesc, id, diff, ErrLayerContentModified)
+						if isReadWrite {
+							report.Layers[id] = append(report.Layers[id], err)
+						} else {
+							report.ROLayers[id] = append(report.ROLayers[id], err)
+						}
+					}
+				}()
+			}
+		}
+		// Check that we don't have any dangling parent layer references.
+		for id, parent := range report.layerParentsByLayerID {
+			// If this layer doesn't have a parent, no problem.
+			if parent == "" {
+				continue
+			}
+			// If we've already seen a layer with this parent ID, skip it.
+			if _, checked := referencedLayers[parent]; checked {
+				continue
+			}
+			if _, checked := referencedROLayers[parent]; checked {
+				continue
+			}
+			// We haven't seen a layer with the ID that this layer's record
+			// says is its parent's ID.
+			err := fmt.Errorf("%slayer %s: %w", readWriteDesc, parent, ErrLayerMissing)
+			report.Layers[id] = append(report.Layers[id], err)
+		}
+		return false, nil
+	}); errored {
+		return CheckReport{}, err
+	}
+
+	// This map will track examined images.  If we have multiple stores, read-only ones can
+	// contain copies of images that are also in the read-write store, or the read-write store
+	// may contain a duplicate entry that refers to layers in the read-only stores, but when
+	// trying to export them, we only look at the first copy of the image.
+	examinedImages := make(map[string]struct{})
+
+	// Walk the list of image stores, looking at each image that we didn't see in a
+	// previously-visited store.
+	if errored, err := s.readAllImageStores(func(store roImageStore) (bool, error) {
+		images, err := store.Images()
+		if err != nil {
+			return true, err
+		}
+		isReadWrite := roImageStoreIsReallyReadWrite(store)
+		readWriteDesc := ""
+		if !isReadWrite {
+			readWriteDesc = "read-only "
+		}
+		// Examine each image in turn.
+		for i := range images {
+			image := images[i]
+			id := image.ID
+			// If we've already seen an image with this ID, skip it.
+			if _, checked := examinedImages[id]; checked {
+				continue
+			}
+			examinedImages[id] = struct{}{}
+			logrus.Debugf("checking %simage %s", readWriteDesc, id)
+			if options.ImageData {
+				// Check that all of the big data items are present and reading them
+				// back gives us the right amount of data.  Even though we record
+				// digests that can be used to look them up, we don't know how they
+				// were calculated (they're only used as lookup keys), so do not try
+				// to check them.
+				for _, key := range image.BigDataNames {
+					func() {
+						data, err := store.BigData(id, key)
+						if err != nil {
+							if errors.Is(err, os.ErrNotExist) {
+								err = fmt.Errorf("%simage %s: data item %q: %w", readWriteDesc, id, key, ErrImageDataMissing)
+								if isReadWrite {
+									report.Images[id] = append(report.Images[id], err)
+								} else {
+									report.ROImages[id] = append(report.ROImages[id], err)
+								}
+								return
+							}
+							err = fmt.Errorf("%simage %s: data item %q: %w", readWriteDesc, id, key, err)
+							if isReadWrite {
+								report.Images[id] = append(report.Images[id], err)
+							} else {
+								report.ROImages[id] = append(report.ROImages[id], err)
+							}
+							return
+						}
+						if int64(len(data)) != image.BigDataSizes[key] {
+							err = fmt.Errorf("%simage %s: data item %q: %w", readWriteDesc, id, key, ErrImageDataIncorrectSize)
+							if isReadWrite {
+								report.Images[id] = append(report.Images[id], err)
+							} else {
+								report.ROImages[id] = append(report.ROImages[id], err)
+							}
+							return
+						}
+					}()
+				}
+			}
+			// Walk the layers list for the image.  For every layer that the image uses
+			// that has errors, the layer's errors are also the image's errors.
+			examinedImageLayers := make(map[string]struct{})
+			for _, topLayer := range append([]string{image.TopLayer}, image.MappedTopLayers...) {
+				if topLayer == "" {
+					continue
+				}
+				if _, checked := examinedImageLayers[topLayer]; checked {
+					continue
+				}
+				examinedImageLayers[topLayer] = struct{}{}
+				for layer := topLayer; layer != ""; layer = report.layerParentsByLayerID[layer] {
+					// The referenced layer should have a corresponding entry in
+					// one map or the other.
+					_, checked := referencedLayers[layer]
+					_, checkedRO := referencedROLayers[layer]
+					if !checked && !checkedRO {
+						err := fmt.Errorf("layer %s: %w", layer, ErrImageLayerMissing)
+						err = fmt.Errorf("%simage %s: %w", readWriteDesc, id, err)
+						if isReadWrite {
+							report.Images[id] = append(report.Images[id], err)
+						} else {
+							report.ROImages[id] = append(report.ROImages[id], err)
+						}
+					} else {
+						// Count this layer as referenced.  Whether by the
+						// image or one of its child layers doesn't matter
+						// at this point.
+						if _, ok := referencedLayers[layer]; ok {
+							referencedLayers[layer] = true
+						}
+						if _, ok := referencedROLayers[layer]; ok {
+							referencedROLayers[layer] = true
+						}
+					}
+					if isReadWrite {
+						if len(report.Layers[layer]) > 0 {
+							report.Images[id] = append(report.Images[id], report.Layers[layer]...)
+						}
+						if len(report.ROLayers[layer]) > 0 {
+							report.Images[id] = append(report.Images[id], report.ROLayers[layer]...)
+						}
+					} else {
+						if len(report.Layers[layer]) > 0 {
+							report.ROImages[id] = append(report.ROImages[id], report.Layers[layer]...)
+						}
+						if len(report.ROLayers[layer]) > 0 {
+							report.ROImages[id] = append(report.ROImages[id], report.ROLayers[layer]...)
+						}
+					}
+				}
+			}
+		}
+		return false, nil
+	}); errored {
+		return CheckReport{}, err
+	}
+
+	// Iterate over each container in turn.
+	if done, err := s.readContainerStore(func() (bool, error) {
+		containers, err := s.containerStore.Containers()
+		if err != nil {
+			return true, err
+		}
+		for i := range containers {
+			container := containers[i]
+			id := container.ID
+			logrus.Debugf("checking container %s", id)
+			if options.ContainerData {
+				// Check that all of the big data items are present and reading them
+				// back gives us the right amount of data.
+				for _, key := range container.BigDataNames {
+					func() {
+						data, err := s.containerStore.BigData(id, key)
+						if err != nil {
+							if errors.Is(err, os.ErrNotExist) {
+								err = fmt.Errorf("container %s: data item %q: %w", id, key, ErrContainerDataMissing)
+								report.Containers[id] = append(report.Containers[id], err)
+								return
+							}
+							err = fmt.Errorf("container %s: data item %q: %w", id, key, err)
+							report.Containers[id] = append(report.Containers[id], err)
+							return
+						}
+						if int64(len(data)) != container.BigDataSizes[key] {
+							err = fmt.Errorf("container %s: data item %q: %w", id, key, ErrContainerDataIncorrectSize)
+							report.Containers[id] = append(report.Containers[id], err)
+							return
+						}
+					}()
+				}
+			}
+			// Look at the container's base image.  If the image has errors, the image's errors
+			// are the container's errors.
+			if container.ImageID != "" {
+				if _, checked := examinedImages[container.ImageID]; !checked {
+					err := fmt.Errorf("image %s: %w", container.ImageID, ErrContainerImageMissing)
+					report.Containers[id] = append(report.Containers[id], err)
+				}
+				if len(report.Images[container.ImageID]) > 0 {
+					report.Containers[id] = append(report.Containers[id], report.Images[container.ImageID]...)
+				}
+				if len(report.ROImages[container.ImageID]) > 0 {
+					report.Containers[id] = append(report.Containers[id], report.ROImages[container.ImageID]...)
+				}
+			}
+			// Count the container's layer as referenced.
+			if container.LayerID != "" {
+				referencedLayers[container.LayerID] = true
+			}
+		}
+		return false, nil
+	}); done {
+		return CheckReport{}, err
+	}
+
+	// Now go back through all of the layer stores, and flag any layers which don't belong
+	// to an image or a container, and has been around longer than we can reasonably expect
+	// such a layer to be present before a corresponding image record is added.
+	if errored, err := s.readAllLayerStores(func(store roLayerStore) (bool, error) {
+		if isReadWrite := roLayerStoreIsReallyReadWrite(store); !isReadWrite {
+			return false, nil
+		}
+		layers, err := store.Layers()
+		if err != nil {
+			return true, err
+		}
+		for _, layer := range layers {
+			maximumAge := defaultMaximumUnreferencedLayerAge
+			if options.LayerUnreferencedMaximumAge != nil {
+				maximumAge = *options.LayerUnreferencedMaximumAge
+			}
+			if referenced := referencedLayers[layer.ID]; !referenced {
+				if layer.Created.IsZero() || layer.Created.Add(maximumAge).Before(time.Now()) {
+					// Either we don't (and never will) know when this layer was
+					// created, or it was created far enough in the past that we're
+					// reasonably sure it's not part of an image that's being written
+					// right now.
+					err := fmt.Errorf("layer %s: %w", layer.ID, ErrLayerUnreferenced)
+					report.Layers[layer.ID] = append(report.Layers[layer.ID], err)
+				}
+			}
+		}
+		return false, nil
+	}); errored {
+		return CheckReport{}, err
+	}
+
+	// If the driver can tell us about which layers it knows about, we should have previously
+	// examined all of them.  Any that we didn't are probably just wasted space.
+	// Note: if the driver doesn't support enumerating layers, it returns ErrNotSupported.
+	if err := s.startUsingGraphDriver(); err != nil {
+		return CheckReport{}, err
+	}
+	defer s.stopUsingGraphDriver()
+	layerList, err := s.graphDriver.ListLayers()
+	if err != nil && !errors.Is(err, drivers.ErrNotSupported) {
+		return CheckReport{}, err
+	}
+	if !errors.Is(err, drivers.ErrNotSupported) {
+		for i, id := range layerList {
+			if _, known := referencedLayers[id]; !known {
+				err := fmt.Errorf("layer %s: %w", id, ErrLayerUnaccounted)
+				report.Layers[id] = append(report.Layers[id], err)
+			}
+			report.layerOrder[id] = i + 1
+		}
+	}
+
+	return report, nil
+}
+
+func roLayerStoreIsReallyReadWrite(store roLayerStore) bool {
+	return store.(*layerStore).lockfile.IsReadWrite()
+}
+
+func roImageStoreIsReallyReadWrite(store roImageStore) bool {
+	return store.(*imageStore).lockfile.IsReadWrite()
+}
+
+// Repair removes items which are themselves damaged, or which depend on items which are damaged.
+// Errors are returned if an attempt to delete an item fails.
+func (s *store) Repair(report CheckReport, options *RepairOptions) []error {
+	if options == nil {
+		options = RepairEverything()
+	}
+	var errs []error
+	// Just delete damaged containers.
+	if options.RemoveContainers {
+		for id := range report.Containers {
+			err := s.DeleteContainer(id)
+			if err != nil && !errors.Is(err, ErrContainerUnknown) {
+				err := fmt.Errorf("deleting container %s: %w", id, err)
+				errs = append(errs, err)
+			}
+		}
+	}
+	// Now delete damaged images.  Note which layers were removed as part of removing those images.
+	deletedLayers := make(map[string]struct{})
+	for id := range report.Images {
+		layers, err := s.DeleteImage(id, true)
+		if err != nil {
+			if !errors.Is(err, ErrImageUnknown) && !errors.Is(err, ErrLayerUnknown) {
+				err := fmt.Errorf("deleting image %s: %w", id, err)
+				errs = append(errs, err)
+			}
+		} else {
+			for _, layer := range layers {
+				logrus.Debugf("deleted layer %s", layer)
+				deletedLayers[layer] = struct{}{}
+			}
+			logrus.Debugf("deleted image %s", id)
+		}
+	}
+	// Build a list of the layers that we need to remove, sorted with parents of layers before
+	// layers that they are parents of.
+	layersToDelete := make([]string, 0, len(report.Layers))
+	for id := range report.Layers {
+		layersToDelete = append(layersToDelete, id)
+	}
+	depth := func(id string) int {
+		d := 0
+		parent := report.layerParentsByLayerID[id]
+		for parent != "" {
+			d++
+			parent = report.layerParentsByLayerID[parent]
+		}
+		return d
+	}
+	isUnaccounted := func(errs []error) bool {
+		for _, err := range errs {
+			if errors.Is(err, ErrLayerUnaccounted) {
+				return true
+			}
+		}
+		return false
+	}
+	sort.Slice(layersToDelete, func(i, j int) bool {
+		// we've not heard of either of them, so remove them in the order the driver suggested
+		if isUnaccounted(report.Layers[layersToDelete[i]]) &&
+			isUnaccounted(report.Layers[layersToDelete[j]]) &&
+			report.layerOrder[layersToDelete[i]] != 0 && report.layerOrder[layersToDelete[j]] != 0 {
+			return report.layerOrder[layersToDelete[i]] < report.layerOrder[layersToDelete[j]]
+		}
+		// always delete the one we've heard of first
+		if isUnaccounted(report.Layers[layersToDelete[i]]) && !isUnaccounted(report.Layers[layersToDelete[j]]) {
+			return false
+		}
+		// always delete the one we've heard of first
+		if !isUnaccounted(report.Layers[layersToDelete[i]]) && isUnaccounted(report.Layers[layersToDelete[j]]) {
+			return true
+		}
+		// we've heard of both of them; the one that's on the end of a longer chain goes first
+		return depth(layersToDelete[i]) > depth(layersToDelete[j]) // closer-to-a-notional-base layers get removed later
+	})
+	// Now delete the layers that haven't been removed along with images.
+	for _, id := range layersToDelete {
+		if _, ok := deletedLayers[id]; ok {
+			continue
+		}
+		for _, reportedErr := range report.Layers[id] {
+			var err error
+			// If a layer was unaccounted for, remove it at the storage driver level.
+			// Otherwise, remove it at the higher level and let the higher level
+			// logic worry about telling the storage driver to delete the layer.
+			if errors.Is(reportedErr, ErrLayerUnaccounted) {
+				if err = s.graphDriver.Remove(id); err != nil {
+					err = fmt.Errorf("deleting storage layer %s: %v", id, err)
+				} else {
+					logrus.Debugf("deleted storage layer %s", id)
+				}
+			} else {
+				var stillMounted bool
+				if stillMounted, err = s.Unmount(id, true); err == nil && !stillMounted {
+					logrus.Debugf("unmounted layer %s", id)
+				} else if err != nil {
+					logrus.Debugf("unmounting layer %s: %v", id, err)
+				} else {
+					logrus.Debugf("layer %s still mounted", id)
+				}
+				if err = s.DeleteLayer(id); err != nil {
+					err = fmt.Errorf("deleting layer %s: %w", id, err)
+					logrus.Debugf("deleted layer %s", id)
+				}
+			}
+			if err != nil && !errors.Is(err, ErrLayerUnknown) && !errors.Is(err, ErrNotALayer) && !errors.Is(err, os.ErrNotExist) {
+				errs = append(errs, err)
+			}
+		}
+	}
+	return errs
+}
+
+// compareFileInfo returns a string summarizing what's different between the two checkFileInfos
+func compareFileInfo(a, b checkFileInfo, ignoreChownErrors bool) string {
+	if a.typeflag == b.typeflag && a.uid != b.uid && a.gid != b.gid && a.size != b.size &&
+		(os.ModeType|os.ModePerm)&a.mode != (os.ModeType|os.ModePerm)&b.mode {
+		return ""
+	}
+	var comparison []string
+	if a.typeflag != b.typeflag {
+		comparison = append(comparison, fmt.Sprintf("filetype:%v￫%v", a.typeflag, b.typeflag))
+	}
+	if a.uid != b.uid && ignoreChownErrors {
+		comparison = append(comparison, fmt.Sprintf("uid:%d￫%d", a.uid, b.uid))
+	}
+	if a.gid != b.gid && ignoreChownErrors {
+		comparison = append(comparison, fmt.Sprintf("gid:%d￫%d", a.gid, b.gid))
+	}
+	if a.size != b.size {
+		comparison = append(comparison, fmt.Sprintf("size:%d￫%d", a.size, b.size))
+	}
+	if (os.ModeType|os.ModePerm)&a.mode != (os.ModeType|os.ModePerm)&b.mode {
+		comparison = append(comparison, fmt.Sprintf("mode:%04o￫%04o", a.mode, b.mode))
+	}
+	return strings.Join(comparison, ",")
+}
+
+// checkFileInfo is what we care about for files
+type checkFileInfo struct {
+	typeflag byte
+	uid, gid int
+	size     int64
+	mode     os.FileMode
+}
+
+// checkDirectory is a node in a filesystem record, possibly the top
+type checkDirectory struct {
+	directory map[string]*checkDirectory // subdirectories
+	file      map[string]checkFileInfo   // non-directories
+	checkFileInfo
+}
+
+// newCheckDirectory creates an empty checkDirectory
+func newCheckDirectory(uid, gid int, size int64, mode os.FileMode) *checkDirectory {
+	return &checkDirectory{
+		directory: make(map[string]*checkDirectory),
+		file:      make(map[string]checkFileInfo),
+		checkFileInfo: checkFileInfo{
+			typeflag: tar.TypeDir,
+			uid:      uid,
+			gid:      gid,
+			size:     size,
+			mode:     mode,
+		},
+	}
+}
+
+// newCheckDirectoryDefaults creates an empty checkDirectory with hardwired defaults for the UID
+// (0), GID (0), size (0) and permissions (0o555)
+func newCheckDirectoryDefaults() *checkDirectory {
+	return newCheckDirectory(0, 0, 0, 0o555)
+}
+
+// newCheckDirectoryFromDirectory creates a checkDirectory for an on-disk directory tree
+func newCheckDirectoryFromDirectory(dir string) (*checkDirectory, error) {
+	cd := newCheckDirectoryDefaults()
+	err := filepath.Walk(dir, func(walkpath string, info os.FileInfo, err error) error {
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		rel, err := filepath.Rel(dir, walkpath)
+		if err != nil {
+			return err
+		}
+		hdr, err := tar.FileInfoHeader(info, "") // we don't record link targets, so don't bother looking it up
+		if err != nil {
+			return err
+		}
+		if hdr.Typeflag == tar.TypeLink || hdr.Typeflag == tar.TypeRegA {
+			hdr.Typeflag = tar.TypeReg
+		}
+		hdr.Name = filepath.ToSlash(rel)
+		cd.header(hdr)
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+	return cd, nil
+}
+
+// add adds an item to a checkDirectory
+func (c *checkDirectory) add(path string, typeflag byte, uid, gid int, size int64, mode os.FileMode) {
+	components := strings.Split(path, "/")
+	if components[len(components)-1] == "" {
+		components = components[:len(components)-1]
+	}
+	if typeflag == tar.TypeLink || typeflag == tar.TypeRegA {
+		typeflag = tar.TypeReg
+	}
+	switch len(components) {
+	case 0:
+		return
+	case 1:
+		switch typeflag {
+		case tar.TypeDir:
+			delete(c.file, components[0])
+			// directory entries are mergers, not replacements
+			if _, present := c.directory[components[0]]; !present {
+				c.directory[components[0]] = newCheckDirectory(uid, gid, size, mode)
+			} else {
+				c.directory[components[0]].checkFileInfo = checkFileInfo{
+					typeflag: tar.TypeDir,
+					uid:      uid,
+					gid:      gid,
+					size:     size,
+					mode:     mode,
+				}
+			}
+		default:
+			// treat these as TypeReg items
+			delete(c.directory, components[0])
+			c.file[components[0]] = checkFileInfo{
+				typeflag: typeflag,
+				uid:      uid,
+				gid:      gid,
+				size:     size,
+				mode:     mode,
+			}
+		case tar.TypeXGlobalHeader:
+			// ignore, since even though it looks like a valid pathname, it doesn't end
+			// up on the filesystem
+		}
+		return
+	}
+	subdirectory := c.directory[components[0]]
+	if subdirectory == nil {
+		subdirectory = newCheckDirectory(uid, gid, size, mode)
+		c.directory[components[0]] = subdirectory
+	}
+	subdirectory.add(strings.Join(components[1:], "/"), typeflag, uid, gid, size, mode)
+}
+
+// remove removes an item from a checkDirectory
+func (c *checkDirectory) remove(path string) {
+	components := strings.Split(path, "/")
+	if len(components) == 1 {
+		delete(c.directory, components[0])
+		delete(c.file, components[0])
+		return
+	}
+	subdirectory := c.directory[components[0]]
+	if subdirectory != nil {
+		subdirectory.remove(strings.Join(components[1:], "/"))
+	}
+}
+
+// header updates a checkDirectory using information from the passed-in header
+func (c *checkDirectory) header(hdr *tar.Header) {
+	name := path.Clean(hdr.Name)
+	dir, base := path.Split(name)
+	if strings.HasPrefix(base, archive.WhiteoutPrefix) {
+		if base == archive.WhiteoutOpaqueDir {
+			c.remove(path.Clean(dir))
+			c.add(path.Clean(dir), tar.TypeDir, hdr.Uid, hdr.Gid, hdr.Size, os.FileMode(hdr.Mode))
+		} else {
+			c.remove(path.Join(dir, base[len(archive.WhiteoutPrefix):]))
+		}
+	} else {
+		c.add(name, hdr.Typeflag, hdr.Uid, hdr.Gid, hdr.Size, os.FileMode(hdr.Mode))
+	}
+}
+
+// headers updates a checkDirectory using information from the passed-in header slice
+func (c *checkDirectory) headers(hdrs []*tar.Header) {
+	hdrs = append([]*tar.Header{}, hdrs...)
+	// sort the headers from the diff to ensure that whiteouts appear
+	// before content when they both appear in the same directory, per
+	// https://github.com/opencontainers/image-spec/blob/main/layer.md#whiteouts
+	sort.Slice(hdrs, func(i, j int) bool {
+		idir, ifile := path.Split(hdrs[i].Name)
+		jdir, jfile := path.Split(hdrs[j].Name)
+		if idir != jdir {
+			return hdrs[i].Name < hdrs[j].Name
+		}
+		if ifile == archive.WhiteoutOpaqueDir {
+			return true
+		}
+		if strings.HasPrefix(ifile, archive.WhiteoutPrefix) && !strings.HasPrefix(jfile, archive.WhiteoutPrefix) {
+			return true
+		}
+		return false
+	})
+	for _, hdr := range hdrs {
+		c.header(hdr)
+	}
+}
+
+// names provides a sorted list of the path names in the directory tree
+func (c *checkDirectory) names() []string {
+	names := make([]string, 0, len(c.file)+len(c.directory))
+	for name := range c.file {
+		names = append(names, name)
+	}
+	for name, subdirectory := range c.directory {
+		names = append(names, name+"/")
+		for _, subname := range subdirectory.names() {
+			names = append(names, name+"/"+subname)
+		}
+	}
+	return names
+}
+
+// compareCheckSubdirectory walks two subdirectory trees and returns a list of differences
+func compareCheckSubdirectory(path string, a, b *checkDirectory, ignoreChownErrors bool) []string {
+	var diff []string
+	if a == nil {
+		a = newCheckDirectoryDefaults()
+	}
+	if b == nil {
+		b = newCheckDirectoryDefaults()
+	}
+	for aname, adir := range a.directory {
+		if bdir, present := b.directory[aname]; !present {
+			// directory was removed
+			diff = append(diff, "-"+path+"/"+aname+"/")
+			diff = append(diff, compareCheckSubdirectory(path+"/"+aname, adir, nil, ignoreChownErrors)...)
+		} else {
+			// directory is in both trees; descend
+			if attributes := compareFileInfo(adir.checkFileInfo, bdir.checkFileInfo, ignoreChownErrors); attributes != "" {
+				diff = append(diff, path+"/"+aname+"("+attributes+")")
+			}
+			diff = append(diff, compareCheckSubdirectory(path+"/"+aname, adir, bdir, ignoreChownErrors)...)
+		}
+	}
+	for bname, bdir := range b.directory {
+		if _, present := a.directory[bname]; !present {
+			// directory added
+			diff = append(diff, "+"+path+"/"+bname+"/")
+			diff = append(diff, compareCheckSubdirectory(path+"/"+bname, nil, bdir, ignoreChownErrors)...)
+		}
+	}
+	for aname, afile := range a.file {
+		if bfile, present := b.file[aname]; !present {
+			// non-directory removed or replaced
+			diff = append(diff, "-"+path+"/"+aname)
+		} else {
+			// item is in both trees; compare
+			if attributes := compareFileInfo(afile, bfile, ignoreChownErrors); attributes != "" {
+				diff = append(diff, path+"/"+aname+"("+attributes+")")
+			}
+		}
+	}
+	for bname := range b.file {
+		filetype, present := a.file[bname]
+		if !present {
+			// non-directory added or replaced with something else
+			diff = append(diff, "+"+path+"/"+bname)
+			continue
+		}
+		if attributes := compareFileInfo(filetype, b.file[bname], ignoreChownErrors); attributes != "" {
+			// non-directory replaced with non-directory
+			diff = append(diff, "+"+path+"/"+bname+"("+attributes+")")
+		}
+	}
+	return diff
+}
+
+// compareCheckDirectory walks two directory trees and returns a sorted list of differences
+func compareCheckDirectory(a, b *checkDirectory, ignoreChownErrors bool) []string {
+	diff := compareCheckSubdirectory("", a, b, ignoreChownErrors)
+	sort.Slice(diff, func(i, j int) bool {
+		if strings.Compare(diff[i][1:], diff[j][1:]) < 0 {
+			return true
+		}
+		if diff[i][0] == '-' {
+			return true
+		}
+		return false
+	})
+	return diff
+}

--- a/check_test.go
+++ b/check_test.go
@@ -1,0 +1,101 @@
+package storage
+
+import (
+	"archive/tar"
+	"sort"
+	"testing"
+
+	"github.com/containers/storage/pkg/archive"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestCheckDirectory(t *testing.T) {
+	vectors := []struct {
+		description string
+		headers     []tar.Header
+		expected    []string
+	}{
+		{
+			description: "basic",
+			headers: []tar.Header{
+				{Name: "a", Typeflag: tar.TypeDir},
+			},
+			expected: []string{
+				"a/",
+			},
+		},
+		{
+			description: "whiteout",
+			headers: []tar.Header{
+				{Name: "a", Typeflag: tar.TypeDir},
+				{Name: "a/b", Typeflag: tar.TypeDir},
+				{Name: "a/b/c", Typeflag: tar.TypeReg},
+				{Name: "a/b/d", Typeflag: tar.TypeReg},
+				{Name: "a/b/" + archive.WhiteoutPrefix + "c", Typeflag: tar.TypeReg},
+			},
+			expected: []string{
+				"a/",
+				"a/b/",
+				"a/b/d",
+			},
+		},
+		{
+			description: "opaque",
+			headers: []tar.Header{
+				{Name: "a", Typeflag: tar.TypeDir},
+				{Name: "a/b", Typeflag: tar.TypeDir},
+				{Name: "a/b/c", Typeflag: tar.TypeReg},
+				{Name: "a/b/d", Typeflag: tar.TypeReg},
+				{Name: "a/b/" + archive.WhiteoutOpaqueDir, Typeflag: tar.TypeReg},
+			},
+			expected: []string{
+				"a/",
+				"a/b/",
+			},
+		},
+	}
+	for i := range vectors {
+		t.Run(vectors[i].description, func(t *testing.T) {
+			cd := newCheckDirectoryDefaults()
+			for _, hdr := range vectors[i].headers {
+				cd.header(&hdr)
+			}
+			actual := cd.names()
+			sort.Strings(actual)
+			expected := append([]string{}, vectors[i].expected...)
+			sort.Strings(expected)
+			assert.Equal(t, expected, actual)
+		})
+	}
+}
+
+func TestCheckDetectWriteable(t *testing.T) {
+	var sawRWlayers, sawRWimages bool
+	stoar, err := GetStore(StoreOptions{
+		RunRoot:         t.TempDir(),
+		GraphRoot:       t.TempDir(),
+		GraphDriverName: "vfs",
+	})
+	require.NoError(t, err, "unexpected error initializing test store")
+	s, ok := stoar.(*store)
+	require.True(t, ok, "unexpected error making type assertion")
+	done, err := s.readAllLayerStores(func(store roLayerStore) (bool, error) {
+		if roLayerStoreIsReallyReadWrite(store) { // implicitly checking that the type assertion in this function doesn't panic
+			sawRWlayers = true
+		}
+		return false, nil
+	})
+	assert.False(t, done, "unexpected error from readAllLayerStores")
+	assert.NoError(t, err, "unexpected error from readAllLayerStores")
+	assert.True(t, sawRWlayers, "unexpected error detecting which layer store is writeable")
+	done, err = s.readAllImageStores(func(store roImageStore) (bool, error) {
+		if roImageStoreIsReallyReadWrite(store) { // implicitly checking that the type assertion in this function doesn't panic
+			sawRWimages = true
+		}
+		return false, nil
+	})
+	assert.False(t, done, "unexpected error from readAllImageStores")
+	assert.NoError(t, err, "unexpected error from readAllImageStores")
+	assert.True(t, sawRWimages, "unexpected error detecting which image store is writeable")
+}

--- a/cmd/containers-storage/check.go
+++ b/cmd/containers-storage/check.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"time"
+
+	"github.com/containers/storage"
+	"github.com/containers/storage/pkg/mflag"
+)
+
+var (
+	quickCheck, repair, forceRepair bool
+	maximumUnreferencedLayerAge     string
+)
+
+func check(flags *mflag.FlagSet, action string, m storage.Store, args []string) (int, error) {
+	if forceRepair {
+		repair = true
+	}
+	defer func() {
+		if _, err := m.Shutdown(true); err != nil {
+			fmt.Fprintf(os.Stderr, "shutdown: %v\n", err)
+		}
+	}()
+	checkOptions := storage.CheckEverything()
+	if quickCheck {
+		checkOptions = storage.CheckMost()
+	}
+	if maximumUnreferencedLayerAge != "" {
+		age, err := time.ParseDuration(maximumUnreferencedLayerAge)
+		if err != nil {
+			return 1, err
+		}
+		checkOptions.LayerUnreferencedMaximumAge = &age
+	}
+	report, err := m.Check(checkOptions)
+	if err != nil {
+		return 1, err
+	}
+	outputNonJSON := func(report storage.CheckReport) {
+		for id, errs := range report.Layers {
+			if len(errs) > 0 {
+				fmt.Fprintf(os.Stdout, "layer %s:\n", id)
+			}
+			for _, err := range errs {
+				fmt.Fprintf(os.Stdout, " %v\n", err)
+			}
+		}
+		for id, errs := range report.ROLayers {
+			if len(errs) > 0 {
+				fmt.Fprintf(os.Stdout, "read-only layer %s:\n", id)
+			}
+			for _, err := range errs {
+				fmt.Fprintf(os.Stdout, " %v\n", err)
+			}
+		}
+		for id, errs := range report.Images {
+			if len(errs) > 0 {
+				fmt.Fprintf(os.Stdout, "image %s:\n", id)
+			}
+			for _, err := range errs {
+				fmt.Fprintf(os.Stdout, " %v\n", err)
+			}
+		}
+		for id, errs := range report.ROImages {
+			if len(errs) > 0 {
+				fmt.Fprintf(os.Stdout, "read-only image %s:\n", id)
+			}
+			for _, err := range errs {
+				fmt.Fprintf(os.Stdout, " %v\n", err)
+			}
+		}
+		for id, errs := range report.Containers {
+			if len(errs) > 0 {
+				fmt.Fprintf(os.Stdout, "container %s:\n", id)
+			}
+			for _, err := range errs {
+				fmt.Fprintf(os.Stdout, " %v\n", err)
+			}
+		}
+	}
+
+	if jsonOutput {
+		if err := json.NewEncoder(os.Stdout).Encode(report); err != nil {
+			return 1, err
+		}
+	} else {
+		outputNonJSON(report)
+	}
+
+	if !repair {
+		if len(report.Layers) > 0 || len(report.ROLayers) > 0 || len(report.Images) > 0 || len(report.ROImages) > 0 || len(report.Containers) > 0 {
+			return 1, fmt.Errorf("%d layer errors, %d read-only layer errors, %d image errors, %d read-only image errors, %d container errors", len(report.Layers), len(report.ROLayers), len(report.Images), len(report.ROImages), len(report.Containers))
+		}
+	} else {
+		options := storage.RepairOptions{
+			RemoveContainers: forceRepair,
+		}
+		if errs := m.Repair(report, &options); len(errs) != 0 {
+			if jsonOutput {
+				if err := json.NewEncoder(os.Stdout).Encode(errs); err != nil {
+					return 1, err
+				}
+			} else {
+				for _, err := range errs {
+					fmt.Fprintf(os.Stderr, "%v\n", err)
+				}
+			}
+			return 1, errs[0]
+		}
+		if len(report.ROLayers) > 0 || len(report.ROImages) > 0 || (!options.RemoveContainers && len(report.Containers) > 0) {
+			var err error
+			if options.RemoveContainers {
+				err = fmt.Errorf("%d read-only layer errors, %d read-only image errors", len(report.ROLayers), len(report.ROImages))
+			} else {
+				err = fmt.Errorf("%d read-only layer errors, %d read-only image errors, %d container errors", len(report.ROLayers), len(report.ROImages), len(report.Containers))
+			}
+			return 1, err
+		}
+	}
+	return 0, nil
+}
+
+func init() {
+	commands = append(commands, command{
+		names:   []string{"check"},
+		usage:   "Check storage consistency",
+		minArgs: 0,
+		maxArgs: 0,
+		action:  check,
+		addFlags: func(flags *mflag.FlagSet, cmd *command) {
+			flags.BoolVar(&jsonOutput, []string{"-json", "j"}, jsonOutput, "Prefer JSON output")
+			flags.StringVar(&maximumUnreferencedLayerAge, []string{"-max", "m"}, "24h", "Maximum allowed age for unreferenced layers")
+			flags.BoolVar(&repair, []string{"-repair", "r"}, repair, "Remove damaged images and layers")
+			flags.BoolVar(&forceRepair, []string{"-force", "f"}, forceRepair, "Remove damaged containers")
+			flags.BoolVar(&quickCheck, []string{"-quick", "q"}, quickCheck, "Perform only quick checks")
+		},
+	})
+}

--- a/docs/containers-storage-check.md
+++ b/docs/containers-storage-check.md
@@ -1,0 +1,34 @@
+## containers-storage-check 1 "September 2022"
+
+## NAME
+containers-storage check - Check for and remove damaged layers/images/containers
+
+## SYNOPSIS
+**containers-storage** **check** [-q] [-r [-f]]
+
+## DESCRIPTION
+Checks layers, images, and containers for identifiable damage.
+
+## OPTIONS
+
+**-f**
+
+When repairing damage, also remove damaged containers.  No effect unless *-r*
+is used.
+
+**-r**
+
+Attempt to repair damage by removing damaged images and layers.  If not
+specified, damage is reported but not acted upon.
+
+**-q**
+
+Perform only checks which are not expected to be time-consuming.  This
+currently skips verifying that a layer which was initialized using a diff can
+reproduce that diff if asked to.
+
+## EXAMPLE
+**containers-storage check -r -f
+
+## SEE ALSO
+containers-storage(1)

--- a/docs/containers-storage.md
+++ b/docs/containers-storage.md
@@ -58,6 +58,8 @@ The *containers-storage* command's features are broken down into several subcomm
 
  **containers-storage changes(1)**             Compare two layers
 
+ **containers-storage check(1)**               Check for and possibly remove damaged layers/images/containers
+
  **containers-storage container(1)**           Examine a container
 
  **containers-storage containers(1)**          List containers

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -111,6 +111,10 @@ type ProtoDriver interface {
 	Exists(id string) bool
 	// Returns a list of layer ids that exist on this driver (does not include
 	// additional storage layers). Not supported by all backends.
+	// If the driver requires that layers be removed in a particular order,
+	// usually due to parent-child relationships that it cares about, The
+	// list should be sorted well enough so that if all layers need to be
+	// removed, they can be removed in the order in which they're returned.
 	ListLayers() ([]string, error)
 	// Status returns a set of key-value pairs which give low
 	// level diagnostic status about this driver.

--- a/tests/check.bats
+++ b/tests/check.bats
@@ -1,0 +1,1064 @@
+#!/usr/bin/env bats
+
+load helpers
+
+# Check that the storage driver doesn't have any layers that we don't know
+# about, and would therefore never be able to clean up, i.e., that we can
+# spot them.
+@test "check-unmanaged-layers" {
+	run storage --debug=false storage-layers
+	echo storage-layers: "$output"
+	if [ $status -eq 1 -a "$output" == "driver not supported" ] ; then
+		skip "driver $STORAGE_DRIVER does not support ListLayers()"
+	fi
+
+	run storage --debug=false create-storage-layer
+	echo create-storage-layer: "$output"
+	[[ $status -eq 0 ]]
+	layer=$output
+
+	run storage create-storage-layer "$layer"
+	echo create-storage-layer: "$output"
+	[[ $status -eq 0 ]]
+
+	run storage create-storage-layer
+	echo create-storage-layer: "$output"
+	[[ $status -eq 0 ]]
+
+	run storage check -r
+	echo "check -r:" "$output"
+	[[ $status -eq 0 ]]
+	[[ $output =~ "layer ${layer}: layer in lower level storage driver not accounted for" ]]
+
+	run storage --debug=false storage-layers
+	echo storage-layers: "$output"
+	[[ $status -eq 0 ]]
+	[[ $output == "" ]]
+}
+
+# Check that nothing happens when the storage driver had layers that we don't
+# know about in a read-only store.  It's not as if we can do anything about
+# them.
+@test "check-unmanaged-ro-layers" {
+	case "$STORAGE_DRIVER" in
+	overlay*|vfs)
+		;;
+	*)
+		skip "driver $STORAGE_DRIVER does not support additional image stores"
+		;;
+	esac
+
+	# Put a couple of unmanaged layers in the read-only location.
+	mkdir ${TESTDIR}/{ro-root,ro-runroot}
+
+	run storage --debug=false --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot --debug=false create-storage-layer
+	echo create-storage-layer: "$output"
+	[[ $status -eq 0 ]]
+	layer=$output
+
+	run storage --debug=false --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot --debug=false create-storage-layer "$layer"
+	echo create-storage-layer: "$output"
+	[[ $status -eq 0 ]]
+	otherlayer="$output"
+
+        storage --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot shutdown
+
+	# Put an image in the read-write location.
+	run storage --debug=false --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root create-layer
+	echo create-storage-layer: "$output"
+	[[ $status -eq 0 ]]
+	layer=$output
+
+	run storage --debug=false --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root create-image "$layer"
+	echo create-image: "$output"
+	[[ $status -eq 0 ]]
+
+	# Check that we don't complain about unmanaged layers in the read-only location.
+	run storage --debug=false --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root check
+	echo "check:" "$output"
+	[[ $status -eq 0 ]]
+	[[ $output == "" ]]
+}
+
+# Check that the storage driver doesn't have any layers that we don't know
+# about in a read-write store, and would therefore never be able to clean up,
+# i.e., that we can spot them.
+@test "check-unmanaged-rw-layers" {
+	case "$STORAGE_DRIVER" in
+	overlay*|vfs)
+		;;
+	*)
+		skip "driver $STORAGE_DRIVER does not support additional image stores"
+		;;
+	esac
+
+	# Put an image in the read-only location.
+	mkdir ${TESTDIR}/{ro-root,ro-runroot}
+
+	run storage --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot --debug=false create-layer
+	echo create-layer: "$output"
+	[[ $status -eq 0 ]]
+	rolayer=$output
+
+	run storage --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot --debug=false create-image "$rolayer"
+	echo create-image: "$output"
+	[[ $status -eq 0 ]]
+
+        storage --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot shutdown
+
+	# Put a couple of unmanaged layers in the read-write location.
+	run storage --debug=false --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root create-storage-layer
+	echo create-storage-layer: "$output"
+	[[ $status -eq 0 ]]
+	layer=$output
+
+	run storage --debug=false --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root create-storage-layer "$layer"
+	echo create-storage-layer: "$output"
+	[[ $status -eq 0 ]]
+	otherlayer=$output
+
+	# Check that we find the unmanaged layers in the read-write location and remove them.
+	run storage --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root check -r
+	echo "check -r:" "$output"
+	[[ $status -eq 0 ]]
+	[[ $output =~ "layer ${layer}: layer in lower level storage driver not accounted for" ]]
+	[[ $output =~ "layer ${otherlayer}: layer in lower level storage driver not accounted for" ]]
+
+	# So now there shouldn't be any layers at all if we're just looking at the read-write location.
+	run storage --debug=false storage-layers
+	echo storage-layers: "$output"
+	[[ $status -eq 0 ]]
+	[[ $output == "" ]]
+
+	# But there should still be that managed layer we put in the read-only location.
+	run storage --debug=false --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root layers -q
+	echo storage-layers: "$output"
+	[[ $status -eq 0 ]]
+	[[ $output == "$rolayer" ]]
+}
+
+# Check that we can detect layers that aren't part of an image or a container.
+@test "check-unused-layers" {
+	run storage --debug=false create-layer
+	echo create-layer: "$output"
+	[[ $status -eq 0 ]]
+	layer=$output
+
+	run storage --debug=false create-layer $output
+	[[ $status -eq 0 ]]
+	layer=$output
+
+	# By default, an unreferenced layer must have reached some minimum age
+	# in order for us to think it's been forgotten.
+	run storage --debug=false check -r
+	echo "check -r:" "$output"
+	[[ $status -eq 0 ]]
+	[[ $output == "" ]]
+
+	# But if we set that minimum age to 0, we should clean it up.
+	run storage check -r -m 0
+	echo "check -r -m 0:" "$output"
+	[[ $status -eq 0 ]]
+	[[ $output =~ "layer ${layer}: layer not referenced by any images or containers" ]]
+
+	# After the cleanup, there shouldn't be anything left.
+	run storage --debug=false layers
+	echo layers: "$output"
+	[[ $status -eq 0 ]]
+	[[ $output == "" ]]
+}
+
+# Check that we don't complain about layers in read-only storage that aren't
+# part of an image or a container, since we can't do anything about them
+# anyway.
+@test "check-unused-ro-layers" {
+	case "$STORAGE_DRIVER" in
+	overlay*|vfs)
+		;;
+	*)
+		skip "driver $STORAGE_DRIVER does not support additional image stores"
+		;;
+	esac
+
+	# Put a couple of unreferenced layers in the read-only location.
+	mkdir ${TESTDIR}/{ro-root,ro-runroot}
+	run storage --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot --debug=false create-layer
+	echo create-layer: "$output"
+	[[ $status -eq 0 ]]
+	rolayer="$output"
+	run storage --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot --debug=false create-layer "$rolayer"
+	echo create-layer: "$output"
+	[[ $status -eq 0 ]]
+	otherlayer="$output"
+
+        storage --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot shutdown
+
+	# Put an image in the read-write location.
+	run storage --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root --debug=false create-layer
+	echo create-layer: "$output"
+	[[ $status -eq 0 ]]
+	layer=$output
+	run storage --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root create-image "$layer"
+	echo create-image: "$output"
+	[[ $status -eq 0 ]]
+
+	# Check for errors.  We shouldn't be warning about the unreferenced read-only layers.
+	run storage --debug=false --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root check -m 0
+	echo "check -m 0:" "$output"
+	[[ $status -eq 0 ]]
+	[[ $output == "" ]]
+}
+
+# Check that we can detect layers in read-write storage that aren't part of an
+# image or a container.
+@test "check-unused-rw-layers" {
+	case "$STORAGE_DRIVER" in
+	overlay*|vfs)
+		;;
+	*)
+		skip "driver $STORAGE_DRIVER does not support additional image stores"
+		;;
+	esac
+
+	# Put an image in the read-only location.
+	mkdir ${TESTDIR}/{ro-root,ro-runroot}
+	run storage --debug=false --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot --debug=false create-layer
+	echo create-layer: "$output"
+	[[ $status -eq 0 ]]
+	rolayer="$output"
+	storage --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot --debug=false create-image "$rolayer"
+
+        storage --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot shutdown
+
+	# Put some unreferenced layers in the read-write location.
+	run storage --debug=false --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root create-layer
+	echo create-layer: "$output"
+	[[ $status -eq 0 ]]
+	layer=$output
+	run storage --debug=false --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root create-layer "$layer"
+	echo create-layer: "$output"
+	[[ $status -eq 0 ]]
+	otherlayer=$output
+
+	# By default, an unreferenced layer must have reached some minimum age
+	# in order for us to think it's been forgotten.
+	run storage --debug=false --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root check -r
+	echo "check -r:" "$output"
+	[[ $status -eq 0 ]]
+	[[ $output == "" ]]
+
+	# Now check for errors and repair them.
+	run storage --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root check -r -m 0
+	echo "check -r -m 0:" "$output"
+	[[ $status -eq 0 ]]
+	[[ $output =~ "layer $layer: layer not referenced by any images or containers" ]]
+	[[ $output =~ "layer $otherlayer: layer not referenced by any images or containers" ]]
+
+	# The read-only layer should be the only one present.
+	run storage --debug=false --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root layers -q
+	echo layers: "$output"
+	[[ $status -eq 0 ]]
+	[[ $output == "$rolayer" ]]
+}
+
+# Check that we can detect when the contents of a layer's files, at least the
+# ones that we'd need to read in order to reconstruct the diff, have been
+# altered.
+@test "check-layer-content-digest" {
+	# This test needs "tar".
+	if test -z "$(which tar 2> /dev/null)" ; then
+		skip "need tar"
+	fi
+
+	# Create a layer.
+	run storage --debug=false create-layer
+	echo create-layer: "$output"
+	[[ $status -eq 0 ]]
+	layer=$output
+
+	# Set contents of the layer.
+	createrandom ${TESTDIR}/datafile1
+	createrandom ${TESTDIR}/datafile2
+	(cd ${TESTDIR}; tar cf - datafile1 datafile2) > ${TESTDIR}/diff
+	storage apply-diff -f ${TESTDIR}/diff $layer
+
+	# Mark that layer as part of an image.
+	run storage --debug=false create-image $layer
+	echo create-image: "$output"
+	[[ $status -eq 0 ]]
+
+	# Put something in the layer that wasn't part of the diff.
+	createrandom ${TESTDIR}/datafile3
+	storage copy ${TESTDIR}/datafile3 ${layer}:/datafile1
+
+	# Now check if the diff can be reproduced correctly.
+	run storage check -r
+	echo "check -r:" "$output"
+	[[ $status -eq 0 ]]
+	[[ $output =~ "layer ${layer}: layer content incorrect digest" ]] || [[ $output =~ "layer ${layer}: file integrity checksum failed" ]]
+
+	# Having removed the layer, there should be no traces left.
+	run storage --debug=false images
+	echo images: "$output"
+	[[ $status -eq 0 ]]
+	[[ $output == "" ]]
+
+	# Should look empty now
+	run storage --debug=false layers
+	echo layers: "$output"
+	[[ $status -eq 0 ]]
+	[[ $output == "" ]]
+}
+
+# Check that we can detect when the contents of a read-only layer's files, at
+# least the ones that we'd need to read in order to reconstruct the diff, have
+# been altered.
+@test "check-ro-layer-content-digest" {
+	# This test needs "tar".
+	if test -z "$(which tar 2> /dev/null)" ; then
+		skip "need tar"
+	fi
+
+	case "$STORAGE_DRIVER" in
+	overlay*|vfs)
+		;;
+	*)
+		skip "driver $STORAGE_DRIVER does not support additional image stores"
+		;;
+	esac
+
+	# Put a layer record in the read-only location.
+	mkdir ${TESTDIR}/{ro-root,ro-runroot}
+	run storage --debug=false --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot --debug=false create-layer
+	echo create-layer: "$output"
+	[[ $status -eq 0 ]]
+	rolayer="$output"
+
+	# Set up that layer's contents.
+	createrandom ${TESTDIR}/datafile1
+	createrandom ${TESTDIR}/datafile2
+	(cd ${TESTDIR}; tar cf - datafile1 datafile2) > ${TESTDIR}/diff
+	storage apply-diff --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot -f ${TESTDIR}/diff $rolayer
+
+	# Mess with that layer's contents.
+	createrandom ${TESTDIR}/datafile3
+	storage --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot copy ${TESTDIR}/datafile3 ${rolayer}:/datafile1
+
+	# Create an image record that uses that layer.
+	run storage --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot --debug=false create-image "$rolayer"
+	echo create-image: "$output"
+	[[ $status -eq 0 ]]
+
+        storage --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot shutdown
+
+	# Create a read-write layer.
+	run storage --debug=false --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root create-layer
+	echo create-layer: "$output"
+	[[ $status -eq 0 ]]
+	rwlayer=$output
+
+	# Create a read-write image.
+	run storage --debug=false --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root create-image $rwlayer
+	echo create-image: "$output"
+	[[ $status -eq 0 ]]
+
+	# Check that we notice the added file, even if we can't fix it.
+	run storage --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root check -r
+	echo "check -r:" "$output"
+	[[ $status -ne 0 ]] # couldn't fix read-only layers
+	[[ $output =~ "layer ${rolayer}: layer content incorrect digest" ]] || [[ $output =~ "layer ${rolayer}: file integrity checksum failed" ]]
+
+	# A check of just the read-write storage shouldn't turn up anything.
+	run storage check
+	echo check: "$output"
+	[[ $status -eq 0 ]]
+}
+
+# Check that we can detect when a layer has had content added.  Due to the
+# way diff reconstructs diffs from layers, items which weren't in the original
+# diff won't be noticed if the check consists of only extracting the diff.
+@test "check-layer-content-modified" {
+	# This test needs "tar".
+	if test -z "$(which tar 2> /dev/null)" ; then
+		skip "need tar"
+	fi
+
+	# Create the layer record.
+	run storage --debug=false create-layer
+	echo create-layer: "$output"
+	[[ $status -eq 0 ]]
+	layer=$output
+
+	# Set up the layer's contents.
+	createrandom ${TESTDIR}/datafile1
+	createrandom ${TESTDIR}/datafile2
+	(cd ${TESTDIR}; tar cf - datafile1 datafile2) > ${TESTDIR}/diff
+	storage apply-diff -f ${TESTDIR}/diff $layer
+
+	# Add some contents to the layer.
+	createrandom ${TESTDIR}/datafile3
+	storage copy ${TESTDIR}/datafile3 ${layer}:/datafile3
+
+	# Create the image record.
+	run storage --debug=false create-image $layer
+	echo create-image: "$output"
+	[[ $status -eq 0 ]]
+
+	# Check if we can detect that file being added.
+	run storage check -r
+	echo "check -r:" "$output"
+	[[ $status -eq 0 ]]
+	[[ $output =~ "layer ${layer}: +/datafile3, layer content modified" ]]
+
+	# Should be all clear now.
+	run storage check
+	echo check: "$output"
+	[[ $status -eq 0 ]]
+}
+
+# Check that we can detect when one of an image's layers is gone, or at least
+# doesn't correspond to one that we know of.
+@test "check-image-layer-missing" {
+	# Create the layer record.
+	run storage --debug=false create-layer
+	echo create-layer: "$output"
+	[[ $status -eq 0 ]]
+	layer=$output
+
+	# Create the image record.
+	run storage --debug=false create-image $layer
+	echo create-image: "$output"
+	[[ $status -eq 0 ]]
+	image="$output"
+
+	# Delete the layer with no safety checking.
+	run storage --debug=false delete $layer
+	echo delete layer: "$output"
+	[[ $status -eq 0 ]]
+
+	# Check that we know to flag the image as damaged, and fix it.
+	run storage check -r
+	echo "check -r:" "$output"
+	[[ $status -eq 0 ]]
+	[[ $output =~ "image ${image}: layer ${layer}: image layer is missing" ]]
+
+	# Check that we no longer think there's damage.
+	run storage check
+	echo check: "$output"
+	[[ $status -eq 0 ]]
+}
+
+# Check that we can detect when one of an image's layers is gone, or at least
+# doesn't correspond to one that we know of.
+@test "check-ro-image-layer-missing" {
+	case "$STORAGE_DRIVER" in
+	overlay*|vfs)
+		;;
+	*)
+		skip "driver $STORAGE_DRIVER does not support additional image stores"
+		;;
+	esac
+
+	# Create the read-only layer record.
+	run storage --debug=false --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot create-layer
+	echo create-layer: "$output"
+	[[ $status -eq 0 ]]
+	layer=$output
+
+	# Create the read-only image record.
+	run storage --debug=false --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot create-image $layer
+	echo create-image: "$output"
+	[[ $status -eq 0 ]]
+	image="$output"
+
+	# Delete the layer with no safety checking.
+	run storage --debug=false --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot delete $layer
+	echo delete layer: "$output"
+	[[ $status -eq 0 ]]
+
+        storage --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot shutdown
+
+	# Create a read-write layer.
+	run storage --debug=false --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root create-layer
+	echo create-layer: "$output"
+	[[ $status -eq 0 ]]
+	rwlayer=$output
+
+	# Create a read-write image.
+	run storage --debug=false --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root create-image $rwlayer
+	echo create-image: "$output"
+	[[ $status -eq 0 ]]
+
+	# Check that we know to flag the image as damaged, even if we can't fix it.
+	run storage --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root check -r
+	echo "check -r:" "$output"
+	[[ $status -ne 0 ]] # we can't fix it
+	[[ $output =~ "image ${image}: layer ${layer}: image layer is missing" ]]
+
+	# Check that we no longer think there's damage if we just look at read-write content.
+	run storage check
+	echo check: "$output"
+	[[ $status -eq 0 ]]
+}
+
+# Check that we can detect when a container's base image is gone, or at least
+# doesn't correspond to one that we know of.
+@test "check-container-image-missing" {
+	# Create the layer.
+	run storage --debug=false create-layer
+	echo create-layer: "$output"
+	[[ $status -eq 0 ]]
+	layer=$output
+
+	# Create the image that uses that layer.
+	run storage --debug=false create-image $layer
+	echo create-image: "$output"
+	[[ $status -eq 0 ]]
+	image=$output
+
+	# Create a container based on that image.
+	run storage --debug=false create-container $image
+	echo create-container: "$output"
+	[[ $status -eq 0 ]]
+	container=$output
+
+	# Delete the image with no safety checks.
+	run storage --debug=false delete $image
+	echo delete image: "$output"
+	[[ $status -eq 0 ]]
+
+	# Check and repair.  Repair is okay with deleting images because they
+	# can be rebuilt or re-pulled.
+	run storage check -r
+	echo "check -r:" "$output"
+	[[ $status -ne 0 ]]
+	[[ $output =~ "container ${container}:" ]]
+	[[ $output =~ "image ${image}: image missing" ]]
+
+	# didn't get rid of the container, though!
+
+	run storage check
+	echo check: "$output"
+	[[ $status -ne 0 ]]
+	[[ $output =~ "container ${container}:" ]]
+	[[ $output =~ "image ${image}: image missing" ]]
+
+	# Repair, but now we're okay with getting rid of containers.
+	run storage check -r -f
+	echo "check -r -f:" "$output"
+	[[ $status -eq 0 ]]
+	[[ $output =~ "container ${container}:" ]]
+	[[ $output =~ "image ${image}: image missing" ]]
+
+	# Should be all clear now.
+	run storage check
+	echo check: "$output"
+	[[ $status -eq 0 ]]
+}
+
+# Check that we can detect when a container's base image is deleted in a
+# read-only store, or at least doesn't correspond to one that we know of.
+@test "check-container-ro-image-missing" {
+	case "$STORAGE_DRIVER" in
+	overlay*|vfs)
+		;;
+	*)
+		skip "driver $STORAGE_DRIVER does not support additional image stores"
+		;;
+	esac
+
+	# Create the read-only layer.
+	run storage --debug=false --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot create-layer
+	echo create-layer: "$output"
+	[[ $status -eq 0 ]]
+	layer=$output
+
+	# Create the read-only image that uses that layer.
+	run storage --debug=false --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot create-image $layer
+	echo create-image: "$output"
+	[[ $status -eq 0 ]]
+	image=$output
+
+        storage --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot shutdown
+
+	# Create a container based on that image.
+	run storage --debug=false --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root create-container $image
+	echo create-container: "$output"
+	[[ $status -eq 0 ]]
+	container=$output
+	run storage --debug=false --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root container ${container}
+	echo container: "$output"
+	[[ $status -eq 0 ]]
+	clayer=$(grep ^Layer: <<< ${output})
+	clayer=${clayer##* }
+	echo clayer: "${clayer}"
+
+	# Delete the layer with no safety checks.
+	run storage --debug=false --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot delete $layer
+	echo delete layer: "$output"
+	[[ $status -eq 0 ]]
+
+	# Delete the image while we're at it.
+	run storage --debug=false --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot delete $image
+	echo delete image: "$output"
+	[[ $status -eq 0 ]]
+
+        storage --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot shutdown
+
+	# Check and repair.  Repair is okay with deleting images because they
+	# can be rebuilt or re-pulled.
+	run storage --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root check -r
+	echo "check -r:" "$output"
+	[[ $status -ne 0 ]]
+	[[ $output =~ "container ${container}:" ]]
+	[[ $output =~ "image ${image}: image missing" ]]
+	[[ $output =~ "layer ${clayer} used by container ${container}: layer is in use by a container" ]]
+
+	# couldn't get rid of the container, even so
+
+	run storage --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root check
+	echo check: "$output"
+	[[ $status -ne 0 ]]
+	[[ $output =~ "container ${container}:" ]]
+	[[ $output =~ "image ${image}: image missing" ]]
+
+	# Repair, but now we're okay with getting rid of damaged containers.
+	run storage --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root check -r -f
+	echo "check -r -f:" "$output"
+	[[ $status -eq 0 ]]
+	[[ $output =~ "container ${container}:" ]]
+	[[ $output =~ "image ${image}: image missing" ]]
+
+	# Should be all clear now.
+	run storage --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root check
+	echo check: "$output"
+	[[ $status -eq 0 ]]
+}
+
+# Check that we can detect layer data being lost.
+@test "check-layer-data-missing" {
+	# Create the layer.
+	run storage --debug=false create-layer
+	echo create-layer: "$output"
+	[[ $status -eq 0 ]]
+	layer=$output
+
+	# Create the image.
+	run storage --debug=false create-image $layer
+	echo create-image: "$output"
+	[[ $status -eq 0 ]]
+
+	# Set a data item associated with the layer.
+	createrandom ${TESTDIR}/datafile
+	storage set-layer-data -f ${TESTDIR}/datafile $layer datafile
+	run storage --debug=false list-layer-data $layer
+	echo list-layer-data: "$output"
+	[[ $status -eq 0 ]]
+	[[ $output != "" ]]
+
+	# Everything should look okay.
+	run storage check
+	echo check: "$output"
+	[[ $status -eq 0 ]]
+
+	# Delete that content and see if we notice.
+	rm -fv ${TESTDIR}/root/${STORAGE_DRIVER}-layers/$layer/datafile
+	run storage check -r
+	echo "check -r:" "$output"
+	[[ $status -eq 0 ]]
+	[[ $output =~ "layer ${layer}: data item \"datafile\": layer data item is missing" ]]
+
+	# Should have repaired by deleting the image and layer, so we should be
+	# in the clear.
+	run storage check
+	echo check: "$output"
+	[[ $status -eq 0 ]]
+}
+
+# Check that we can detect read-only layer data being lost.
+@test "check-ro-layer-data-missing" {
+	case "$STORAGE_DRIVER" in
+	overlay*|vfs)
+		;;
+	*)
+		skip "driver $STORAGE_DRIVER does not support additional image stores"
+		;;
+	esac
+
+	# Create the read-only layer.
+	run storage --debug=false --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot create-layer
+	echo create-layer: "$output"
+	[[ $status -eq 0 ]]
+	layer=$output
+
+	# Create the image.
+	run storage --debug=false --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot create-image $layer
+	echo create-image: "$output"
+	[[ $status -eq 0 ]]
+
+	# Set a data item associated with the layer.
+	createrandom ${TESTDIR}/datafile
+	storage --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot set-layer-data -f ${TESTDIR}/datafile $layer datafile
+	run storage --debug=false --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot list-layer-data $layer
+	echo list-layer-data: "$output"
+	[[ $status -eq 0 ]]
+	[[ $output != "" ]]
+
+        storage --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot shutdown
+
+	# Create a read-write layer.
+	run storage --debug=false --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root create-layer
+	echo create-layer: "$output"
+	[[ $status -eq 0 ]]
+	rwlayer=$output
+
+	# Create a read-write image.
+	run storage --debug=false --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root create-image $rwlayer
+	echo create-image: "$output"
+	[[ $status -eq 0 ]]
+
+	# Everything should look okay.
+	run storage --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root check
+	echo check: "$output"
+	[[ $status -eq 0 ]]
+
+	# Delete that content and see if we notice.
+	rm -fv ${TESTDIR}/ro-root/${STORAGE_DRIVER}-layers/$layer/datafile
+	run storage --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root check -r
+	echo "check -r:" "$output"
+	[[ $status -ne 0 ]]
+	[[ $output =~ "layer ${layer}: data item \"datafile\": layer data item is missing" ]]
+
+	# Can't repair it by deleting the image and layer, so we should be just
+	# as broken as last time.
+	run storage --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root check
+	echo check: "$output"
+	[[ $status -ne 0 ]]
+	[[ $output =~ "layer ${layer}: data item \"datafile\": layer data item is missing" ]]
+
+	# A check of just the read-write storage shouldn't turn up anything.
+	run storage check
+	echo check: "$output"
+	[[ $status -eq 0 ]]
+}
+
+# Check that we can detect image data being lost.
+@test "check-image-data-missing" {
+	# Create the layer.
+	run storage --debug=false create-layer
+	echo create-layer: "$output"
+	[[ $status -eq 0 ]]
+	layer=$output
+
+	# Create the image.
+	run storage --debug=false create-image $layer
+	echo create-image: "$output"
+	[[ $status -eq 0 ]]
+	image=$output
+
+	# Create the data associated with the image.
+	createrandom ${TESTDIR}/datafile
+	storage set-image-data -f ${TESTDIR}/datafile $image datafile
+	run storage --debug=false list-image-data $image
+	echo list-image-data: "$output"
+	[[ $status -eq 0 ]]
+	[[ $output != "" ]]
+
+	# Everything should look good so far.
+	run storage check
+	echo check: "$output"
+	[[ $status -eq 0 ]]
+
+	# Now delete the data and check that we notice it's gone.
+	rm -fv ${TESTDIR}/root/${STORAGE_DRIVER}-images/$image/datafile
+	run storage check -r
+	echo "check -r:" "$output"
+	[[ $status -eq 0 ]]
+	[[ $output =~ "image ${image}: data item \"datafile\": image data item is missing" ]]
+
+	# Having repaired it by deleting the offending image, we should be okay again.
+	run storage check
+	echo check: "$output"
+	[[ $status -eq 0 ]]
+}
+
+# Check that we can detect image data in read-only stores being lost.
+@test "check-ro-image-data-missing" {
+	case "$STORAGE_DRIVER" in
+	overlay*|vfs)
+		;;
+	*)
+		skip "driver $STORAGE_DRIVER does not support additional image stores"
+		;;
+	esac
+
+	# Create the read-only layer.
+	run storage --debug=false --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot create-layer
+	echo create-layer: "$output"
+	[[ $status -eq 0 ]]
+	layer=$output
+
+	# Create the image.
+	run storage --debug=false --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot create-image $layer
+	echo create-image: "$output"
+	[[ $status -eq 0 ]]
+	image=$output
+
+	# Create the data associated with the image.
+	createrandom ${TESTDIR}/datafile
+	storage --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot set-image-data -f ${TESTDIR}/datafile $image datafile
+	run storage --debug=false --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot list-image-data $image
+	echo list-image-data: "$output"
+	[[ $status -eq 0 ]]
+	[[ $output != "" ]]
+
+	# Everything should look good so far.
+	run storage --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot check
+	echo check: "$output"
+	[[ $status -eq 0 ]]
+
+        storage --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot shutdown
+
+	# Create a read-write layer.
+	run storage --debug=false --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root create-layer
+	echo create-layer: "$output"
+	[[ $status -eq 0 ]]
+	rwlayer=$output
+
+	# Create a read-write image.
+	run storage --debug=false --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root create-image $rwlayer
+	echo create-image: "$output"
+	[[ $status -eq 0 ]]
+
+	# Now delete the data and check that we notice it's gone.
+	rm -fv ${TESTDIR}/ro-root/${STORAGE_DRIVER}-images/$image/datafile
+	run storage --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root check -r
+	echo "check -r:" "$output"
+	[[ $status -ne 0 ]]
+	[[ $output =~ "image ${image}: data item \"datafile\": image data item is missing" ]]
+
+	# Having been unable to repair it by deleting the offending image, we
+	# should still flag the error.
+	run storage --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root check
+	echo check: "$output"
+	[[ $status -ne 0 ]]
+	[[ $output =~ "image ${image}: data item \"datafile\": image data item is missing" ]]
+
+	# A check of just the read-write storage shouldn't turn up anything.
+	run storage check
+	echo check: "$output"
+	[[ $status -eq 0 ]]
+}
+
+# Check that we can detect image data being modified.
+@test "check-image-data-modified" {
+	# Create the layer.
+	run storage --debug=false create-layer
+	echo create-layer: "$output"
+	[[ $status -eq 0 ]]
+	layer=$output
+
+	# Create the image.
+	run storage --debug=false create-image $layer
+	echo create-image: "$output"
+	[[ $status -eq 0 ]]
+	image=$output
+
+	# Create some data to associate with the image.
+	createrandom ${TESTDIR}/datafile
+	storage set-image-data -f ${TESTDIR}/datafile $image datafile
+	run storage --debug=false list-image-data $image
+	echo list-image-data: "$output"
+	[[ $status -eq 0 ]]
+	[[ $output != "" ]]
+
+	# Everything should look okay so far.
+	run storage check
+	echo check: "$output"
+	[[ $status -eq 0 ]]
+
+	# Corrupt that data and see if we notice.
+	echo "" >> ${TESTDIR}/root/${STORAGE_DRIVER}-images/$image/datafile
+	run storage check -r
+	echo "check -r:" "$output"
+	[[ $status -eq 0 ]]
+	[[ $output =~ "image ${image}: data item \"datafile\": image data item has incorrect size" ]]
+
+	# We fixed that by removing the image, so everything should be okay now.
+	run storage check
+	echo check: "$output"
+	[[ $status -eq 0 ]]
+}
+
+# Check that we can detect image data being modified in read-only locations.
+@test "check-ro-image-data-modified" {
+	case "$STORAGE_DRIVER" in
+	overlay*|vfs)
+		;;
+	*)
+		skip "driver $STORAGE_DRIVER does not support additional image stores"
+		;;
+	esac
+
+	# Create the read-only layer.
+	run storage --debug=false --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot create-layer
+	echo create-layer: "$output"
+	[[ $status -eq 0 ]]
+	layer=$output
+
+	# Create the read-only image.
+	run storage --debug=false --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot create-image $layer
+	echo create-image: "$output"
+	[[ $status -eq 0 ]]
+	image=$output
+
+	# Create some data to associate with the read-only image.
+	createrandom ${TESTDIR}/datafile
+	storage --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot set-image-data -f ${TESTDIR}/datafile $image datafile
+	run storage --debug=false --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot list-image-data $image
+	echo list-image-data: "$output"
+	[[ $status -eq 0 ]]
+	[[ $output != "" ]]
+
+	# Everything should look okay so far.
+	run storage --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot check
+	echo check: "$output"
+	[[ $status -eq 0 ]]
+
+        storage --graph ${TESTDIR}/ro-root --run ${TESTDIR}/ro-runroot shutdown
+
+	# Create a read-write layer.
+	run storage --debug=false --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root create-layer
+	echo create-layer: "$output"
+	[[ $status -eq 0 ]]
+	rwlayer=$output
+
+	# Create a read-write image.
+	run storage --debug=false --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root create-image $rwlayer
+	echo create-image: "$output"
+	[[ $status -eq 0 ]]
+
+	# Corrupt that data and see if we notice.
+	echo "" >> ${TESTDIR}/ro-root/${STORAGE_DRIVER}-images/$image/datafile
+	run storage --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root check -r
+	echo "check -r:" "$output"
+	[[ $status -ne 0 ]]
+	[[ $output =~ "image ${image}: data item \"datafile\": image data item has incorrect size" ]]
+
+	# We couldn't fix that by removing the image, so we should still notice the problem.
+	run storage --storage-opt ${STORAGE_DRIVER}.imagestore=${TESTDIR}/ro-root check
+	echo check: "$output"
+	[[ $status -ne 0 ]]
+	[[ $output =~ "image ${image}: data item \"datafile\": image data item has incorrect size" ]]
+
+	# A check of just the read-write storage shouldn't turn up anything.
+	run storage check
+	echo check: "$output"
+	[[ $status -eq 0 ]]
+}
+
+# Check that we can detect container data being lost.
+@test "check-container-data-missing" {
+	# Create a container that isn't using an image as its base.
+	run storage --debug=false create-container ""
+	echo create-container: "$output"
+	[[ $status -eq 0 ]]
+	container=$output
+
+	# Store some data alongside the container.
+	createrandom ${TESTDIR}/datafile
+	storage set-container-data -f ${TESTDIR}/datafile $container datafile
+	run storage --debug=false list-container-data $container
+	echo list-container-data: "$output"
+	[[ $status -eq 0 ]]
+	[[ $output != "" ]]
+
+	# Everything should look okay so far.
+	run storage check
+	echo check: "$output"
+	[[ $status -eq 0 ]]
+
+	# Now remove the associated data and see if we notice.
+	rm -fv ${TESTDIR}/root/${STORAGE_DRIVER}-containers/$container/datafile
+	run storage check -r
+	echo "check -r:" "$output"
+	[[ $status -ne 0 ]]
+	[[ $output =~ "container ${container}: data item \"datafile\": container data item is missing" ]]
+
+	# didn't get rid of the container, though
+
+	# Should still look broken.
+	run storage check
+	echo check: "$output"
+	[[ $status -ne 0 ]]
+	[[ $output =~ "container ${container}: data item \"datafile\": container data item is missing" ]]
+
+	# Now let repair remove containers.
+	run storage check -r -f
+	echo "check -r -f:" "$output"
+	[[ $status -eq 0 ]]
+
+	# Should look okay now.
+	run storage check
+	echo check: "$output"
+	[[ $status -eq 0 ]]
+}
+
+# Check that we can detect container data being modified.
+@test "check-container-data-modified" {
+	# Create a container that isn't using an image as its base.
+	run storage --debug=false create-container ""
+	echo create-container: "$output"
+	[[ $status -eq 0 ]]
+	container=$output
+
+	# Store some data alongside the container.
+	createrandom ${TESTDIR}/datafile
+	storage set-container-data -f ${TESTDIR}/datafile $container datafile
+	run storage --debug=false list-container-data $container
+	echo list-container-data: "$output"
+	[[ $status -eq 0 ]]
+	[[ $output != "" ]]
+
+	# Everything should look okay so far.
+	run storage check
+	echo check: "$output"
+	[[ $status -eq 0 ]]
+
+	# Create a read-write layer.
+	run storage --debug=false create-layer
+	echo create-layer: "$output"
+	[[ $status -eq 0 ]]
+	rwlayer=$output
+
+	# Create a read-write image.
+	run storage --debug=false create-image $rwlayer
+	echo create-image: "$output"
+	[[ $status -eq 0 ]]
+
+	# Now remove the associated data and see if we notice.
+	echo "" >> ${TESTDIR}/root/${STORAGE_DRIVER}-containers/$container/datafile
+	run storage check -r
+	echo "check -r:" "$output"
+	[[ $status -ne 0 ]]
+	[[ $output =~ "container ${container}: data item \"datafile\": container data item has incorrect size" ]]
+
+	# didn't get rid of the container, though
+
+	# Should still look broken.
+	run storage check
+	echo check: "$output"
+	[[ $status -ne 0 ]]
+	[[ $output =~ "container ${container}: data item \"datafile\": container data item has incorrect size" ]]
+
+	# Now let repair remove containers.
+	run storage check -r -f
+	echo "check -r -f:" "$output"
+	[[ $status -eq 0 ]]
+	[[ $output =~ "container ${container}: data item \"datafile\": container data item has incorrect size" ]]
+
+	# Should look okay now.
+	run storage check
+	echo check: "$output"
+	[[ $status -eq 0 ]]
+}

--- a/tests/helpers.bash
+++ b/tests/helpers.bash
@@ -28,8 +28,14 @@ function setup() {
 
 # Delete the unique root directory and a runroot directory.
 function teardown() {
-	storage wipe
-	storage shutdown
+	run storage wipe
+	if [[ $status -ne 0 ]] ; then
+		echo "$output"
+	fi
+	run storage shutdown
+	if [[ $status -ne 0 ]] ; then
+		echo "$output"
+	fi
 	rm -fr ${TESTDIR}
 }
 

--- a/tests/idmaps.bats
+++ b/tests/idmaps.bats
@@ -3,6 +3,11 @@
 load helpers
 
 @test "idmaps-create-apply-layer" {
+	# This test needs "tar".
+	if test -z "$(which tar 2> /dev/null)" ; then
+		skip "need tar"
+	fi
+
 	if [ "$OS" != "Linux" ]; then
 		skip "not supported on $OS"
 	fi
@@ -112,6 +117,11 @@ load helpers
 }
 
 @test "idmaps-create-diff-layer" {
+	# This test needs "tar".
+	if test -z "$(which tar 2> /dev/null)" ; then
+		skip "need tar"
+	fi
+
 	if [ "$OS" != "Linux" ]; then
 		skip "not supported on $OS"
 	fi
@@ -574,6 +584,11 @@ load helpers
 }
 
 @test "idmaps-create-mapped-image" {
+	# This test needs "tar".
+	if test -z "$(which tar 2> /dev/null)" ; then
+		skip "need tar"
+	fi
+
 	if [ "$OS" != "Linux" ]; then
 		skip "not supported on $OS"
 	fi
@@ -968,6 +983,11 @@ load helpers
 }
 
 @test "idmaps-create-layer-from-another-image-store" {
+	# This test needs "tar".
+	if test -z "$(which tar 2> /dev/null)" ; then
+		skip "need tar"
+	fi
+
 	if [ "$OS" != "Linux" ]; then
 		skip "not supported on $OS"
 	fi

--- a/types/errors.go
+++ b/types/errors.go
@@ -59,4 +59,41 @@ var (
 	ErrInvalidMappings = errors.New("invalid mappings specified")
 	// ErrNoAvailableIDs is returned when there are not enough unused IDS within the user namespace.
 	ErrNoAvailableIDs = errors.New("not enough unused IDs in user namespace")
+
+	// ErrLayerUnaccounted describes a layer that is present in the lower-level storage driver,
+	// but which is not known to or managed by the higher-level driver-agnostic logic.
+	ErrLayerUnaccounted = errors.New("layer in lower level storage driver not accounted for")
+	// ErrLayerUnreferenced describes a layer which is not used by any image or container.
+	ErrLayerUnreferenced = errors.New("layer not referenced by any images or containers")
+	// ErrLayerIncorrectContentDigest describes a layer for which the contents of one or more
+	// files which were added in the layer appear to have changed.  It may instead look like an
+	// unnamed "file integrity checksum failed" error.
+	ErrLayerIncorrectContentDigest = errors.New("layer content incorrect digest")
+	// ErrLayerIncorrectContentSize describes a layer for which regenerating the diff that was
+	// used to populate the layer produced a diff of a different size.  We check the digest
+	// first, so it's highly unlikely you'll ever see this error.
+	ErrLayerIncorrectContentSize = errors.New("layer content incorrect size")
+	// ErrLayerContentModified describes a layer which contains contents which should not be
+	// there, or for which ownership/permissions/dates have been changed.
+	ErrLayerContentModified = errors.New("layer content modified")
+	// ErrLayerDataMissing describes a layer which is missing a big data item.
+	ErrLayerDataMissing = errors.New("layer data item is missing")
+	// ErrLayerMissing describes a layer which is the missing parent of a layer.
+	ErrLayerMissing = errors.New("layer is missing")
+	// ErrImageLayerMissing describes an image which claims to have a layer that we don't know
+	// about.
+	ErrImageLayerMissing = errors.New("image layer is missing")
+	// ErrImageDataMissing describes an image which is missing a big data item.
+	ErrImageDataMissing = errors.New("image data item is missing")
+	// ErrImageDataIncorrectSize describes an image which has a big data item which looks like
+	// its size has changed, likely because it's been modified somehow.
+	ErrImageDataIncorrectSize = errors.New("image data item has incorrect size")
+	// ErrContainerImageMissing describes a container which claims to be based on an image that
+	// we don't know about.
+	ErrContainerImageMissing = errors.New("image missing")
+	// ErrContainerDataMissing describes a container which is missing a big data item.
+	ErrContainerDataMissing = errors.New("container data item is missing")
+	// ErrContainerDataIncorrectSize describes a container which has a big data item which looks
+	// like its size has changed, likely because it's been modified somehow.
+	ErrContainerDataIncorrectSize = errors.New("container data item has incorrect size")
 )


### PR DESCRIPTION
Add initial Check() and Repair() methods to Stores.

Check() checks for inconsistencies between the layers which the lower-level storage driver claims to know about and the ones which we know we're managing.  It checks that layers referenced by layers, images, and containers are known to us and that images referenced by containers are known to us.  It checks that data which we store alongside layers, images, and containers is still present, and to the extent which we store other information about that data (frequenly just the size of the data), verifies that it matches recorded expectations. Lastly, it checks that layers which are part of images (and which we therefore know what they should have in them) have the expected content, and nothing else.

Repair() removes any containers, images, and layers which have any errors associated with them.  This is destructive, so its use should be considered and deliberate.