### PR TITLE
Use Go 1.18 generics in the store’s locking helpers

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -168,7 +168,7 @@ vendor_task:
 
 cross_task:
     container:
-        image: golang:1.17
+        image: golang:1.18
     build_script: make cross
 
 
@@ -182,6 +182,6 @@ success_task:
         - vendor
         - cross
     container:
-        image: golang:1.17
+        image: golang:1.18
     clone_script: 'mkdir -p "$CIRRUS_WORKING_DIR"'  # Source code not needed
     script: /bin/true

--- a/check.go
+++ b/check.go
@@ -452,10 +452,10 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 
 	// Walk the list of image stores, looking at each image that we didn't see in a
 	// previously-visited store.
-	if errored, err := s.readAllImageStores(func(store roImageStore) (bool, error) {
+	if _, _, err := readAllImageStores(s, func(store roImageStore) (struct{}, bool, error) {
 		images, err := store.Images()
 		if err != nil {
-			return true, err
+			return struct{}{}, true, err
 		}
 		isReadWrite := roImageStoreIsReallyReadWrite(store)
 		readWriteDesc := ""
@@ -564,8 +564,8 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 				}
 			}
 		}
-		return false, nil
-	}); errored {
+		return struct{}{}, false, nil
+	}); err != nil {
 		return CheckReport{}, err
 	}
 

--- a/check.go
+++ b/check.go
@@ -570,10 +570,10 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 	}
 
 	// Iterate over each container in turn.
-	if done, err := s.readContainerStore(func() (bool, error) {
+	if _, _, err := readContainerStore(s, func() (struct{}, bool, error) {
 		containers, err := s.containerStore.Containers()
 		if err != nil {
-			return true, err
+			return struct{}{}, true, err
 		}
 		for i := range containers {
 			container := containers[i]
@@ -622,8 +622,8 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 				referencedLayers[container.LayerID] = true
 			}
 		}
-		return false, nil
-	}); done {
+		return struct{}{}, false, nil
+	}); err != nil {
 		return CheckReport{}, err
 	}
 

--- a/check.go
+++ b/check.go
@@ -160,10 +160,10 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 
 	// Walk the list of layer stores, looking at each layer that we didn't see in a
 	// previously-visited store.
-	if errored, err := s.readAllLayerStores(func(store roLayerStore) (bool, error) {
+	if _, _, err := readAllLayerStores(s, func(store roLayerStore) (struct{}, bool, error) {
 		layers, err := store.Layers()
 		if err != nil {
-			return true, err
+			return struct{}{}, true, err
 		}
 		isReadWrite := roLayerStoreIsReallyReadWrite(store)
 		readWriteDesc := ""
@@ -337,7 +337,7 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 		// At this point we're out of things that we can be sure will work in read-only
 		// stores, so skip the rest for any stores that aren't also read-write stores.
 		if !isReadWrite {
-			return false, nil
+			return struct{}{}, false, nil
 		}
 		// Content and mount checks are also things that we can only be sure will work in
 		// read-write stores.
@@ -439,8 +439,8 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 			err := fmt.Errorf("%slayer %s: %w", readWriteDesc, parent, ErrLayerMissing)
 			report.Layers[id] = append(report.Layers[id], err)
 		}
-		return false, nil
-	}); errored {
+		return struct{}{}, false, nil
+	}); err != nil {
 		return CheckReport{}, err
 	}
 
@@ -630,13 +630,13 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 	// Now go back through all of the layer stores, and flag any layers which don't belong
 	// to an image or a container, and has been around longer than we can reasonably expect
 	// such a layer to be present before a corresponding image record is added.
-	if errored, err := s.readAllLayerStores(func(store roLayerStore) (bool, error) {
+	if _, _, err := readAllLayerStores(s, func(store roLayerStore) (struct{}, bool, error) {
 		if isReadWrite := roLayerStoreIsReallyReadWrite(store); !isReadWrite {
-			return false, nil
+			return struct{}{}, false, nil
 		}
 		layers, err := store.Layers()
 		if err != nil {
-			return true, err
+			return struct{}{}, true, err
 		}
 		for _, layer := range layers {
 			maximumAge := defaultMaximumUnreferencedLayerAge
@@ -654,8 +654,8 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 				}
 			}
 		}
-		return false, nil
-	}); errored {
+		return struct{}{}, false, nil
+	}); err != nil {
 		return CheckReport{}, err
 	}
 

--- a/check_test.go
+++ b/check_test.go
@@ -89,11 +89,11 @@ func TestCheckDetectWriteable(t *testing.T) {
 	assert.False(t, done, "unexpected error from readAllLayerStores")
 	assert.NoError(t, err, "unexpected error from readAllLayerStores")
 	assert.True(t, sawRWlayers, "unexpected error detecting which layer store is writeable")
-	done, err = s.readAllImageStores(func(store roImageStore) (bool, error) {
+	_, done, err = readAllImageStores(s, func(store roImageStore) (struct{}, bool, error) {
 		if roImageStoreIsReallyReadWrite(store) { // implicitly checking that the type assertion in this function doesn't panic
 			sawRWimages = true
 		}
-		return false, nil
+		return struct{}{}, false, nil
 	})
 	assert.False(t, done, "unexpected error from readAllImageStores")
 	assert.NoError(t, err, "unexpected error from readAllImageStores")

--- a/check_test.go
+++ b/check_test.go
@@ -80,11 +80,11 @@ func TestCheckDetectWriteable(t *testing.T) {
 	require.NoError(t, err, "unexpected error initializing test store")
 	s, ok := stoar.(*store)
 	require.True(t, ok, "unexpected error making type assertion")
-	done, err := s.readAllLayerStores(func(store roLayerStore) (bool, error) {
+	_, done, err := readAllLayerStores(s, func(store roLayerStore) (struct{}, bool, error) {
 		if roLayerStoreIsReallyReadWrite(store) { // implicitly checking that the type assertion in this function doesn't panic
 			sawRWlayers = true
 		}
-		return false, nil
+		return struct{}{}, false, nil
 	})
 	assert.False(t, done, "unexpected error from readAllLayerStores")
 	assert.NoError(t, err, "unexpected error from readAllLayerStores")


### PR DESCRIPTION
… avoiding quite a bit of the previously-required boilerplate.

This is probably easier to review as individual commits, and maybe with whitespace changes ignored.

@nalind PTAL