### PR TITLE
vfs,splitstore: add `graphRoot` as additionalStore

### DIFF
--- a/drivers/vfs/driver.go
+++ b/drivers/vfs/driver.go
@@ -62,6 +62,12 @@ func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) 
 			return nil, fmt.Errorf("vfs driver does not support %s options", key)
 		}
 	}
+	// If --imagestore is provided, lets add writable graphRoot
+	// to vfs's additional image store, as it is done for
+	// `overlay` driver.
+	if options.ImageStore != "" {
+		d.homes = append(d.homes, options.ImageStore)
+	}
 	d.updater = graphdriver.NewNaiveLayerIDMapUpdater(d)
 	d.naiveDiff = graphdriver.NewNaiveDiffDriver(d, d.updater)
 

--- a/tests/split-store.bats
+++ b/tests/split-store.bats
@@ -47,7 +47,7 @@ load helpers
 
 @test "split-store - use graphRoot as an additional store by default" {
 	case "$STORAGE_DRIVER" in
-	overlay*)
+	overlay*|vfs)
 		;;
 	*)
 		skip "additional store not supported by driver $STORAGE_DRIVER"


### PR DESCRIPTION
When we added splitstore support via `--imagestore` the `graphRoot` was added as an `rw` additionalImageStore so lets do same for the `vfs` driver.

See PR for more details:
* https://github.com/containers/storage/pull/1549
* https://github.com/containers/storage/pull/1578