### PR TITLE
pkg/rm: attempt os.RemoveAll() first

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -127,7 +127,6 @@ lint_task:
         fingerprint_script: cat go.sum
         folder: $GOPATH/pkg/mod
     build_script: |
-      echo "deb http://deb.debian.org/debian stretch-backports main" > /etc/apt/sources.list.d/backports.list
       apt-get update
       apt-get install -y libbtrfs-dev libdevmapper-dev
     test_script: make TAGS=regex_precompile local-validate && make lint && make clean

--- a/pkg/system/rm.go
+++ b/pkg/system/rm.go
@@ -30,6 +30,12 @@ func EnsureRemoveAll(dir string) error {
 	exitOnErr := make(map[string]int)
 	maxRetry := 100
 
+	// Attempt a simple remove all first, this avoids the more expensive
+	// RecursiveUnmount call if not needed.
+	if err := os.RemoveAll(dir); err == nil {
+		return nil
+	}
+
 	// Attempt to unmount anything beneath this dir first
 	if err := mount.RecursiveUnmount(dir); err != nil {
 		logrus.Debugf("RecusiveUnmount on %s failed: %v", dir, err)


### PR DESCRIPTION
the mount.RecursiveUnmount() call can be expensive, since it needs to parse the mount table to reconstruct the mount tree.

Attempt the simple case first, and do the more expensive removal only if necessary.