### PR TITLE
check: suppress certain errors when pull_options might cause them

### DIFF
--- a/check.go
+++ b/check.go
@@ -333,7 +333,6 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 						} else {
 							report.ROLayers[id] = append(report.ROLayers[id], err)
 						}
-						return
 					}
 					if layer.UncompressedSize != -1 && counter.Count != layer.UncompressedSize {
 						// We expected the diff to have a specific size, and
@@ -347,7 +346,6 @@ func (s *store) Check(options *CheckOptions) (CheckReport, error) {
 						} else {
 							report.ROLayers[id] = append(report.ROLayers[id], err)
 						}
-						return
 					}
 				}()
 			}

--- a/check.go
+++ b/check.go
@@ -922,6 +922,10 @@ func (c *checkDirectory) add(path string, typeflag byte, uid, gid int, size int6
 	}
 	switch len(components) {
 	case 0:
+		c.uid = uid
+		c.gid = gid
+		c.mode = mode
+		c.mtime = mtime
 		return
 	case 1:
 		switch typeflag {

--- a/check.go
+++ b/check.go
@@ -898,9 +898,6 @@ func newCheckDirectoryFromDirectory(dir string) (*checkDirectory, error) {
 		if err != nil {
 			return err
 		}
-		if hdr.Typeflag == tar.TypeLink {
-			hdr.Typeflag = tar.TypeReg
-		}
 		hdr.Name = filepath.ToSlash(rel)
 		cd.header(hdr)
 		return nil
@@ -917,8 +914,11 @@ func (c *checkDirectory) add(path string, typeflag byte, uid, gid int, size int6
 	if components[len(components)-1] == "" {
 		components = components[:len(components)-1]
 	}
-	if typeflag == tar.TypeLink || typeflag == tar.TypeRegA {
-		typeflag = tar.TypeReg
+	if components[0] == "." {
+		components = components[1:]
+	}
+	if typeflag != tar.TypeReg {
+		size = 0
 	}
 	switch len(components) {
 	case 0:

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -1029,7 +1029,7 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts, disable
 			}
 			if imageStore != "" {
 				if err2 := os.RemoveAll(workDirBase); err2 != nil {
-					logrus.Errorf("While recovering from a failure creating a layer, error deleting %#v: %v", dir, err2)
+					logrus.Errorf("While recovering from a failure creating a layer, error deleting %#v: %v", workDirBase, err2)
 				}
 			}
 		}

--- a/layers.go
+++ b/layers.go
@@ -314,9 +314,6 @@ type rwLayerStore interface {
 
 	// Clean up unreferenced layers
 	GarbageCollect() error
-
-	// supportsShifting() returns true if the driver.Driver.SupportsShifting().
-	supportsShifting() bool
 }
 
 type layerStore struct {
@@ -2470,10 +2467,6 @@ func (r *layerStore) LayersByCompressedDigest(d digest.Digest) ([]Layer, error) 
 // Requires startReading or startWriting.
 func (r *layerStore) LayersByUncompressedDigest(d digest.Digest) ([]Layer, error) {
 	return r.layersByDigestMap(r.byuncompressedsum, d)
-}
-
-func (r *layerStore) supportsShifting() bool {
-	return r.driver.SupportsShifting()
 }
 
 func closeAll(closes ...func() error) (rErr error) {


### PR DESCRIPTION
Files hard linked in from an OSTree repository won't tend to have the right ownership, permissions, or timestamps on them, so we have to accept that they'll frequently not match what we have on record when we're using one to speed up pulling images.