### PR TITLE
drivers/overlay.get(): only use the relative workdir for mountOverlayFrom()

### DIFF
--- a/drivers/overlay/check.go
+++ b/drivers/overlay/check.go
@@ -210,6 +210,9 @@ func doesVolatile(d string) (bool, error) {
 	}
 	// Mount using the mandatory options and configured options
 	opts := fmt.Sprintf("volatile,lowerdir=%s,upperdir=%s,workdir=%s", path.Join(td, "lower"), path.Join(td, "upper"), path.Join(td, "work"))
+	if unshare.IsRootless() {
+		opts = fmt.Sprintf("%s,userxattr", opts)
+	}
 	if err := unix.Mount("overlay", filepath.Join(td, "merged"), "overlay", 0, opts); err != nil {
 		return false, fmt.Errorf("failed to mount overlay for volatile check: %w", err)
 	}

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -202,6 +202,8 @@ func checkSupportVolatile(home, runhome string) (bool, error) {
 			if err = cachedFeatureRecord(runhome, feature, usingVolatile, ""); err != nil {
 				return false, fmt.Errorf("recording volatile-being-used status: %w", err)
 			}
+		} else {
+			usingVolatile = false
 		}
 	}
 	return usingVolatile, nil
@@ -1678,16 +1680,15 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 		// Use mountFrom when the mount data has exceeded the page size. The mount syscall fails if
 		// the mount data cannot fit within a page and relative links make the mount data much
 		// smaller at the expense of requiring a fork exec to chdir().
-
-		workdir = path.Join(id, "work")
 		if readWrite {
 			diffDir := path.Join(id, "diff")
-			opts = fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", strings.Join(absLowers, ":"), diffDir, workdir)
+			workDir := path.Join(id, "work")
+			opts = fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", strings.Join(absLowers, ":"), diffDir, workDir)
 		} else {
 			opts = fmt.Sprintf("lowerdir=%s:%s", diffDir, strings.Join(absLowers, ":"))
 		}
 		if len(optsList) > 0 {
-			opts = fmt.Sprintf("%s,%s", opts, strings.Join(optsList, ","))
+			opts = strings.Join(append([]string{opts}, optsList...), ",")
 		}
 		mountData = label.FormatMountLabel(opts, options.MountLabel)
 		mountFunc = func(source string, target string, mType string, flags uintptr, label string) error {
@@ -1697,9 +1698,9 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 	}
 
 	// overlay has a check in place to prevent mounting the same file system twice
-	// if volatile was already specified.
-	err = os.RemoveAll(filepath.Join(workdir, "work/incompat/volatile"))
-	if err != nil && !os.IsNotExist(err) {
+	// if volatile was already specified. Yes, the kernel repeats the "work" component.
+	err = os.RemoveAll(filepath.Join(workdir, "work", "incompat", "volatile"))
+	if err != nil && !errors.Is(err, os.ErrNotExist) {
 		return "", err
 	}
 


### PR DESCRIPTION
When we convert the work directory's location to a relative path for passing to mount-in-a-subprocess, don't change the value that we'll subsequently use when removing the "work/incompat/volatile" subdirectory while still in the parent process.  Fixes https://github.com/containers/buildah/issues/4794.
