### PR TITLE
store: ensure lockfile is updated before writes

### DIFF
--- a/images.go
+++ b/images.go
@@ -575,14 +575,16 @@ func (r *imageStore) Save() error {
 	if err != nil {
 		return err
 	}
-	if err := ioutils.AtomicWriteFile(rpath, jdata, 0600); err != nil {
-		return err
-	}
+	// This must be done before we write the file, because the process could be terminated
+	// after the file is written but before the lock file is updated.
 	lw, err := r.lockfile.RecordWrite()
 	if err != nil {
 		return err
 	}
 	r.lastWrite = lw
+	if err := ioutils.AtomicWriteFile(rpath, jdata, 0600); err != nil {
+		return err
+	}
 	return nil
 }
 


### PR DESCRIPTION
The lockfile's write record is now updated prior to the actual write operation.  This ensures that, in the event of an unexpected termination, other processes are correctly notified of an initiated write operation.