### PR TITLE
Fail on unmount/rmdir in overlay.Driver.Put

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -1770,11 +1770,13 @@ func (d *Driver) Put(id string) error {
 	if !unmounted {
 		if err := unix.Unmount(mountpoint, unix.MNT_DETACH); err != nil && !os.IsNotExist(err) {
 			logrus.Debugf("Failed to unmount %s overlay: %s - %v", id, mountpoint, err)
+			return fmt.Errorf("unmounting %q: %w", mountpoint, err)
 		}
 	}
 
 	if err := unix.Rmdir(mountpoint); err != nil && !os.IsNotExist(err) {
 		logrus.Debugf("Failed to remove mountpoint %s overlay: %s - %v", id, mountpoint, err)
+		return fmt.Errorf("removing mount point %q: %w", mountpoint, err)
 	}
 
 	return nil


### PR DESCRIPTION
… instead of only logging a debug-level failure.

We are seeing layers being mounted while our metadata claims that they are unmounted, and this seems to be a way how that could happen without leaving a visible trace.

It's unclear to me why this silently succeeds; this behavior is very long-standing.

Motivated by https://github.com/containers/podman/issues/17216 , where we seem to be seeing mounted layers with zero count in `mount points.json`.

⚠️ I don’t really know what I’m doing, there might be a good reason for the current behavior. Alternatively, I’d like the `Debug` logs to be elevated to at least a `Warning`, possibly outright `Error`. @nalind @giuseppe PTAL.