### PR TITLE
Fix typo in storage.conf

### DIFF
--- a/docs/containers-storage.conf.5.md
+++ b/docs/containers-storage.conf.5.md
@@ -93,7 +93,7 @@ container registry. These options can deduplicate pulling of content, disk
 storage of content and can allow the kernel to use less memory when running
 containers.
 
-containers/storage supports four keys
+containers/storage supports three keys
   * enable_partial_images="true" | "false"
     Tells containers/storage to look for files previously pulled in storage
     rather then always pulling them from the container registry.
@@ -110,8 +110,8 @@ containers/storage supports four keys
   Remap-UIDs/GIDs is the mapping from UIDs/GIDs as they should appear inside of a container, to the UIDs/GIDs outside of the container, and the length of the range of UIDs/GIDs.  Additional mapped sets can be listed and will be heeded by libraries, but there are limits to the number of mappings which the kernel will allow when you later attempt to run a container.
 
   Example
-     remap-uids = 0:1668442479:65536
-     remap-gids = 0:1668442479:65536
+     remap-uids = "0:1668442479:65536"
+     remap-gids = "0:1668442479:65536"
 
   These mappings tell the container engines to map UID 0 inside of the container to UID 1668442479 outside.  UID 1 will be mapped to 1668442480. UID 2 will be mapped to 1668442481, etc, for the next 65533 UIDs in succession.
 

--- a/storage.conf
+++ b/storage.conf
@@ -55,7 +55,7 @@ additionalimagestores = [
 # can deduplicate pulling of content, disk storage of content and can allow the
 # kernel to use less memory when running containers.
 
-# containers/storage supports four keys
+# containers/storage supports three keys
 #   * enable_partial_images="true" | "false"
 #     Tells containers/storage to look for files previously pulled in storage
 #     rather then always pulling them from the container registry.
@@ -75,8 +75,8 @@ pull_options = {enable_partial_images = "false", use_hard_links = "false", ostre
 # mappings which the kernel will allow when you later attempt to run a
 # container.
 #
-# remap-uids = 0:1668442479:65536
-# remap-gids = 0:1668442479:65536
+# remap-uids = "0:1668442479:65536"
+# remap-gids = "0:1668442479:65536"
 
 # Remap-User/Group is a user name which can be used to look up one or more UID/GID
 # ranges in the /etc/subuid or /etc/subgid file.  Mappings are set up starting
@@ -100,7 +100,7 @@ pull_options = {enable_partial_images = "false", use_hard_links = "false", ostre
 # Auto-userns-min-size is the minimum size for a user namespace created automatically.
 # auto-userns-min-size=1024
 #
-# Auto-userns-max-size is the minimum size for a user namespace created automatically.
+# Auto-userns-max-size is the maximum size for a user namespace created automatically.
 # auto-userns-max-size=65536
 
 [storage.options.overlay]


### PR DESCRIPTION
- remap-uids and remap-gids requires a string data type.
- "four keys" -> "three keys"
- "minimum" -> "maximum"