### PR TITLE
WIP: [1.37] Always close pgzip writer on `applyDiffWithOptions`

### DIFF
--- a/layers.go
+++ b/layers.go
@@ -1554,8 +1554,9 @@ func (r *layerStore) applyDiffWithOptions(to string, layerOptions *LayerOptions,
 	tsdata := bytes.Buffer{}
 	compressor, err := pgzip.NewWriterLevel(&tsdata, pgzip.BestSpeed)
 	if err != nil {
-		compressor = pgzip.NewWriter(&tsdata)
+		return -1, err
 	}
+	defer compressor.Close()
 	if err := compressor.SetConcurrency(1024*1024, 1); err != nil { // 1024*1024 is the hard-coded default; we're not changing that
 		logrus.Infof("Error setting compression concurrency threads to 1: %v; ignoring", err)
 	}
@@ -1595,7 +1596,6 @@ func (r *layerStore) applyDiffWithOptions(to string, layerOptions *LayerOptions,
 	if err != nil {
 		return -1, err
 	}
-	compressor.Close()
 	if err == nil {
 		if err := os.MkdirAll(filepath.Dir(r.tspath(layer.ID)), 0700); err != nil {
 			return -1, err


### PR DESCRIPTION
There are cases where the writer will not be closed because we return earlier, which may cause goroutines leaking in CRI-O.

Refers to https://issues.redhat.com/browse/OCPBUGS-10290