### PR TITLE
.cirrus.yml: fix a warning

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -56,7 +56,6 @@ gce_instance:
 linux_testing: &linux_testing
     depends_on:
         - lint
-    only_if: $CIRRUS_CHANGE_TITLE !=~ '.*CI:DOCS.*'
     gce_instance:  # Only need to specify differences from defaults (above)
         image_name: "${VM_IMAGE}"
 


### PR DESCRIPTION
Cirrus CI emits a bunch of warnings like this one:

> task "success" depends on task "fedora-38 vfs", but their only_if conditions are different

~~To fix, use "skip" instead of "only_if". The difference between the two is described at
https://cirrus-ci.org/guide/writing-tasks/#conditional-task-execution~~

This was probably a copy-paste leftover from another repo, which uses CI:DOCS
magic to skip some tests. In this repo, it is not used, so remove the condition.
