### PR TITLE
options: keep using prior drivers if found

### DIFF
--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -342,12 +342,12 @@ func New(name string, config Options) (Driver, error) {
 	}
 
 	// Guess for prior driver
-	driversMap := scanPriorDrivers(config.Root)
+	driversMap := ScanPriorDrivers(config.Root)
 
 	// use the supplied priority list unless it is empty
 	prioList := config.DriverPriority
 	if len(prioList) == 0 {
-		prioList = priority
+		prioList = Priority
 	}
 
 	for _, name := range prioList {
@@ -419,12 +419,12 @@ func isDriverNotSupported(err error) bool {
 }
 
 // scanPriorDrivers returns an un-ordered scan of directories of prior storage drivers
-func scanPriorDrivers(root string) map[string]bool {
+func ScanPriorDrivers(root string) map[string]bool {
 	driversMap := make(map[string]bool)
 
 	for driver := range drivers {
 		p := filepath.Join(root, driver)
-		if _, err := os.Stat(p); err == nil && driver != "vfs" {
+		if _, err := os.Stat(p); err == nil {
 			driversMap[driver] = true
 		}
 	}

--- a/drivers/driver_darwin.go
+++ b/drivers/driver_darwin.go
@@ -2,7 +2,7 @@ package graphdriver
 
 var (
 	// Slice of drivers that should be used in order
-	priority = []string{
+	Priority = []string{
 		"vfs",
 	}
 )

--- a/drivers/driver_freebsd.go
+++ b/drivers/driver_freebsd.go
@@ -13,7 +13,7 @@ const (
 
 var (
 	// Slice of drivers that should be used in an order
-	priority = []string{
+	Priority = []string{
 		"zfs",
 		"vfs",
 	}

--- a/drivers/driver_linux.go
+++ b/drivers/driver_linux.go
@@ -90,7 +90,7 @@ const (
 
 var (
 	// Slice of drivers that should be used in an order
-	priority = []string{
+	Priority = []string{
 		"overlay",
 		// We don't support devicemapper without configuration
 		// "devicemapper",

--- a/drivers/driver_solaris.go
+++ b/drivers/driver_solaris.go
@@ -31,7 +31,7 @@ const (
 
 var (
 	// Slice of drivers that should be used in an order
-	priority = []string{
+	Priority = []string{
 		"zfs",
 	}
 

--- a/drivers/driver_unsupported.go
+++ b/drivers/driver_unsupported.go
@@ -5,7 +5,7 @@ package graphdriver
 
 var (
 	// Slice of drivers that should be used in an order
-	priority = []string{
+	Priority = []string{
 		"unsupported",
 	}
 )

--- a/drivers/driver_windows.go
+++ b/drivers/driver_windows.go
@@ -2,7 +2,7 @@ package graphdriver
 
 var (
 	// Slice of drivers that should be used in order
-	priority = []string{
+	Priority = []string{
 		"windowsfilter",
 	}
 )


### PR DESCRIPTION
There is no need for `vfs` to be the default storage driver since kernel
`>= 5.13` supports `overlay` natively however there is use-case for users
who don't had any configs and they started using `vfs` in a default manner following check is a hack to keep `buildah` and `podman` working for such users.

See: https://github.com/containers/storage/pull/1571 for prior discussions.