### PR TITLE
options: enable Remap-User/Group setting

### DIFF
--- a/docs/containers-storage.conf.5.md
+++ b/docs/containers-storage.conf.5.md
@@ -117,7 +117,7 @@ containers/storage supports three keys
 
 **remap-user**=""
 **remap-group**=""
-  Remap-User/Group is a user name which can be used to look up one or more UID/GID ranges in the /etc/subuid or /etc/subgid file.  Mappings are set up starting with an in-container ID of 0 and then a host-level ID taken from the lowest range that matches the specified name, and using the length of that range. Additional ranges are then assigned, using the ranges which specify the lowest host-level IDs first, to the lowest not-yet-mapped in-container ID, until all of the entries have been used for maps.
+  Remap-User/Group is a user name which can be used to look up one or more UID/GID ranges in the /etc/subuid or /etc/subgid file.  Mappings are set up starting with an in-container ID of 0 and then a host-level ID taken from the lowest range that matches the specified name, and using the length of that range. Additional ranges are then assigned, using the ranges which specify the lowest host-level IDs first, to the lowest not-yet-mapped in-container ID, until all of the entries have been used for maps.  This setting overrides the Remap-UIDs/GIDs setting.
 
   Example
      remap-user = "containers"

--- a/storage.conf
+++ b/storage.conf
@@ -84,7 +84,8 @@ pull_options = {enable_partial_images = "false", use_hard_links = "false", ostre
 # range that matches the specified name, and using the length of that range.
 # Additional ranges are then assigned, using the ranges which specify the
 # lowest host-level IDs first, to the lowest not-yet-mapped in-container ID,
-# until all of the entries have been used for maps.
+# until all of the entries have been used for maps. This setting overrides the
+# Remap-UIDs/GIDs setting.
 #
 # remap-user = "containers"
 # remap-group = "containers"

--- a/types/options.go
+++ b/types/options.go
@@ -444,6 +444,16 @@ func ReloadConfigurationFile(configFile string, storeOptions *StoreOptions) erro
 	if config.Storage.Options.MountOpt != "" {
 		storeOptions.GraphDriverOptions = append(storeOptions.GraphDriverOptions, fmt.Sprintf("%s.mountopt=%s", config.Storage.Driver, config.Storage.Options.MountOpt))
 	}
+
+	uidmap, err := idtools.ParseIDMap([]string{config.Storage.Options.RemapUIDs}, "remap-uids")
+	if err != nil {
+		return err
+	}
+	gidmap, err := idtools.ParseIDMap([]string{config.Storage.Options.RemapGIDs}, "remap-gids")
+	if err != nil {
+		return err
+	}
+
 	if config.Storage.Options.RemapUser != "" && config.Storage.Options.RemapGroup == "" {
 		config.Storage.Options.RemapGroup = config.Storage.Options.RemapUser
 	}
@@ -456,19 +466,9 @@ func ReloadConfigurationFile(configFile string, storeOptions *StoreOptions) erro
 			logrus.Warningf("Error initializing ID mappings for %s:%s %v\n", config.Storage.Options.RemapUser, config.Storage.Options.RemapGroup, err)
 			return err
 		}
-		storeOptions.UIDMap = mappings.UIDs()
-		storeOptions.GIDMap = mappings.GIDs()
+		uidmap = mappings.UIDs()
+		gidmap = mappings.GIDs()
 	}
-
-	uidmap, err := idtools.ParseIDMap([]string{config.Storage.Options.RemapUIDs}, "remap-uids")
-	if err != nil {
-		return err
-	}
-	gidmap, err := idtools.ParseIDMap([]string{config.Storage.Options.RemapGIDs}, "remap-gids")
-	if err != nil {
-		return err
-	}
-
 	storeOptions.UIDMap = uidmap
 	storeOptions.GIDMap = gidmap
 	storeOptions.RootAutoNsUser = config.Storage.Options.RootAutoUsernsUser

--- a/types/options_test.go
+++ b/types/options_test.go
@@ -5,9 +5,11 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"strings"
 	"testing"
 
+	"github.com/containers/storage/pkg/idtools"
 	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 	"gotest.tools/assert"
@@ -129,6 +131,75 @@ func TestGetRootlessStorageOpts2(t *testing.T) {
 	storageOpts, err := getRootlessStorageOpts(2000, opts)
 	assert.NilError(t, err)
 	assert.Equal(t, storageOpts.GraphRoot, expectedPath)
+}
+
+func TestSetRemapUIDsGIDsOpts(t *testing.T) {
+	var remapOpts StoreOptions
+	uidmap := []idtools.IDMap{
+		{
+			ContainerID: 0,
+			HostID:      1000000000,
+			Size:        30000,
+		},
+	}
+	gidmap := []idtools.IDMap{
+		{
+			ContainerID: 0,
+			HostID:      1500000000,
+			Size:        60000,
+		},
+	}
+
+	err := ReloadConfigurationFile("./storage_test.conf", &remapOpts)
+	require.NoError(t, err)
+	if !reflect.DeepEqual(uidmap, remapOpts.UIDMap) {
+		t.Errorf("Failed to set UIDMap: Expected %v Actual %v", uidmap, remapOpts.UIDMap)
+	}
+	if !reflect.DeepEqual(gidmap, remapOpts.GIDMap) {
+		t.Errorf("Failed to set GIDMap: Expected %v Actual %v", gidmap, remapOpts.GIDMap)
+	}
+}
+
+func TestSetRemapUserGroupOpts(t *testing.T) {
+	var remapOpts StoreOptions
+
+	user := os.Getenv("USER")
+	if user == "root" {
+		t.Skip("This test is enabled only rootless user")
+	}
+
+	configPath := "./remap_user_test.conf"
+	config := fmt.Sprintf(`
+[storage]
+driver = ""
+
+[storage.options]
+remap-uids = "0:1000000000:30000"
+remap-gids = "0:1500000000:60000"
+
+remap-user = "%s"
+remap-group = "%s"
+`, user, user)
+	f, err := os.Create(configPath)
+	require.NoError(t, err)
+	defer func() {
+		f.Close()
+		os.Remove(configPath)
+	}()
+
+	_, err = f.Write([]byte(config))
+	require.NoError(t, err)
+
+	mappings, err := idtools.NewIDMappings(user, user)
+	require.NoError(t, err)
+	err = ReloadConfigurationFile(configPath, &remapOpts)
+	require.NoError(t, err)
+	if !reflect.DeepEqual(mappings.UIDs(), remapOpts.UIDMap) {
+		t.Errorf("Failed to set UIDMap: Expected %v Actual %v", mappings.UIDs(), remapOpts.UIDMap)
+	}
+	if !reflect.DeepEqual(mappings.GIDs(), remapOpts.GIDMap) {
+		t.Errorf("Failed to set GIDMap: Expected %v Actual %v", mappings.GIDs(), remapOpts.GIDMap)
+	}
 }
 
 func TestReloadConfigurationFile(t *testing.T) {

--- a/types/storage_test.conf
+++ b/types/storage_test.conf
@@ -25,6 +25,16 @@ rootless_storage_path = "$HOME/$UID/containers/storage"
 additionalimagestores = [
 ]
 
+# Remap-UIDs/GIDs is the mapping from UIDs/GIDs as they should appear inside of
+# a container, to the UIDs/GIDs as they should appear outside of the container,
+# and the length of the range of UIDs/GIDs.  Additional mapped sets can be
+# listed and will be heeded by libraries, but there are limits to the number of
+# mappings which the kernel will allow when you later attempt to run a
+# container.
+#
+remap-uids = "0:1000000000:30000"
+remap-gids = "0:1500000000:60000"
+
 [storage.options.overlay]
 
 # mountopt specifies comma separated list of extra mount options


### PR DESCRIPTION
`Remap-User/Group` setting is always override by
`Remap-UIDs/GIDs` setting and ignored.

This commit enables `Remap-User/Group` setting.