### PR TITLE
Audit data flow in applyDiffWithOptions

### DIFF
--- a/layers.go
+++ b/layers.go
@@ -2255,6 +2255,7 @@ func (r *layerStore) applyDiffWithOptions(to string, layerOptions *LayerOptions,
 		if err != nil {
 			return -1, err
 		}
+		defer compressor.Close()                                        // This must happen before tsdata is consumed.
 		if err := compressor.SetConcurrency(1024*1024, 1); err != nil { // 1024*1024 is the hard-coded default; we're not changing that
 			logrus.Infof("setting compression concurrency threads to 1: %v; ignoring", err)
 		}
@@ -2292,7 +2293,6 @@ func (r *layerStore) applyDiffWithOptions(to string, layerOptions *LayerOptions,
 		if err != nil {
 			return -1, err
 		}
-		compressor.Close()
 		return size, err
 	}()
 	if err != nil {

--- a/layers.go
+++ b/layers.go
@@ -2248,7 +2248,7 @@ func (r *layerStore) applyDiffWithOptions(to string, layerOptions *LayerOptions,
 	tsdata := bytes.Buffer{}
 	compressor, err := pgzip.NewWriterLevel(&tsdata, pgzip.BestSpeed)
 	if err != nil {
-		compressor = pgzip.NewWriter(&tsdata)
+		return -1, err
 	}
 	if err := compressor.SetConcurrency(1024*1024, 1); err != nil { // 1024*1024 is the hard-coded default; we're not changing that
 		logrus.Infof("setting compression concurrency threads to 1: %v; ignoring", err)


### PR DESCRIPTION
This is a superset of #1612 / #1623 , also fixing an unlikely-to-hit race in use of `pkg/tarlog`.

See individual commit messages for details.