### PR TITLE
options,rootless: honor `imagestore` from config file

### DIFF
--- a/types/options.go
+++ b/types/options.go
@@ -300,6 +300,7 @@ func getRootlessStorageOpts(rootlessUID int, systemOpts StoreOptions) (StoreOpti
 	// present.
 	if defaultConfigFileSet {
 		opts.GraphDriverOptions = systemOpts.GraphDriverOptions
+		opts.ImageStore = systemOpts.ImageStore
 	} else if opts.GraphDriverName == overlayDriver {
 		for _, o := range systemOpts.GraphDriverOptions {
 			if strings.Contains(o, "ignore_chown_errors") {


### PR DESCRIPTION
Honor `imagestore` option from config file for rootless setups.

Fixes issues in: https://github.com/containers/podman/pull/18224