### PR TITLE
composefs integration in the overlay driver

### DIFF
--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -191,8 +191,21 @@ type DriverWithDifferOutput struct {
 	TOCDigest          digest.Digest
 }
 
+type DifferOutputFormat int
+
+const (
+	// DifferOutputFormatDir means the output is a directory and it will
+	// keep the original layout.
+	DifferOutputFormatDir = iota
+	// DifferOutputFormatFlat will store the files by their checksum, in the form
+	// checksum[0:2]/checksum[2:]
+	DifferOutputFormatFlat
+)
+
 // DifferOptions overrides how the differ work
 type DifferOptions struct {
+	// Format defines the destination directory layout format
+	Format DifferOutputFormat
 }
 
 // Differ defines the interface for using a custom differ.

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -191,10 +191,14 @@ type DriverWithDifferOutput struct {
 	TOCDigest          digest.Digest
 }
 
+// DifferOptions overrides how the differ work
+type DifferOptions struct {
+}
+
 // Differ defines the interface for using a custom differ.
 // This API is experimental and can be changed without bumping the major version number.
 type Differ interface {
-	ApplyDiff(dest string, options *archive.TarOptions) (DriverWithDifferOutput, error)
+	ApplyDiff(dest string, options *archive.TarOptions, differOpts *DifferOptions) (DriverWithDifferOutput, error)
 }
 
 // DriverWithDiffer is the interface for direct diff access.

--- a/drivers/overlay/composefs_notsupported.go
+++ b/drivers/overlay/composefs_notsupported.go
@@ -1,0 +1,20 @@
+//go:build !linux || !composefs || !cgo
+// +build !linux !composefs !cgo
+
+package overlay
+
+import (
+	"fmt"
+)
+
+func composeFsSupported() bool {
+	return false
+}
+
+func generateComposeFsBlob(toc []byte, destFile string) error {
+	return fmt.Errorf("composefs is not supported")
+}
+
+func mountErofsBlob(blobFile, mountPoint string) error {
+	return fmt.Errorf("composefs is not supported")
+}

--- a/drivers/overlay/composefs_notsupported.go
+++ b/drivers/overlay/composefs_notsupported.go
@@ -18,3 +18,7 @@ func generateComposeFsBlob(toc []byte, destFile string) error {
 func mountErofsBlob(blobFile, mountPoint string) error {
 	return fmt.Errorf("composefs is not supported")
 }
+
+func enableVerityRecursive(path string) error {
+	return fmt.Errorf("composefs is not supported")
+}

--- a/drivers/overlay/composefs_supported.go
+++ b/drivers/overlay/composefs_supported.go
@@ -1,0 +1,66 @@
+//go:build linux && composefs && cgo
+// +build linux,composefs,cgo
+
+package overlay
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"sync"
+
+	"github.com/containers/storage/pkg/loopback"
+	"golang.org/x/sys/unix"
+)
+
+var (
+	composeFsHelperOnce sync.Once
+	composeFsHelperPath string
+	composeFsHelperErr  error
+)
+
+func getComposeFsHelper() (string, error) {
+	composeFsHelperOnce.Do(func() {
+		composeFsHelperPath, composeFsHelperErr = exec.LookPath("composefs-from-json")
+	})
+	return composeFsHelperPath, composeFsHelperErr
+}
+
+func composeFsSupported() bool {
+	_, err := getComposeFsHelper()
+	return err == nil
+}
+
+func generateComposeFsBlob(toc []byte, destFile string) error {
+	writerJson, err := getComposeFsHelper()
+	if err != nil {
+		return fmt.Errorf("failed to find composefs-from-json: %w", err)
+	}
+
+	fd, err := unix.Openat(unix.AT_FDCWD, destFile, unix.O_WRONLY|unix.O_CREAT|unix.O_TRUNC|unix.O_EXCL|unix.O_CLOEXEC, 0o644)
+	if err != nil {
+		return fmt.Errorf("failed to open output file: %w", err)
+	}
+	outFd := os.NewFile(uintptr(fd), "outFd")
+
+	defer outFd.Close()
+	cmd := exec.Command(writerJson, "--format=erofs", "--out=/proc/self/fd/3", "/proc/self/fd/0")
+	cmd.ExtraFiles = []*os.File{outFd}
+	cmd.Stdin = bytes.NewReader(toc)
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		return fmt.Errorf("failed to convert json to erofs: %w", err)
+	}
+	return nil
+}
+
+func mountErofsBlob(blobFile, mountPoint string) error {
+	loop, err := loopback.AttachLoopDevice(blobFile)
+	if err != nil {
+		return err
+	}
+	defer loop.Close()
+
+	return unix.Mount(loop.Name(), mountPoint, "erofs", unix.MS_RDONLY, "ro")
+}

--- a/drivers/overlay/composefs_supported.go
+++ b/drivers/overlay/composefs_supported.go
@@ -5,12 +5,18 @@ package overlay
 
 import (
 	"bytes"
+	"errors"
 	"fmt"
+	"io/fs"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"sync"
+	"syscall"
+	"unsafe"
 
 	"github.com/containers/storage/pkg/loopback"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
 
@@ -32,6 +38,43 @@ func composeFsSupported() bool {
 	return err == nil
 }
 
+func enableVerity(description string, fd int) error {
+	enableArg := unix.FsverityEnableArg{
+		Version:        1,
+		Hash_algorithm: unix.FS_VERITY_HASH_ALG_SHA256,
+		Block_size:     4096,
+	}
+
+	_, _, e1 := syscall.Syscall(unix.SYS_IOCTL, uintptr(fd), uintptr(unix.FS_IOC_ENABLE_VERITY), uintptr(unsafe.Pointer(&enableArg)))
+	if e1 != 0 && !errors.Is(e1, unix.EEXIST) {
+		return fmt.Errorf("failed to enable verity for %q: %w", description, e1)
+	}
+	return nil
+}
+
+func enableVerityRecursive(path string) error {
+	walkFn := func(path string, d fs.DirEntry, err error) error {
+		if err != nil {
+			return err
+		}
+		if !d.Type().IsRegular() {
+			return nil
+		}
+
+		f, err := os.Open(path)
+		if err != nil {
+			return err
+		}
+		defer f.Close()
+
+		if err := enableVerity(path, int(f.Fd())); err != nil {
+			return err
+		}
+		return nil
+	}
+	return filepath.WalkDir(path, walkFn)
+}
+
 func generateComposeFsBlob(toc []byte, destFile string) error {
 	writerJson, err := getComposeFsHelper()
 	if err != nil {
@@ -44,14 +87,35 @@ func generateComposeFsBlob(toc []byte, destFile string) error {
 	}
 	outFd := os.NewFile(uintptr(fd), "outFd")
 
-	defer outFd.Close()
-	cmd := exec.Command(writerJson, "--format=erofs", "--out=/proc/self/fd/3", "/proc/self/fd/0")
-	cmd.ExtraFiles = []*os.File{outFd}
-	cmd.Stdin = bytes.NewReader(toc)
-	cmd.Stderr = os.Stderr
-	if err := cmd.Run(); err != nil {
-		return fmt.Errorf("failed to convert json to erofs: %w", err)
+	fd, err = unix.Open(fmt.Sprintf("/proc/self/fd/%d", outFd.Fd()), unix.O_RDONLY|unix.O_CLOEXEC, 0)
+	if err != nil {
+		outFd.Close()
+		return fmt.Errorf("failed to dup output file: %w", err)
 	}
+	newFd := os.NewFile(uintptr(fd), "newFd")
+	defer newFd.Close()
+
+	err = func() error {
+		// a scope to close outFd before setting fsverity on the read-only fd.
+		defer outFd.Close()
+
+		cmd := exec.Command(writerJson, "--format=erofs", "--out=/proc/self/fd/3", "/proc/self/fd/0")
+		cmd.ExtraFiles = []*os.File{outFd}
+		cmd.Stderr = os.Stderr
+		cmd.Stdin = bytes.NewReader(toc)
+		if err := cmd.Run(); err != nil {
+			return fmt.Errorf("failed to convert json to erofs: %w", err)
+		}
+		return nil
+	}()
+	if err != nil {
+		return err
+	}
+
+	if err := enableVerity("manifest file", int(newFd.Fd())); err != nil && !errors.Is(err, unix.ENOTSUP) && !errors.Is(err, unix.ENOTTY) {
+		logrus.Warningf("%s", err)
+	}
+
 	return nil
 }
 

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -1934,7 +1934,7 @@ func (d *Driver) ApplyDiffWithDiffer(id, parent string, options *graphdriver.App
 		IgnoreChownErrors: d.options.ignoreChownErrors,
 		WhiteoutFormat:    d.getWhiteoutFormat(),
 		InUserNS:          unshare.IsRootless(),
-	})
+	}, nil)
 	out.Target = applyDir
 	return out, err
 }

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -1431,6 +1431,9 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 		logLevel = logrus.DebugLevel
 	}
 	optsList := options.Options
+
+	needsIDMapping := !disableShifting && len(options.UidMaps) > 0 && len(options.GidMaps) > 0 && d.options.mountProgram == ""
+
 	if len(optsList) == 0 {
 		optsList = strings.Split(d.options.mountOptions, ",")
 	} else {
@@ -1596,7 +1599,7 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 		}
 	}
 
-	if !disableShifting && len(options.UidMaps) > 0 && len(options.GidMaps) > 0 && d.options.mountProgram == "" {
+	if needsIDMapping {
 		var newAbsDir []string
 		mappedRoot := filepath.Join(d.home, id, "mapped")
 		if err := os.MkdirAll(mappedRoot, 0o700); err != nil {

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -2064,6 +2064,11 @@ func (d *Driver) ApplyDiffFromStagingDirectory(id, parent, stagingDirectory stri
 	}
 
 	if d.useComposeFs() {
+		// FIXME: move this logic into the differ so we don't have to open
+		// the file twice.
+		if err := enableVerityRecursive(stagingDirectory); err != nil && !errors.Is(err, unix.ENOTSUP) && !errors.Is(err, unix.ENOTTY) {
+			logrus.Warningf("%s", err)
+		}
 		toc := diffOutput.BigData[zstdChunkedManifest]
 		if err := generateComposeFsBlob(toc, d.getErofsBlob(id)); err != nil {
 			return err

--- a/pkg/chunked/cache_linux.go
+++ b/pkg/chunked/cache_linux.go
@@ -15,6 +15,7 @@ import (
 	"unsafe"
 
 	storage "github.com/containers/storage"
+	graphdriver "github.com/containers/storage/drivers"
 	"github.com/containers/storage/pkg/chunked/internal"
 	"github.com/containers/storage/pkg/ioutils"
 	jsoniter "github.com/json-iterator/go"
@@ -109,7 +110,7 @@ func (c *layersCache) load() error {
 		}
 
 		bigData, err := c.store.LayerBigData(r.ID, cacheKey)
-		// if the cache areadly exists, read and use it
+		// if the cache already exists, read and use it
 		if err == nil {
 			defer bigData.Close()
 			metadata, err := readMetadataFromCache(bigData)
@@ -120,6 +121,23 @@ func (c *layersCache) load() error {
 			logrus.Warningf("Error reading cache file for layer %q: %v", r.ID, err)
 		} else if !errors.Is(err, os.ErrNotExist) {
 			return err
+		}
+
+		var lcd chunkedLayerData
+
+		clFile, err := c.store.LayerBigData(r.ID, chunkedLayerDataKey)
+		if err != nil && !errors.Is(err, os.ErrNotExist) {
+			return err
+		}
+		if clFile != nil {
+			cl, err := io.ReadAll(clFile)
+			if err != nil {
+				return fmt.Errorf("open manifest file for layer %q: %w", r.ID, err)
+			}
+			json := jsoniter.ConfigCompatibleWithStandardLibrary
+			if err := json.Unmarshal(cl, &lcd); err != nil {
+				return err
+			}
 		}
 
 		// otherwise create it from the layer TOC.
@@ -134,7 +152,7 @@ func (c *layersCache) load() error {
 			return fmt.Errorf("open manifest file for layer %q: %w", r.ID, err)
 		}
 
-		metadata, err := writeCache(manifest, r.ID, c.store)
+		metadata, err := writeCache(manifest, lcd.Format, r.ID, c.store)
 		if err == nil {
 			c.addLayer(r.ID, metadata)
 		}
@@ -211,13 +229,13 @@ type setBigData interface {
 // - digest(file.payload))
 // - digest(digest(file.payload) + file.UID + file.GID + file.mode + file.xattrs)
 // - digest(i) for each i in chunks(file payload)
-func writeCache(manifest []byte, id string, dest setBigData) (*metadata, error) {
+func writeCache(manifest []byte, format graphdriver.DifferOutputFormat, id string, dest setBigData) (*metadata, error) {
 	var vdata bytes.Buffer
 	tagLen := 0
 	digestLen := 0
 	var tagsBuffer bytes.Buffer
 
-	toc, err := prepareMetadata(manifest)
+	toc, err := prepareMetadata(manifest, format)
 	if err != nil {
 		return nil, err
 	}
@@ -396,12 +414,23 @@ func readMetadataFromCache(bigData io.Reader) (*metadata, error) {
 	}, nil
 }
 
-func prepareMetadata(manifest []byte) ([]*internal.FileMetadata, error) {
+func prepareMetadata(manifest []byte, format graphdriver.DifferOutputFormat) ([]*internal.FileMetadata, error) {
 	toc, err := unmarshalToc(manifest)
 	if err != nil {
 		// ignore errors here.  They might be caused by a different manifest format.
 		logrus.Debugf("could not unmarshal manifest: %v", err)
 		return nil, nil //nolint: nilnil
+	}
+
+	switch format {
+	case graphdriver.DifferOutputFormatDir:
+	case graphdriver.DifferOutputFormatFlat:
+		toc.Entries, err = makeEntriesFlat(toc.Entries)
+		if err != nil {
+			return nil, err
+		}
+	default:
+		return nil, fmt.Errorf("unknown format %q", format)
 	}
 
 	var r []*internal.FileMetadata
@@ -420,6 +449,7 @@ func prepareMetadata(manifest []byte) ([]*internal.FileMetadata, error) {
 			chunkSeen[cd] = true
 		}
 	}
+
 	return r, nil
 }
 

--- a/pkg/chunked/storage_linux.go
+++ b/pkg/chunked/storage_linux.go
@@ -28,6 +28,7 @@ import (
 	"github.com/containers/storage/pkg/system"
 	"github.com/containers/storage/types"
 	securejoin "github.com/cyphar/filepath-securejoin"
+	jsoniter "github.com/json-iterator/go"
 	"github.com/klauspost/compress/zstd"
 	"github.com/klauspost/pgzip"
 	digest "github.com/opencontainers/go-digest"
@@ -41,6 +42,8 @@ const (
 	newFileFlags            = (unix.O_CREAT | unix.O_TRUNC | unix.O_EXCL | unix.O_WRONLY)
 	containersOverrideXattr = "user.containers.override_stat"
 	bigDataKey              = "zstd-chunked-manifest"
+	chunkedData             = "zstd-chunked-data"
+	chunkedLayerDataKey     = "zstd-chunked-layer-data"
 
 	fileTypeZstdChunked = iota
 	fileTypeEstargz
@@ -71,6 +74,11 @@ type chunkedDiffer struct {
 
 var xattrsToIgnore = map[string]interface{}{
 	"security.selinux": true,
+}
+
+// chunkedLayerData is used to store additional information about the layer
+type chunkedLayerData struct {
+	Format graphdriver.DifferOutputFormat `json:"format"`
 }
 
 func timeToTimespec(time *time.Time) (ts unix.Timespec) {
@@ -241,7 +249,7 @@ func copyFileFromOtherLayer(file *internal.FileMetadata, source string, name str
 
 	srcFile, err := openFileUnderRoot(name, srcDirfd, unix.O_RDONLY, 0)
 	if err != nil {
-		return false, nil, 0, fmt.Errorf("open source file under target rootfs: %w", err)
+		return false, nil, 0, fmt.Errorf("open source file under target rootfs (%s): %w", name, err)
 	}
 	defer srcFile.Close()
 
@@ -1324,6 +1332,38 @@ func (c *chunkedDiffer) findAndCopyFile(dirfd int, r *internal.FileMetadata, cop
 	return false, nil
 }
 
+func makeEntriesFlat(mergedEntries []internal.FileMetadata) ([]internal.FileMetadata, error) {
+	var new []internal.FileMetadata
+
+	hashes := make(map[string]string)
+	for i := range mergedEntries {
+		if mergedEntries[i].Type != TypeReg {
+			continue
+		}
+		if mergedEntries[i].Digest == "" {
+			if mergedEntries[i].Size != 0 {
+				return nil, fmt.Errorf("missing digest for %q", mergedEntries[i].Name)
+			}
+			continue
+		}
+		digest, err := digest.Parse(mergedEntries[i].Digest)
+		if err != nil {
+			return nil, err
+		}
+		d := digest.Encoded()
+
+		if hashes[d] != "" {
+			continue
+		}
+		hashes[d] = d
+
+		mergedEntries[i].Name = fmt.Sprintf("%s/%s", d[0:2], d[2:])
+
+		new = append(new, mergedEntries[i])
+	}
+	return new, nil
+}
+
 func (c *chunkedDiffer) ApplyDiff(dest string, options *archive.TarOptions, differOpts *graphdriver.DifferOptions) (graphdriver.DriverWithDifferOutput, error) {
 	defer c.layersCache.release()
 	defer func() {
@@ -1332,11 +1372,21 @@ func (c *chunkedDiffer) ApplyDiff(dest string, options *archive.TarOptions, diff
 		}
 	}()
 
+	lcd := chunkedLayerData{
+		Format: differOpts.Format,
+	}
+
+	json := jsoniter.ConfigCompatibleWithStandardLibrary
+	lcdBigData, err := json.Marshal(lcd)
+	if err != nil {
+		return graphdriver.DriverWithDifferOutput{}, err
+	}
 	output := graphdriver.DriverWithDifferOutput{
 		Differ:   c,
 		TarSplit: c.tarSplit,
 		BigData: map[string][]byte{
-			bigDataKey: c.manifest,
+			bigDataKey:          c.manifest,
+			chunkedLayerDataKey: lcdBigData,
 		},
 		TOCDigest: c.tocDigest,
 	}
@@ -1395,6 +1445,21 @@ func (c *chunkedDiffer) ApplyDiff(dest string, options *archive.TarOptions, diff
 		return output, fmt.Errorf("cannot open %q: %w", dest, err)
 	}
 	defer unix.Close(dirfd)
+
+	if differOpts != nil && differOpts.Format == graphdriver.DifferOutputFormatFlat {
+		mergedEntries, err = makeEntriesFlat(mergedEntries)
+		if err != nil {
+			return output, err
+		}
+		createdDirs := make(map[string]struct{})
+		for _, e := range mergedEntries {
+			d := e.Name[0:2]
+			if _, found := createdDirs[d]; !found {
+				unix.Mkdirat(dirfd, d, 0o755)
+				createdDirs[d] = struct{}{}
+			}
+		}
+	}
 
 	// hardlinks can point to missing files.  So create them after all files
 	// are retrieved

--- a/pkg/chunked/storage_linux.go
+++ b/pkg/chunked/storage_linux.go
@@ -1324,7 +1324,7 @@ func (c *chunkedDiffer) findAndCopyFile(dirfd int, r *internal.FileMetadata, cop
 	return false, nil
 }
 
-func (c *chunkedDiffer) ApplyDiff(dest string, options *archive.TarOptions) (graphdriver.DriverWithDifferOutput, error) {
+func (c *chunkedDiffer) ApplyDiff(dest string, options *archive.TarOptions, differOpts *graphdriver.DifferOptions) (graphdriver.DriverWithDifferOutput, error) {
 	defer c.layersCache.release()
 	defer func() {
 		if c.zstdReader != nil {

--- a/pkg/chunked/storage_linux.go
+++ b/pkg/chunked/storage_linux.go
@@ -844,7 +844,14 @@ func openDestinationFile(dirfd int, metadata *internal.FileMetadata, options *ar
 	}, nil
 }
 
-func (d *destinationFile) Close() error {
+func (d *destinationFile) Close() (Err error) {
+	defer func() {
+		err := d.file.Close()
+		if Err == nil {
+			Err = err
+		}
+	}()
+
 	manifestChecksum, err := digest.Parse(d.metadata.Digest)
 	if err != nil {
 		return err


### PR DESCRIPTION
ComposeFS has been integrated into the overlay driver.  The EROFS filesystem is now used to mount the file system metadata.  Each layer is mounted individually, but we can change this later and merge multiple layers into a single file system.

Filesystem-level integrity verification is now enabled through the implementation of fs-verity. This enhancement ensures the integrity of both the composefs blob and data files, providing an additional layer of security. Note that this implementation is currently considered a best-effort attempt since there is no control yet on how to configure it as well as there is no support from the overlay driver in the kernel (it is being worked on upstream).

It requires the `composefs-from-json` tool installed and accessible in the path from the https://github.com/containers/composefs project.