### PR TITLE
pkg/regexp: make sure that &Regexp implements the interfaces

### DIFF
--- a/pkg/regexp/regexp.go
+++ b/pkg/regexp/regexp.go
@@ -10,7 +10,9 @@ import (
 // used as global variables. Using this structure helps speed the startup time
 // of apps that want to use global regex variables. This library initializes them on
 // first use as opposed to the start of the executable.
-type Regexp = *regexpStruct
+type Regexp struct {
+	*regexpStruct
+}
 
 type regexpStruct struct {
 	_      noCopy
@@ -26,7 +28,7 @@ func Delayed(val string) Regexp {
 	if precompile {
 		re.regexp = regexp.MustCompile(re.val)
 	}
-	return re
+	return Regexp{re}
 }
 
 func (re *regexpStruct) compile() {

--- a/pkg/regexp/regexp_test.go
+++ b/pkg/regexp/regexp_test.go
@@ -4,6 +4,14 @@ import (
 	"testing"
 )
 
+type partOfRegexp interface {
+	FindStringSubmatch(s string) []string
+	MatchString(s string) bool
+	NumSubexp() int
+}
+
+var _ partOfRegexp = &Regexp{}
+
 func TestMatchString(t *testing.T) {
 	r := Delayed(`[0-9]+`)
 


### PR DESCRIPTION
Making our exported Regexp type a pointer breaks code that expects to be able to take its address and call methods on the result.
Should fix vendor test error at https://cirrus-ci.com/task/6751444020232192?logs=main#L222.