### PR TITLE
[RFC] overlay: make sure directories omitted from layers have the right permissions

### DIFF
--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -188,6 +188,7 @@ type DriverWithDifferOutput struct {
 	Metadata           string
 	BigData            map[string][]byte
 	TarSplit           []byte
+	ImplicitDirs       []string
 	TOCDigest          digest.Digest
 }
 

--- a/drivers/unionbackfill/backfill.go
+++ b/drivers/unionbackfill/backfill.go
@@ -1,0 +1,106 @@
+package unionbackfill
+
+import (
+	"archive/tar"
+	"io/fs"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+
+	"github.com/containers/storage/pkg/archive"
+	"github.com/containers/storage/pkg/idtools"
+	"github.com/containers/storage/pkg/system"
+)
+
+// NewBackfiller supplies a backfiller whose Backfill method provides the
+// ownership/permissions/attributes of a directory from a lower layer so that
+// we don't have to create it in an upper layer using default values that will
+// be mistaken for a reason that the directory was pulled up to that layer.
+func NewBackfiller(idmap *idtools.IDMappings, lowerDiffDirs []string) *backfiller {
+	if idmap != nil {
+		uidMaps, gidMaps := idmap.UIDs(), idmap.GIDs()
+		if len(uidMaps) > 0 || len(gidMaps) > 0 {
+			idmap = idtools.NewIDMappingsFromMaps(append([]idtools.IDMap{}, uidMaps...), append([]idtools.IDMap{}, gidMaps...))
+		}
+	}
+	return &backfiller{idmap: idmap, lowerDiffDirs: append([]string{}, lowerDiffDirs...)}
+}
+
+type backfiller struct {
+	idmap         *idtools.IDMappings
+	lowerDiffDirs []string
+}
+
+// Backfill supplies the ownership/permissions/attributes of a directory from a
+// lower layer so that we don't have to create it in an upper layer using
+// default values that will be mistaken for a reason that the directory was
+// pulled up to that layer.
+func (b *backfiller) Backfill(pathname string) (*tar.Header, error) {
+	for _, lowerDiffDir := range b.lowerDiffDirs {
+		candidate := filepath.Join(lowerDiffDir, pathname)
+		// if the asked-for path is in this lower, return a tar header for it
+		if st, err := os.Lstat(candidate); err == nil {
+			var linkTarget string
+			if st.Mode()&fs.ModeType == fs.ModeSymlink {
+				target, err := os.Readlink(candidate)
+				if err != nil {
+					return nil, err
+				}
+				linkTarget = target
+			}
+			hdr, err := tar.FileInfoHeader(st, linkTarget)
+			if err != nil {
+				return nil, err
+			}
+			// this is where we'd delete "opaque" from the header, if FileInfoHeader read xattrs
+			hdr.Name = strings.Trim(filepath.ToSlash(pathname), "/")
+			if st.Mode()&fs.ModeType == fs.ModeDir {
+				hdr.Name += "/"
+			}
+			if b.idmap != nil && !b.idmap.Empty() {
+				if uid, gid, err := b.idmap.ToContainer(idtools.IDPair{UID: hdr.Uid, GID: hdr.Gid}); err == nil {
+					hdr.Uid, hdr.Gid = uid, gid
+				}
+			}
+			return hdr, nil
+		}
+		// if the directory or any of its parents is marked opaque, we're done looking at lowers
+		p := strings.Trim(pathname, "/")
+		subpathname := ""
+		for {
+			dir, subdir := filepath.Split(p)
+			dir = strings.Trim(dir, "/")
+			if dir == p {
+				break
+			}
+			// kernel overlay style
+			xval, err := system.Lgetxattr(filepath.Join(lowerDiffDir, dir), archive.GetOverlayXattrName("opaque"))
+			if err == nil && len(xval) == 1 && xval[0] == 'y' {
+				return nil, nil
+			}
+			// aufs or fuse-overlayfs using aufs-like whiteouts
+			if _, err := os.Stat(filepath.Join(lowerDiffDir, dir, archive.WhiteoutOpaqueDir)); err == nil {
+				return nil, nil
+			}
+			// kernel overlay "redirect" - starting with the next lower layer, we'll need to look elsewhere
+			subpathname = strings.Trim(path.Join(subdir, subpathname), "/")
+			xval, err = system.Lgetxattr(filepath.Join(lowerDiffDir, dir), archive.GetOverlayXattrName("redirect"))
+			if err == nil && len(xval) > 0 {
+				subdir := string(xval)
+				if path.IsAbs(subdir) {
+					// path is relative to the root of the mount point
+					pathname = path.Join(subdir, subpathname)
+				} else {
+					// path is relative to the current directory
+					parent, _ := filepath.Split(dir)
+					parent = strings.Trim(parent, "/")
+					pathname = path.Join(parent, subdir, subpathname)
+				}
+				break
+			}
+			p = dir
+		}
+	}
+	return nil, nil
+}

--- a/drivers/unionbackfill/backfill_test.go
+++ b/drivers/unionbackfill/backfill_test.go
@@ -1,0 +1,270 @@
+package unionbackfill
+
+import (
+	"archive/tar"
+	"errors"
+	"fmt"
+	"io/fs"
+	"io/ioutil"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"testing"
+	"time"
+
+	"github.com/containers/storage/pkg/archive"
+	"github.com/containers/storage/pkg/system"
+	"github.com/containers/storage/pkg/tarbackfill"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBackfiller(t *testing.T) {
+	tmp := t.TempDir()
+	subdirs := make([]string, 0, 10)
+	lower := filepath.Join(tmp, "lower")
+	require.NoError(t, os.Mkdir(lower, 0o755))
+	for i := 0; i < cap(subdirs); i++ {
+		subdir := filepath.Join(lower, fmt.Sprintf("%d", i))
+		require.NoError(t, os.Mkdir(subdir, 0o755))
+		subdirs = append(subdirs, subdir)
+	}
+	epoch := time.Time{}.UTC()
+	early := time.Unix(1000000000, 234567).UTC()
+	// mark some parts of lowers as opaque (i.e., stop here when looking for content)
+	for _, opaqueDir := range []string{
+		"4/a/b/c/d",
+		"5/a/b/c",
+		"6/a/b",
+		"7/a",
+		"8",
+		".",
+	} {
+		// create the opaque marker in the specified directory
+		parent := filepath.Join(lower, opaqueDir)
+		err := os.MkdirAll(parent, 0o755)
+		require.NoError(t, err)
+		f, err := os.Create(filepath.Join(parent, archive.WhiteoutOpaqueDir))
+		require.NoError(t, err)
+		f.Close()
+		// create a piece of content that we should see in the opaque directory
+		f, err = os.Create(filepath.Join(parent, "in-opaque"))
+		require.NoError(t, err)
+		f.Close()
+		os.Chtimes(filepath.Join(parent, "in-opaque"), epoch, epoch)
+	}
+	// some content that should be hidden because it's below an opaque, higher directory
+	for _, hiddenItemDir := range []string{
+		"5/a/b/c/d",
+		"6/a/b/c",
+		"7/a/b",
+		"8/a",
+		"9",
+	} {
+		parent := filepath.Join(lower, hiddenItemDir)
+		err := os.MkdirAll(parent, 0o755)
+		require.NoError(t, err)
+		f, err := os.Create(filepath.Join(parent, "hidden"))
+		require.NoError(t, err)
+		f.Close()
+	}
+	// some content that we expect to be able to find
+	for _, visibleItemDir := range []string{
+		"2/a/b/c/d/e",
+		"3/a/b/c/d",
+		"4/a/b/c",
+		"5/a/b",
+		"6/a",
+	} {
+		parent := filepath.Join(lower, visibleItemDir)
+		err := os.MkdirAll(parent, 0o755)
+		require.NoError(t, err)
+		f, err := os.Create(filepath.Join(parent, "visible"))
+		require.NoError(t, err)
+		require.NoError(t, f.Chmod(0o640))
+		f.Close()
+		require.NoError(t, os.Chtimes(filepath.Join(parent, "visible"), early, early))
+	}
+	var backfiller tarbackfill.Backfiller = NewBackfiller(nil, subdirs)
+	testCases := []struct {
+		requested, actual string
+	}{
+		{"a/b/c/d/hidden", ""},
+		{"a/b/c/hidden", ""},
+		{"a/b/hidden", ""},
+		{"a/hidden", ""},
+		{"hidden", ""},
+		{"a/b/c/d/in-opaque", "4/a/b/c/d/in-opaque"},
+		{"a/b/c/in-opaque", "5/a/b/c/in-opaque"},
+		{"a/b/in-opaque", "6/a/b/in-opaque"},
+		{"a/in-opaque", "7/a/in-opaque"},
+		{"in-opaque", "8/in-opaque"},
+		{"a/b/c/d/e/visible", "2/a/b/c/d/e/visible"},
+		{"a/b/c/d/visible", "3/a/b/c/d/visible"},
+		{"a/b/c/visible", "4/a/b/c/visible"},
+		{"a/b/visible", "5/a/b/visible"},
+		{"a/visible", "6/a/visible"},
+	}
+	for testCase := range testCases {
+		t.Run(testCases[testCase].requested, func(t *testing.T) {
+			hdr, err := backfiller.Backfill(testCases[testCase].requested)
+			require.NoError(t, err)
+			if testCases[testCase].actual == "" {
+				require.Nilf(t, hdr, "expected to not find content for path %q", testCases[testCase].requested)
+			} else {
+				require.NotNilf(t, hdr, "expected to find content for path %q", testCases[testCase].requested)
+				info, err := os.Lstat(filepath.Join(lower, testCases[testCase].actual))
+				require.NoErrorf(t, err, "internal error looking for %q", testCases[testCase].actual)
+				expectedHdr, err := tar.FileInfoHeader(info, "")
+				require.NoErrorf(t, err, "internal error converting info about %q to a header", testCases[testCase].actual)
+				require.NotNilf(t, expectedHdr, "internal error converting info about %q to a header", testCases[testCase].actual)
+				expectedHdr.Name = testCases[testCase].requested
+				require.Equalf(t, *expectedHdr, *hdr, "unexpected header values for %q", testCases[testCase].actual)
+			}
+		})
+	}
+}
+
+func TestRedirectBackfiller(t *testing.T) {
+	tmp := t.TempDir()
+	mergedDir := filepath.Join(tmp, "merged")
+	require.NoError(t, os.Mkdir(mergedDir, 0o755))
+	workDir := filepath.Join(tmp, "work")
+	require.NoError(t, os.Mkdir(workDir, 0o755))
+
+	directoryMode := 0o710
+	directoryUid := 7
+	directoryGid := 8
+	now := time.Unix(time.Now().Unix(), 0)
+	defaultMode := 0o755
+
+	// create a directory we'll move around and put a directory under it and content in _that_
+	layerDir := filepath.Join(tmp, "layer0")
+	layerDirs := []string{layerDir}
+	targetDir := filepath.Join(layerDirs[0], "a", "b", "c", "d", "e", "f", "g", "h", "template")
+	require.NoError(t, os.MkdirAll(targetDir, fs.FileMode(defaultMode)))
+	require.NoError(t, ioutil.WriteFile(filepath.Join(targetDir, "file"), []byte("some content"), 0o644))
+	require.NoError(t, os.Chown(targetDir, directoryUid, directoryGid))
+	require.NoError(t, os.Chmod(targetDir, fs.FileMode(directoryMode)))
+	require.NoError(t, os.Chtimes(targetDir, now, now))
+
+	// construct the location of the parent directory that we'll move once the overlay fs is mounted
+	targetDir = strings.ReplaceAll(filepath.Dir(targetDir), layerDir, mergedDir)
+
+	mount := func() error {
+		redirectArg := "redirect_dir=on"
+		workdirArg := fmt.Sprintf("workdir=%s", workDir)
+		upperArg := fmt.Sprintf("upperdir=%s", layerDirs[0])
+		var lowers []string
+		for i := 1; i < len(layerDirs); i++ {
+			lowers = append(lowers, layerDirs[i])
+		}
+		lowersArg := fmt.Sprintf("lowerdir=%s", strings.Join(lowers, ":"))
+		mountOptArgs := []string{redirectArg, workdirArg, lowersArg, upperArg}
+		mountOpts := strings.Join(mountOptArgs, ",")
+		return syscall.Mount("none", mergedDir, "overlay", 0, mountOpts)
+	}
+	unmount := func() error {
+		return syscall.Unmount(mergedDir, 0)
+	}
+	defer unmount()
+
+	// mount, then rename the mobile directory through the overlay mount
+	layerDir = filepath.Join(tmp, "layer1")
+	layerDirs = append([]string{layerDir}, layerDirs...)
+	require.NoError(t, os.Mkdir(layerDir, fs.FileMode(defaultMode)))
+	require.NoError(t, mount())
+	newTargetDir := filepath.Join(mergedDir, "a", "b", "c", "d", "e", "f", "g", "h-new")
+	err := os.Rename(targetDir, newTargetDir)
+	if err != nil && (errors.Is(err, syscall.EXDEV) || errors.Is(err, syscall.EINVAL)) {
+		t.Skipf("unexpected error %v during rename - unable to test with redirect_dir=on", err)
+	}
+	require.NoError(t, err)
+	targetDir = newTargetDir
+	require.NoError(t, unmount())
+
+	// check that the kernel attached a "redirect" overlay attribute to the
+	// directory in the upper layer
+	xval, err := system.Lgetxattr(strings.ReplaceAll(targetDir, mergedDir, layerDir), archive.GetOverlayXattrName("redirect"))
+	if err != nil || len(xval) == 0 {
+		t.Skipf("kernel did not set redirect attribute in upper directory, can't test this")
+	}
+
+	// add another layer in which we move it again
+	layerDir = filepath.Join(tmp, "layer2")
+	layerDirs = append([]string{layerDir}, layerDirs...)
+	require.NoError(t, os.Mkdir(layerDir, fs.FileMode(defaultMode)))
+	require.NoError(t, mount())
+	newTargetDir = filepath.Join(mergedDir, "look-in-a-subdirectory")
+	require.NoError(t, os.Rename(targetDir, newTargetDir))
+	targetDir = newTargetDir
+	require.NoError(t, unmount())
+
+	// add another layer in which we move it again
+	layerDir = filepath.Join(tmp, "layer3")
+	layerDirs = append([]string{layerDir}, layerDirs...)
+	require.NoError(t, os.Mkdir(layerDir, fs.FileMode(defaultMode)))
+	require.NoError(t, mount())
+	newTargetDir = filepath.Join(mergedDir, "a", "b", "c", "d", "look-in-a-parent-sibling-directory")
+	require.NoError(t, os.Rename(targetDir, newTargetDir))
+	targetDir = newTargetDir
+	require.NoError(t, unmount())
+
+	// add another layer in which we move it again
+	layerDir = filepath.Join(tmp, "layer4")
+	layerDirs = append([]string{layerDir}, layerDirs...)
+	require.NoError(t, os.Mkdir(layerDir, fs.FileMode(defaultMode)))
+	require.NoError(t, mount())
+	newTargetDir = filepath.Join(mergedDir, "a", "b", "c", "d", "look-in-a-sibling-directory")
+	require.NoError(t, os.Rename(targetDir, newTargetDir))
+	targetDir = newTargetDir
+	require.NoError(t, unmount())
+
+	// add another layer in which we move it again
+	layerDir = filepath.Join(tmp, "layer5")
+	layerDirs = append([]string{layerDir}, layerDirs...)
+	require.NoError(t, os.Mkdir(layerDir, fs.FileMode(defaultMode)))
+	require.NoError(t, mount())
+	require.NoError(t, os.Mkdir(filepath.Join(mergedDir, "a", "b", "c", "d", "e", "f", "g", "h"), 0o755))
+	newTargetDir = filepath.Join(mergedDir, "a", "b", "c", "d", "e", "f", "g", "h", "template")
+	require.NoError(t, os.Rename(targetDir, newTargetDir))
+	// targetDir = newTargetDir
+	require.NoError(t, unmount())
+
+	// add another layer in which nothing happens
+	layerDir = filepath.Join(tmp, "layer6")
+	layerDirs = append([]string{layerDir}, layerDirs...)
+
+	// start looking around
+	backfiller := NewBackfiller(nil, layerDirs)
+	hdr, err := backfiller.Backfill(path.Join("/", "a", "b", "c"))
+	require.NoError(t, err)
+	require.NotNil(t, hdr)
+	require.Equal(t, path.Join("a", "b", "c")+"/", hdr.Name)
+	hdr, err = backfiller.Backfill(path.Join("a", "b", "c"))
+	require.NoError(t, err)
+	require.NotNil(t, hdr)
+	require.Equal(t, path.Join("a", "b", "c")+"/", hdr.Name)
+	hdr, err = backfiller.Backfill(path.Join("a", "b", "d"))
+	require.NoError(t, err)
+	require.Nil(t, hdr)
+	hdr, err = backfiller.Backfill(path.Join("a", "b", "c", "d", "e", "f", "g", "h", "template"))
+	require.NoError(t, err)
+	require.NotNil(t, hdr)
+	require.Equal(t, int64(defaultMode), int64(hdr.Mode))
+	require.Equal(t, 0, int(hdr.Uid))
+	require.Equal(t, 0, int(hdr.Gid))
+	hdr, err = backfiller.Backfill(path.Join("a", "b", "c", "d", "e", "f", "g", "h", "template", "template"))
+	require.NoError(t, err)
+	require.NotNil(t, hdr)
+	require.Equal(t, int64(directoryMode), int64(hdr.Mode))
+	require.Equal(t, directoryUid, int(hdr.Uid))
+	require.Equal(t, directoryGid, int(hdr.Gid))
+	hdr, err = backfiller.Backfill(path.Join("a", "b", "c", "d", "e", "f", "g", "h", "template", "template", "file"))
+	require.NoError(t, err)
+	require.NotNil(t, hdr)
+	require.Equal(t, int64(0o644), int64(hdr.Mode))
+	require.Equal(t, os.Getuid(), int(hdr.Uid))
+	require.Equal(t, os.Getgid(), int(hdr.Gid))
+}

--- a/pkg/chunked/internal/compression.go
+++ b/pkg/chunked/internal/compression.go
@@ -48,7 +48,7 @@ type FileMetadata struct {
 	ChunkDigest string `json:"chunkDigest,omitempty"`
 	ChunkType   string `json:"chunkType,omitempty"`
 
-	// internal: computed by mergeTOCEntries.
+	// internal: computed by mergeTocEntries.
 	Chunks []*FileMetadata `json:"-"`
 }
 

--- a/pkg/tarbackfill/tarbackfill.go
+++ b/pkg/tarbackfill/tarbackfill.go
@@ -1,0 +1,159 @@
+package tarbackfill
+
+import (
+	"archive/tar"
+	"io"
+	"path"
+	"strings"
+)
+
+// Reader wraps a tar.Reader so that if an item which would be read from it is
+// in a directory which is not included in the archive, a specified Backfiller
+// interface's Backfill() method will be called to supply a tar.Header which
+// will be inserted into the stream just ahead of that item.
+type Reader struct {
+	*tar.Reader
+	backfiller      Backfiller
+	seen            map[string]struct{}
+	queue           []*tar.Header
+	currentIsQueued bool
+	err             error
+}
+
+// Backfiller is a wrapper for Backfill, which can supply headers to insert
+// into an archive which is on its way to being extracted.
+type Backfiller interface {
+	// Backfill either returns an entry for the passed-in path, nil if
+	// no entry should be added to the stream, or an error if something
+	// unexpected happened.
+	Backfill(string) (*tar.Header, error)
+}
+
+// NewReaderWithBackfiller creates a new Reader reading from r, asking the
+// passed-in Backfiller for information about parent directories which it
+// hasn't seen yet.
+func NewReaderWithBackfiller(r *tar.Reader, backfiller Backfiller) *Reader {
+	reader := &Reader{
+		Reader:     r,
+		backfiller: backfiller,
+		seen:       make(map[string]struct{}),
+	}
+	return reader
+}
+
+// Next returns either the next item from the archive we're filtering, or a
+// synthesized entry for a directory that arguably should have been in that
+// archive.
+func (r *Reader) Next() (*tar.Header, error) {
+	// Drain the queue first.
+	if len(r.queue) > 0 {
+		next, queue := r.queue[0], r.queue[1:]
+		r.queue = queue
+		r.currentIsQueued = len(r.queue) > 0
+		return next, nil
+	}
+	// If we've hit the end of the archive, we've hit the end of the archive.
+	r.currentIsQueued = false
+	if r.err != nil {
+		return nil, r.err
+	}
+	// Check what's next in the archive.
+	hdr, err := r.Reader.Next()
+	if err != nil {
+		r.err = err
+	}
+	if hdr == nil {
+		return hdr, err
+	}
+	for {
+		// Trim off an initial or final path separator.
+		name := strings.Trim(hdr.Name, "/")
+		if hdr.Typeflag == tar.TypeDir {
+			// Trim off an initial or final path separator, and
+			// note that we won't need to supply it later.
+			r.seen[name] = struct{}{}
+		}
+		// Figure out which directory this item is directly in.
+		p := name
+		dir, _ := path.Split(name)
+		var newHdr *tar.Header
+		for dir != p {
+			var bfErr error
+			dir = strings.Trim(dir, "/")
+			// If we already saw that directory, no need to interfere (further).
+			if _, ok := r.seen[dir]; dir == "" || ok || dir == name {
+				return hdr, err
+			}
+			// Ask the backfiller what to do here.
+			newHdr, bfErr = r.backfiller.Backfill(dir)
+			if bfErr != nil {
+				r.err = bfErr
+				return nil, bfErr
+			}
+			if newHdr == nil {
+				dir, _ = path.Split(dir)
+				continue
+			}
+			// Make sure the Name looks right, then queue up the current entry.
+			newHdr.Format = tar.FormatPAX
+			newHdr.Name = strings.Trim(newHdr.Name, "/")
+			if newHdr.Typeflag == tar.TypeDir {
+				// We won't need to supply it later.
+				r.seen[newHdr.Name] = struct{}{}
+				newHdr.Name += "/"
+			}
+			r.queue = append([]*tar.Header{hdr}, r.queue...)
+			hdr = newHdr
+			r.currentIsQueued = true
+			dir, _ = path.Split(dir)
+		}
+	}
+}
+
+// Read will either read from a real entry in the archive, or pretend very hard
+// that an entry we inserted had no content.
+func (r *Reader) Read(b []byte) (int, error) {
+	if r.currentIsQueued {
+		return 0, nil
+	}
+	return r.Reader.Read(b)
+}
+
+// NewIOReaderWithBackfiller creates a new ReadCloser for reading from a
+// Reader, asking the passed-in Backfiller for parent directories of items in
+// the archive that aren't in the archive.
+func NewIOReaderWithBackfiller(reader io.Reader, backfiller Backfiller) io.ReadCloser {
+	rc, wc := io.Pipe()
+	go func() {
+		r := tar.NewReader(reader)
+		tr := NewReaderWithBackfiller(r, backfiller)
+		tw := tar.NewWriter(wc)
+		hdr, err := tr.Next()
+		defer func() {
+			closeErr := tw.Close()
+			io.Copy(wc, reader)
+			if err != nil {
+				wc.CloseWithError(err)
+			} else if closeErr != nil {
+				wc.CloseWithError(closeErr)
+			} else {
+				wc.Close()
+			}
+		}()
+		for hdr != nil {
+			if writeError := tw.WriteHeader(hdr); writeError != nil {
+				return
+			}
+			if err != nil {
+				break
+			}
+			if hdr.Size != 0 {
+				if _, err = io.Copy(tw, tr); err != nil {
+					return
+				}
+			}
+			hdr, err = tr.Next()
+		}
+	}()
+	return rc
+}

--- a/pkg/tarbackfill/tarbackfill_test.go
+++ b/pkg/tarbackfill/tarbackfill_test.go
@@ -1,0 +1,475 @@
+package tarbackfill
+
+import (
+	"archive/tar"
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"sort"
+	"testing"
+	"time"
+
+	"github.com/containers/storage/pkg/stringutils"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func makeTarByteSlice(headers []*tar.Header, trailerLength int) []byte {
+	var buf bytes.Buffer
+	block := make([]byte, 256)
+	for i := 0; i < 256; i++ {
+		block[i] = byte(i % 256)
+	}
+	tw := tar.NewWriter(&buf)
+	for i := range headers {
+		hdr := *headers[i]
+		hdr.Format = tar.FormatPAX
+		tw.WriteHeader(&hdr)
+		if hdr.Size > 0 {
+			written := int64(0)
+			for written < hdr.Size {
+				left := hdr.Size - written
+				if left > int64(len(block)) {
+					left = int64(len(block))
+				}
+				n, err := tw.Write(block[:int(left)])
+				if err != nil {
+					break
+				}
+				written += int64(n)
+			}
+		}
+		tw.Flush()
+	}
+	tw.Close()
+	padding := make([]byte, trailerLength) // some layer diffs have more trailing zeros than necessary, we need to preserve them
+	buf.Write(padding)
+	return buf.Bytes()
+}
+
+func consumeTar(t *testing.T, reader io.Reader, fn func(*tar.Header)) {
+	t.Helper()
+	t.Run("parse", func(t *testing.T) {
+		tr := tar.NewReader(reader)
+		hdr, err := tr.Next()
+		for hdr != nil {
+			if fn != nil {
+				fn(hdr)
+			}
+			if hdr.Size != 0 {
+				n, err := io.Copy(ioutil.Discard, tr)
+				require.NoErrorf(t, err, "unexpected error copying entry payload for %q", hdr.Name)
+				require.Equalf(t, hdr.Size, n, "payload for %q had unexpected length", hdr.Name)
+			}
+			if err != nil {
+				break
+			}
+			hdr, err = tr.Next()
+		}
+		require.ErrorIs(t, err, io.EOF, "hit an error that wasn't EOF")
+		_, err = io.Copy(io.Discard, reader)
+		require.NoError(t, err, "while draining possible trailer")
+	})
+}
+
+type backfillerLogger struct {
+	t        *testing.T
+	log      *[]string
+	backfill bool
+	mode     int64
+	uid, gid int
+	date     time.Time
+}
+
+func (b *backfillerLogger) Backfill(path string) (*tar.Header, error) {
+	if !stringutils.InSlice(*(b.log), path) {
+		*(b.log) = append(*(b.log), path)
+		sort.Strings(*(b.log))
+	}
+	if b.backfill {
+		return &tar.Header{Name: path, Typeflag: tar.TypeDir, Mode: b.mode, Uid: b.uid, Gid: b.gid, ModTime: b.date}, nil
+	}
+	return nil, nil
+}
+
+func newBackfillerLogger(t *testing.T, log *[]string, backfill bool, mode int64, uid, gid int, date time.Time) *backfillerLogger {
+	return &backfillerLogger{t: t, log: log, backfill: backfill, mode: mode, uid: uid, gid: gid, date: date}
+}
+
+func TestNewIOReaderWithBackfiller(t *testing.T) {
+	directoryMode := int64(0o750)
+	directoryUid := 5
+	directoryGid := 6
+	now := time.Now().UTC()
+	testCases := []struct {
+		description string
+		inputs      []*tar.Header
+		backfills   []string
+		outputs     []*tar.Header
+	}{
+		{
+			description: "empty",
+		},
+		{
+			description: "base",
+			inputs: []*tar.Header{
+				{
+					Name:     "a",
+					Typeflag: tar.TypeReg,
+					Mode:     0o644,
+					Uid:      1,
+					Gid:      1,
+					Size:     2,
+					ModTime:  now,
+				},
+			},
+			outputs: []*tar.Header{
+				{
+					Name:     "a",
+					Typeflag: tar.TypeReg,
+					Mode:     0o644,
+					Uid:      1,
+					Gid:      1,
+					Size:     2,
+					ModTime:  now,
+				},
+			},
+		},
+		{
+			description: "topdir",
+			inputs: []*tar.Header{
+				{
+					Name:     "a",
+					Typeflag: tar.TypeDir,
+					Mode:     0o750,
+					Uid:      1,
+					Gid:      1,
+					Size:     0,
+					ModTime:  now,
+				},
+			},
+			outputs: []*tar.Header{
+				{
+					Name:     "a",
+					Typeflag: tar.TypeDir,
+					Mode:     0o750,
+					Uid:      1,
+					Gid:      1,
+					Size:     0,
+					ModTime:  now,
+				},
+			},
+		},
+		{
+			description: "shallow",
+			inputs: []*tar.Header{
+				{
+					Name:     "a/b",
+					Typeflag: tar.TypeReg,
+					Mode:     0o644,
+					Uid:      1,
+					Gid:      2,
+					Size:     1234,
+					ModTime:  now,
+				},
+				{
+					Name:     "a/c",
+					Typeflag: tar.TypeReg,
+					Mode:     0o644,
+					Uid:      3,
+					Gid:      4,
+					Size:     1234,
+					ModTime:  now,
+				},
+				{
+					Name:     "a/d",
+					Typeflag: tar.TypeDir,
+					Mode:     0o700,
+					Uid:      5,
+					Gid:      6,
+					Size:     0,
+					ModTime:  now,
+				},
+			},
+			backfills: []string{
+				"a",
+			},
+			outputs: []*tar.Header{
+				{
+					Name:     "a/",
+					Typeflag: tar.TypeDir,
+					Mode:     directoryMode,
+					Uid:      directoryUid,
+					Gid:      directoryGid,
+					Size:     0,
+					ModTime:  now,
+				},
+				{
+					Name:     "a/b",
+					Typeflag: tar.TypeReg,
+					Mode:     0o644,
+					Uid:      1,
+					Gid:      2,
+					Size:     1234,
+					ModTime:  now,
+				},
+				{
+					Name:     "a/c",
+					Typeflag: tar.TypeReg,
+					Mode:     0o644,
+					Uid:      3,
+					Gid:      4,
+					Size:     1234,
+					ModTime:  now,
+				},
+				{
+					Name:     "a/d",
+					Typeflag: tar.TypeDir,
+					Mode:     0o700,
+					Uid:      5,
+					Gid:      6,
+					Size:     0,
+					ModTime:  now,
+				},
+			},
+		},
+		{
+			description: "deep",
+			inputs: []*tar.Header{
+				{
+					Name:     "a/c",
+					Typeflag: tar.TypeReg,
+					Mode:     0o644,
+					Uid:      3,
+					Gid:      4,
+					Size:     1234,
+					ModTime:  now,
+				},
+				{
+					Name:     "a/b/c/d/",
+					Typeflag: tar.TypeDir,
+					Mode:     0o700,
+					Uid:      1,
+					Gid:      2,
+					Size:     0,
+					ModTime:  now,
+				},
+				{
+					Name:     "a/b/c/d/e/f/g",
+					Typeflag: tar.TypeReg,
+					Mode:     0o644,
+					Uid:      3,
+					Gid:      4,
+					Size:     12346,
+					ModTime:  now,
+				},
+				{
+					Name:     "b/c/d/e/f/g/",
+					Typeflag: tar.TypeDir,
+					Mode:     0o711,
+					Uid:      5,
+					Gid:      6,
+					Size:     0,
+					ModTime:  now,
+				},
+			},
+			backfills: []string{
+				"a",
+				"a/b",
+				"a/b/c",
+				"a/b/c/d/e",
+				"a/b/c/d/e/f",
+				"b",
+				"b/c",
+				"b/c/d",
+				"b/c/d/e",
+				"b/c/d/e/f",
+			},
+			outputs: []*tar.Header{
+				{
+					Name:     "a/",
+					Typeflag: tar.TypeDir,
+					Mode:     directoryMode,
+					Uid:      directoryUid,
+					Gid:      directoryGid,
+					Size:     0,
+					ModTime:  now,
+				},
+				{
+					Name:     "a/c",
+					Typeflag: tar.TypeReg,
+					Mode:     0o644,
+					Uid:      1,
+					Gid:      2,
+					Size:     1234,
+					ModTime:  now,
+				},
+				{
+					Name:     "a/b/",
+					Typeflag: tar.TypeDir,
+					Mode:     directoryMode,
+					Uid:      directoryUid,
+					Gid:      directoryGid,
+					Size:     0,
+					ModTime:  now,
+				},
+				{
+					Name:     "a/b/c/",
+					Typeflag: tar.TypeDir,
+					Mode:     directoryMode,
+					Uid:      directoryUid,
+					Gid:      directoryGid,
+					Size:     0,
+					ModTime:  now,
+				},
+				{
+					Name:     "a/b/c/d/",
+					Typeflag: tar.TypeDir,
+					Mode:     0o700,
+					Uid:      1,
+					Gid:      2,
+					Size:     0,
+					ModTime:  now,
+				},
+				{
+					Name:     "a/b/c/d/e/",
+					Typeflag: tar.TypeDir,
+					Mode:     directoryMode,
+					Uid:      directoryUid,
+					Gid:      directoryGid,
+					Size:     0,
+					ModTime:  now,
+				},
+				{
+					Name:     "a/b/c/d/e/f/",
+					Typeflag: tar.TypeDir,
+					Mode:     directoryMode,
+					Uid:      directoryUid,
+					Gid:      directoryGid,
+					Size:     0,
+					ModTime:  now,
+				},
+				{
+					Name:     "a/b/c/d/e/f/g",
+					Typeflag: tar.TypeReg,
+					Mode:     0o644,
+					Uid:      3,
+					Gid:      4,
+					Size:     12346,
+					ModTime:  now,
+				},
+				{
+					Name:     "b/",
+					Typeflag: tar.TypeDir,
+					Mode:     directoryMode,
+					Uid:      directoryUid,
+					Gid:      directoryGid,
+					Size:     0,
+					ModTime:  now,
+				},
+				{
+					Name:     "b/c/",
+					Typeflag: tar.TypeDir,
+					Mode:     directoryMode,
+					Uid:      directoryUid,
+					Gid:      directoryGid,
+					Size:     0,
+					ModTime:  now,
+				},
+				{
+					Name:     "b/c/d/",
+					Typeflag: tar.TypeDir,
+					Mode:     directoryMode,
+					Uid:      directoryUid,
+					Gid:      directoryGid,
+					Size:     0,
+					ModTime:  now,
+				},
+				{
+					Name:     "b/c/d/e/",
+					Typeflag: tar.TypeDir,
+					Mode:     directoryMode,
+					Uid:      directoryUid,
+					Gid:      directoryGid,
+					Size:     0,
+					ModTime:  now,
+				},
+				{
+					Name:     "b/c/d/e/f/",
+					Typeflag: tar.TypeDir,
+					Mode:     directoryMode,
+					Uid:      directoryUid,
+					Gid:      directoryGid,
+					Size:     0,
+					ModTime:  now,
+				},
+				{
+					Name:     "b/c/d/e/f/g/",
+					Typeflag: tar.TypeDir,
+					Mode:     0o711,
+					Uid:      5,
+					Gid:      6,
+					Size:     0,
+					ModTime:  now,
+				},
+			},
+		},
+	}
+	for testCase := range testCases {
+		t.Run(testCases[testCase].description, func(t *testing.T) {
+			for _, paddingSize := range []int{0, 512, 1024, 2048, 4096, 8192} {
+				t.Run(fmt.Sprintf("paddingSize=%d", paddingSize), func(t *testing.T) {
+					tarBytes := makeTarByteSlice(testCases[testCase].inputs, paddingSize)
+
+					t.Run("basic", func(t *testing.T) {
+						tarBytesReader := bytes.NewReader(tarBytes)
+						consumeTar(t, tarBytesReader, nil)
+						assert.Zero(t, tarBytesReader.Len())
+					})
+
+					t.Run("logged", func(t *testing.T) {
+						var backfillLog []string
+						tarBytesReader := bytes.NewReader(tarBytes)
+						rc := NewIOReaderWithBackfiller(tarBytesReader, newBackfillerLogger(t, &backfillLog, false, 0o700, 1, 2, time.Time{}))
+						defer rc.Close()
+						consumeTar(t, rc, nil)
+						require.Equal(t, testCases[testCase].backfills, backfillLog, "backfill not called exactly the right number of times")
+						assert.Zero(t, tarBytesReader.Len())
+					})
+
+					t.Run("broken", func(t *testing.T) {
+						var backfillLog []string
+						tarBytesReader := bytes.NewReader(tarBytes)
+						rc := NewIOReaderWithBackfiller(tarBytesReader, newBackfillerLogger(t, &backfillLog, false, directoryMode, directoryUid, directoryGid, now))
+						defer rc.Close()
+						consumeTar(t, rc, nil)
+						assert.Zero(t, tarBytesReader.Len())
+					})
+
+					t.Run("filled", func(t *testing.T) {
+						var backfillLog []string
+						tarBytesReader := bytes.NewReader(tarBytes)
+						rc := NewIOReaderWithBackfiller(tarBytesReader, newBackfillerLogger(t, &backfillLog, true, directoryMode, directoryUid, directoryGid, now))
+						defer rc.Close()
+						outputs := make([]*tar.Header, 0, len(testCases[testCase].inputs)+len(testCases[testCase].backfills))
+						consumeTar(t, rc, func(hdr *tar.Header) { tmp := *hdr; hdr = &tmp; outputs = append(outputs, hdr) })
+						require.Equal(t, len(testCases[testCase].outputs), len(outputs), "wrong number of output entries")
+						assert.Zero(t, tarBytesReader.Len())
+						if len(outputs) != 0 {
+							for i := range outputs {
+								expected := testCases[testCase].outputs[i]
+								actual := outputs[i]
+								require.EqualValuesf(t, expected.Name, actual.Name, "output %d name", i)
+								require.EqualValuesf(t, expected.Mode, actual.Mode, "output %d mode", i)
+								require.EqualValuesf(t, expected.Typeflag, actual.Typeflag, "output %d type", i)
+								require.Truef(t, actual.ModTime.UTC().Equal(expected.ModTime.UTC()), "output %d (%q) date differs (%v != %v)", i, actual.Name, actual.ModTime.UTC(), expected.ModTime.UTC())
+							}
+						}
+						require.Equal(t, testCases[testCase].backfills, backfillLog, "backfill not called exactly the right number of times")
+					})
+				})
+			}
+		})
+	}
+}

--- a/tests/apply-diff.bats
+++ b/tests/apply-diff.bats
@@ -44,3 +44,71 @@ load helpers
 	checkchanges
 	checkdiffs
 }
+
+@test "apply-implicitdir-diff" {
+	# We need "tar" to build layer diffs.
+	if test -z "$(which tar 2> /dev/null)" ; then
+		skip "need tar"
+	fi
+
+	# Create one layer diff, then another that includes added/modified
+	# items but _not_ the directories that contain them.
+	pushd $TESTDIR
+	mkdir subdirectory1
+	chmod 0700 subdirectory1
+	mkdir subdirectory2
+	chmod 0750 subdirectory2
+	tar cvf lower.tar subdirectory1 subdirectory2
+	touch subdirectory1/testfile1 subdirectory2/testfile2
+	tar cvf middle.tar subdirectory1/testfile1 subdirectory2/testfile2
+	popd
+
+	# Create layers and populate them using the diffs.
+	run storage --debug=false create-layer
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	lowerlayer="$output"
+	storage applydiff -f "$TESTDIR"/lower.tar "$lowerlayer"
+
+	run storage --debug=false create-layer "$lowerlayer"
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	middlelayer="$output"
+	storage applydiff -f "$TESTDIR"/middle.tar "$middlelayer"
+
+	run storage --debug=false create-layer "$middlelayer"
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	upperlayer="$output"
+
+	run storage --debug=false mount "$upperlayer"
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	mountpoint="$output"
+
+	run stat -c %a "$TESTDIR"/subdirectory1
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	expected="$output"
+	echo subdirectory1 should have mode $expected
+
+	run stat -c %a "$mountpoint"/subdirectory1
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	actual="$output"
+	echo subdirectory1 has mode $actual
+	[ "$actual" = "$expected" ]
+
+	run stat -c %a "$TESTDIR"/subdirectory2
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	expected="$output"
+	echo subdirectory2 should have mode $expected
+
+	run stat -c %a "$mountpoint"/subdirectory2
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	actual="$output"
+	echo subdirectory2 has mode $actual
+	[ "$actual" = "$expected" ]
+}


### PR DESCRIPTION
When extracting layer contents, if we find ourselves needing to implicitly create a directory (due to its not being included in the layer diff), try to give it the permissions, ownership, attributes, and datestamp of the corresponding directory from the layer which would be stacked below it.
    
When a layer omits any of the directories which contain items which that layer adds or modifies, this should prevent the default values that we would use from overriding those which correspond to the same directory
in a lower layer, which could later be mistaken as an indication that one or more of those was intentionally changed, forcing the directory to be pulled up.