### PR TITLE
pkg/archive: Ignore file mounts when checking for mount points

### DIFF
--- a/pkg/archive/changes_other.go
+++ b/pkg/archive/changes_other.go
@@ -92,7 +92,10 @@ func collectFileInfo(sourceDir string, idMappings *idtools.IDMappings) (*FileInf
 			return err
 		}
 
-		if s.Dev() != sourceStat.Dev() {
+		// Don't cross mount points. This ignores file mounts to avoid
+		// generating a diff which deletes all files following the
+		// mount.
+		if s.Dev() != sourceStat.Dev() && s.IsDir() {
 			return filepath.SkipDir
 		}
 

--- a/pkg/system/stat_unix.go
+++ b/pkg/system/stat_unix.go
@@ -7,6 +7,8 @@ import (
 	"os"
 	"strconv"
 	"syscall"
+
+	"golang.org/x/sys/unix"
 )
 
 // StatT type contains status of a file. It contains metadata
@@ -55,6 +57,10 @@ func (s StatT) Mtim() syscall.Timespec {
 // Dev returns a unique identifier for owning filesystem
 func (s StatT) Dev() uint64 {
 	return s.dev
+}
+
+func (s StatT) IsDir() bool {
+	return (s.mode & unix.S_IFDIR) != 0
 }
 
 // Stat takes a path to a file and returns

--- a/pkg/system/stat_windows.go
+++ b/pkg/system/stat_windows.go
@@ -48,6 +48,10 @@ func (s StatT) Dev() uint64 {
 	return 0
 }
 
+func (s StatT) IsDir() bool {
+	return s.Mode().IsDir()
+}
+
 // Stat takes a path to a file and returns
 // a system.StatT type pertaining to that file.
 //


### PR DESCRIPTION
If we return SkipDir for file mounts, this can generate a diff that deletes all files after the mount point.