### PR TITLE
chunked: move GetTOCDigest to a subpackage

### DIFF
--- a/pkg/chunked/storage_linux.go
+++ b/pkg/chunked/storage_linux.go
@@ -164,26 +164,6 @@ func copyFileContent(srcFd int, destFile string, dirfd int, mode os.FileMode, us
 	return dstFile, st.Size(), nil
 }
 
-// GetTOCDigest returns the digest of the TOC as recorded in the annotations.
-// This is an experimental feature and may be changed/removed in the future.
-func GetTOCDigest(annotations map[string]string) (*digest.Digest, error) {
-	if contentDigest, ok := annotations[estargz.TOCJSONDigestAnnotation]; ok {
-		d, err := digest.Parse(contentDigest)
-		if err != nil {
-			return nil, err
-		}
-		return &d, nil
-	}
-	if contentDigest, ok := annotations[internal.ManifestChecksumKey]; ok {
-		d, err := digest.Parse(contentDigest)
-		if err != nil {
-			return nil, err
-		}
-		return &d, nil
-	}
-	return nil, nil
-}
-
 type seekableFile struct {
 	file *os.File
 }

--- a/pkg/chunked/storage_unsupported.go
+++ b/pkg/chunked/storage_unsupported.go
@@ -16,9 +16,3 @@ import (
 func GetDiffer(ctx context.Context, store storage.Store, blobSize int64, annotations map[string]string, iss ImageSourceSeekable) (graphdriver.Differ, error) {
 	return nil, errors.New("format not supported on this system")
 }
-
-// GetTOCDigest returns the digest of the TOC as recorded in the annotations.
-// This is an experimental feature and may be changed/removed in the future.
-func GetTOCDigest(annotations map[string]string) (*digest.Digest, error) {
-	return nil, errors.New("format not supported on this system")
-}

--- a/pkg/chunked/toc/toc.go
+++ b/pkg/chunked/toc/toc.go
@@ -1,0 +1,34 @@
+package toc
+
+import (
+	"github.com/containers/storage/pkg/chunked/internal"
+	digest "github.com/opencontainers/go-digest"
+)
+
+// tocJSONDigestAnnotation is the annotation key for the digest of the estargz
+// TOC JSON.
+// It is defined in github.com/containerd/stargz-snapshotter/estargz as TOCJSONDigestAnnotation
+// Duplicate it here to avoid a dependency on the package.
+const tocJSONDigestAnnotation = "containerd.io/snapshot/stargz/toc.digest"
+
+// GetTOCDigest returns the digest of the TOC as recorded in the annotations.
+// This function retrieves a digest that represents the content of a
+// table of contents (TOC) from the image's annotations.
+// This is an experimental feature and may be changed/removed in the future.
+func GetTOCDigest(annotations map[string]string) (*digest.Digest, error) {
+	if contentDigest, ok := annotations[tocJSONDigestAnnotation]; ok {
+		d, err := digest.Parse(contentDigest)
+		if err != nil {
+			return nil, err
+		}
+		return &d, nil
+	}
+	if contentDigest, ok := annotations[internal.ManifestChecksumKey]; ok {
+		d, err := digest.Parse(contentDigest)
+		if err != nil {
+			return nil, err
+		}
+		return &d, nil
+	}
+	return nil, nil
+}

--- a/pkg/chunked/toc/toc_test.go
+++ b/pkg/chunked/toc/toc_test.go
@@ -1,0 +1,47 @@
+package toc
+
+import (
+	"testing"
+)
+
+func TestGetTOCDigest(t *testing.T) {
+	t.Run("ValidTOCDigestAnnotation", func(t *testing.T) {
+		expectedDigest := "sha256:8bc94b65d0b3ae8998cc0405a424ee7c3a04c72996f99eda9670374832dc9667"
+		annotations := map[string]string{
+			tocJSONDigestAnnotation: expectedDigest,
+		}
+
+		digestPtr, err := GetTOCDigest(annotations)
+		if err != nil {
+			t.Error(err)
+		}
+		if digestPtr == nil {
+			t.Errorf("Expected a non-nil digest pointer")
+		} else if digestPtr.String() != expectedDigest {
+			t.Errorf("Expected digest %s, but got %s", expectedDigest, digestPtr.String())
+		}
+	})
+
+	t.Run("InvalidTOCDigestAnnotation", func(t *testing.T) {
+		annotations := map[string]string{
+			tocJSONDigestAnnotation: "invalid-checksum",
+		}
+
+		_, err := GetTOCDigest(annotations)
+		if err == nil {
+			t.Fatal("Expected error")
+		}
+	})
+
+	t.Run("NoValidAnnotations", func(t *testing.T) {
+		annotations := map[string]string{}
+
+		digestPtr, err := GetTOCDigest(annotations)
+		if err != nil {
+			t.Error(err)
+		}
+		if digestPtr != nil {
+			t.Errorf("Expected nil digest pointer, but got %s", digestPtr.String())
+		}
+	})
+}


### PR DESCRIPTION
The purpose of this move is to reduce dependencies for the new package.