### PR TITLE
btrfs: remove an unnecessary local variable

### DIFF
--- a/drivers/btrfs/btrfs.go
+++ b/drivers/btrfs/btrfs.go
@@ -675,8 +675,7 @@ func (d *Driver) Exists(id string) bool {
 
 // List all of the layers known to the driver.
 func (d *Driver) ListLayers() ([]string, error) {
-	subvolumesDir := filepath.Join(d.home, "subvolumes")
-	entries, err := os.ReadDir(subvolumesDir)
+	entries, err := os.ReadDir(d.subvolumesDir())
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
We don't need to construct a path ourselves when we already have a method that does it.