### PR TITLE
overlay: Diffsize: avoid naive diff

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -2162,10 +2162,6 @@ func (d *Driver) getLowerDiffPaths(id string) ([]string, error) {
 // and its parent and returns the size in bytes of the changes
 // relative to its base filesystem directory.
 func (d *Driver) DiffSize(id string, idMappings *idtools.IDMappings, parent string, parentMappings *idtools.IDMappings, mountLabel string) (size int64, err error) {
-	if d.options.mountProgram == "" && (d.useNaiveDiff() || !d.isParent(id, parent)) {
-		return d.naiveDiff.DiffSize(id, idMappings, parent, parentMappings, mountLabel)
-	}
-
 	p, err := d.getDiffPath(id)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
Computing the diff size for the rootful overlay storage driver used the naive diff.  The reasoning was that we have made use of rootful copy-up. The downside is a mind-blowing performance penalty in comparison to the rootless case.

Hence, drop the naive diff and only compute the size of the directory which is absolutely sufficient for the motivating use case of podman-system-df.  This drops the execution of system-df from 19.3s to 0.11s listing 5 containers and 1 image.

Fixes: github.com/containers/podman/issues/19467