### PR TITLE
overlay: Diffsize: naive diff when not parent

### DIFF
--- a/contrib/cirrus/build_and_test.sh
+++ b/contrib/cirrus/build_and_test.sh
@@ -71,7 +71,10 @@ case $TEST_DRIVER in
         zfs create $zpool/tmp
         TMPDIR="/$zpool/tmp" showrun make STORAGE_DRIVER=$TEST_DRIVER local-test-integration local-test-unit
         # Ensure no datasets are held open prior to `zfs destroy` trap.
-        kill $(lsns -J -t mnt --output-all | jq '.namespaces[]|select(.command=="sleep 1000s").pid')
+        datasets=$(lsns -J -t mnt --output-all | jq '.namespaces[]|select(.command=="sleep 1000s").pid')
+        if [[ -n "$datasets" ]]; then
+            kill $datasets
+        fi
         ;;
     *)
         die "Unknown/Unsupported \$TEST_DRIVER=$TEST_DRIVER (see .cirrus.yml and $(basename $0))"

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -2170,6 +2170,10 @@ func (d *Driver) getLowerDiffPaths(id string) ([]string, error) {
 // and its parent and returns the size in bytes of the changes
 // relative to its base filesystem directory.
 func (d *Driver) DiffSize(id string, idMappings *idtools.IDMappings, parent string, parentMappings *idtools.IDMappings, mountLabel string) (size int64, err error) {
+	if !d.isParent(id, parent) {
+		return d.naiveDiff.DiffSize(id, idMappings, parent, parentMappings, mountLabel)
+	}
+
 	p, err := d.getDiffPath(id)
 	if err != nil {
 		return 0, err


### PR DESCRIPTION
If the specified parent is not ID's parent, use the naive diff.

@mtrmac @giuseppe PTAL