### PR TITLE
Add an OWNERS file for the merge bot to refer to

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,0 +1,32 @@
+approvers:
+  - Luap99
+  - TomSweeneyRedHat
+  - cevich
+  - edsantiago
+  - flouthoc
+  - giuseppe
+  - haircommander
+  - kolyshkin
+  - mrunalp
+  - mtrmac
+  - nalind
+  - rhatdan
+  - saschagrunert
+  - umohnani8
+  - vrothberg
+reviewers:
+  - Luap99
+  - TomSweeneyRedHat
+  - cevich
+  - edsantiago
+  - flouthoc
+  - giuseppe
+  - haircommander
+  - kolyshkin
+  - mrunalp
+  - mtrmac
+  - nalind
+  - rhatdan
+  - saschagrunert
+  - umohnani8
+  - vrothberg


### PR DESCRIPTION
The OpenShift CI and merge bots expect an OWNERS file to be present to tell them who's allowed to tell them to do what.  If you're reviewing this and I forgot you, comment.