### PR TITLE
overlay, composefs: mount loop device RO

### DIFF
--- a/drivers/overlay/composefs_supported.go
+++ b/drivers/overlay/composefs_supported.go
@@ -166,7 +166,7 @@ func hasACL(path string) (bool, error) {
 
 func mountComposefsBlob(dataDir, mountPoint string) error {
 	blobFile := getComposefsBlob(dataDir)
-	loop, err := loopback.AttachLoopDevice(blobFile)
+	loop, err := loopback.AttachLoopDeviceRO(blobFile)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
otherwise it fails when mounting a file that was protected with fs-verity.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
