### PR TITLE
overlay, composefs: use data-only lower layers

### DIFF
--- a/docs/containers-storage-applydiff-using-staging-dir.md
+++ b/docs/containers-storage-applydiff-using-staging-dir.md
@@ -1,0 +1,27 @@
+## containers-storage-applydiff-using-staging-dir 1 "September 2023"
+
+## NAME
+containers-storage applydiff-using-staging-dir - Apply a layer diff to a layer using a staging directory
+
+## SYNOPSIS
+**containers-storage** **applydiff-using-staging-dir** *layerNameOrID* *source*
+
+## DESCRIPTION
+When a layer is first created, it contains no changes relative to its parent
+layer.  The layer can either be mounted read-write and its contents modified
+directly, or contents can be added (or removed) by applying a layer diff.  A
+layer diff takes the form of a (possibly compressed) tar archive with
+additional information present in its headers, and can be produced by running
+*containers-storage diff* or an equivalent.
+
+Differently than **apply-diff**, the command **applydiff-using-staging-dir**
+first creates a staging directory and then moves the final result to the destination.
+
+## EXAMPLE
+**containers-storage applydiff-using-staging-dir 5891b5b522 /path/to/diff**
+
+## SEE ALSO
+containers-storage-apply-diff(1)
+containers-storage-changes(1)
+containers-storage-diff(1)
+containers-storage-diffsize(1)

--- a/docs/containers-storage.md
+++ b/docs/containers-storage.md
@@ -52,79 +52,81 @@ configuration will be stored as data items.
 
 ## SUB-COMMANDS
 The *containers-storage* command's features are broken down into several subcommands:
- **containers-storage add-names(1)**           Add layer, image, or container name or names
+ **containers-storage add-names(1)**                   Add layer, image, or container name or names
 
- **containers-storage applydiff(1)**           Apply a diff to a layer
+ **containers-storage applydiff(1)**                   Apply a diff to a layer
 
- **containers-storage changes(1)**             Compare two layers
+ **containers-storage applydiff-using-staging-dir(1)** Apply a diff to a layer staging the new content first.
 
- **containers-storage check(1)**               Check for and possibly remove damaged layers/images/containers
+ **containers-storage changes(1)**                     Compare two layers
 
- **containers-storage container(1)**           Examine a container
+ **containers-storage check(1)**                       Check for and possibly remove damaged layers/images/containers
 
- **containers-storage containers(1)**          List containers
+ **containers-storage container(1)**                   Examine a container
 
- **containers-storage create-container(1)**    Create a new container from an image
+ **containers-storage containers(1)**                  List containers
 
- **containers-storage create-image(1)**        Create a new image using layers
+ **containers-storage create-container(1)**            Create a new container from an image
 
- **containers-storage create-layer(1)**        Create a new layer
+ **containers-storage create-image(1)**                Create a new image using layers
 
- **containers-storage create-storage-layer(1)** Create a new layer in the lower-level storage driver
+ **containers-storage create-layer(1)**                Create a new layer
 
- **containers-storage delete(1)**              Delete a layer or image or container, with no safety checks
+ **containers-storage create-storage-layer(1)**        Create a new layer in the lower-level storage driver
 
- **containers-storage delete-container(1)**    Delete a container, with safety checks
+ **containers-storage delete(1)**                      Delete a layer or image or container, with no safety checks
 
- **containers-storage delete-image(1)**        Delete an image, with safety checks
+ **containers-storage delete-container(1)**            Delete a container, with safety checks
 
- **containers-storage delete-layer(1)**        Delete a layer, with safety checks
+ **containers-storage delete-image(1)**                Delete an image, with safety checks
 
- **containers-storage diff(1)**                Compare two layers
+ **containers-storage delete-layer(1)**                Delete a layer, with safety checks
 
- **containers-storage diffsize(1)**            Compare two layers
+ **containers-storage diff(1)**                        Compare two layers
 
- **containers-storage exists(1)**              Check if a layer or image or container exists
+ **containers-storage diffsize(1)**                    Compare two layers
 
- **containers-storage get-container-data(1)**  Get data that is attached to a container
+ **containers-storage exists(1)**                      Check if a layer or image or container exists
 
- **containers-storage get-image-data(1)**      Get data that is attached to an image
+ **containers-storage get-container-data(1)**          Get data that is attached to a container
 
- **containers-storage image(1)**               Examine an image
+ **containers-storage get-image-data(1)**              Get data that is attached to an image
 
- **containers-storage images(1)**              List images
+ **containers-storage image(1)**                       Examine an image
 
- **containers-storage layers(1)**              List layers
+ **containers-storage images(1)**                      List images
 
- **containers-storage list-container-data(1)** List data items that are attached to a container
+ **containers-storage layers(1)**                      List layers
 
- **containers-storage list-image-data(1)**     List data items that are attached to an image
+ **containers-storage list-container-data(1)**         List data items that are attached to a container
 
- **containers-storage metadata(1)**            Retrieve layer, image, or container metadata
+ **containers-storage list-image-data(1)**             List data items that are attached to an image
 
- **containers-storage mount(1)**               Mount a layer or container
+ **containers-storage metadata(1)**                    Retrieve layer, image, or container metadata
 
- **containers-storage mounted(1)**             Check if a file system is mounted
+ **containers-storage mount(1)**                       Mount a layer or container
 
- **containers-storage set-container-data(1)**  Set data that is attached to a container
+ **containers-storage mounted(1)**                     Check if a file system is mounted
 
- **containers-storage set-image-data(1)**      Set data that is attached to an image
+ **containers-storage set-container-data(1)**          Set data that is attached to a container
 
- **containers-storage set-metadata(1)**        Set layer, image, or container metadata
+ **containers-storage set-image-data(1)**              Set data that is attached to an image
 
- **containers-storage set-names(1)**           Set layer, image, or container name or names
+ **containers-storage set-metadata(1)**                Set layer, image, or container metadata
 
- **containers-storage shutdown(1)**            Shut down graph driver
+ **containers-storage set-names(1)**                   Set layer, image, or container name or names
 
- **containers-storage status(1)**              Check on graph driver status
+ **containers-storage shutdown(1)**                    Shut down graph driver
 
- **containers-storage unmount(1)**             Unmount a layer or container
+ **containers-storage status(1)**                      Check on graph driver status
 
- **containers-storage unshare(1)**             Run a command in a user namespace
+ **containers-storage unmount(1)**                     Unmount a layer or container
 
- **containers-storage version(1)**             Return containers-storage version information
+ **containers-storage unshare(1)**                     Run a command in a user namespace
 
- **containers-storage wipe(1)**                Wipe all layers, images, and containers
+ **containers-storage version(1)**                     Return containers-storage version information
+
+ **containers-storage wipe(1)**                        Wipe all layers, images, and containers
 
 ## OPTIONS
 **--help**

--- a/drivers/overlay/composefs_supported.go
+++ b/drivers/overlay/composefs_supported.go
@@ -93,7 +93,7 @@ func generateComposeFsBlob(toc []byte, composefsDir string) error {
 
 	fd, err := unix.Openat(unix.AT_FDCWD, destFile, unix.O_WRONLY|unix.O_CREAT|unix.O_TRUNC|unix.O_EXCL|unix.O_CLOEXEC, 0o644)
 	if err != nil {
-		return fmt.Errorf("failed to open output file: %w", err)
+		return fmt.Errorf("failed to open output file %q: %w", destFile, err)
 	}
 	outFd := os.NewFile(uintptr(fd), "outFd")
 

--- a/drivers/overlay/mount.go
+++ b/drivers/overlay/mount.go
@@ -141,14 +141,27 @@ func mountOverlayFromMain() {
 	// the new value for the list of lowers, because it's shorter.
 	if lowerv != "" {
 		lowers := strings.Split(lowerv, ":")
-		for i := range lowers {
-			lowerFd, err := unix.Open(lowers[i], unix.O_RDONLY, 0)
+		var newLowers []string
+		dataOnly := false
+		for _, lowerPath := range lowers {
+			if lowerPath == "" {
+				dataOnly = true
+				continue
+			}
+			lowerFd, err := unix.Open(lowerPath, unix.O_RDONLY, 0)
 			if err != nil {
 				fatal(err)
 			}
-			lowers[i] = fmt.Sprintf("%d", lowerFd)
+			var lower string
+			if dataOnly {
+				lower = fmt.Sprintf(":%d", lowerFd)
+				dataOnly = false
+			} else {
+				lower = fmt.Sprintf("%d", lowerFd)
+			}
+			newLowers = append(newLowers, lower)
 		}
-		lowerv = strings.Join(lowers, ":")
+		lowerv = strings.Join(newLowers, ":")
 	}
 
 	// Reconstruct the Label field.

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -1542,7 +1542,7 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 		}
 	}()
 
-	maybeAddComposefsMount := func(lowerID string, i int) (string, error) {
+	maybeAddComposefsMount := func(lowerID string, i int, readWrite bool) (string, error) {
 		composefsBlob := d.getComposefsData(lowerID)
 		_, err = os.Stat(composefsBlob)
 		if err != nil {
@@ -1552,6 +1552,10 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 			return "", err
 		}
 		logrus.Debugf("overlay: using composefs blob %s for lower %s", composefsBlob, lowerID)
+
+		if readWrite && i == 0 {
+			return "", fmt.Errorf("cannot mount a composefs layer as writeable")
+		}
 
 		dest := filepath.Join(composefsLayers, fmt.Sprintf("%d", i))
 		if err := os.MkdirAll(dest, 0o700); err != nil {
@@ -1573,7 +1577,7 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 
 	diffDir := path.Join(workDirBase, "diff")
 
-	if dest, err := maybeAddComposefsMount(id, 0); err != nil {
+	if dest, err := maybeAddComposefsMount(id, 0, readWrite); err != nil {
 		return "", err
 	} else if dest != "" {
 		diffDir = dest
@@ -1625,7 +1629,7 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 			return "", err
 		}
 		lowerID := filepath.Base(filepath.Dir(linkContent))
-		composefsMount, err := maybeAddComposefsMount(lowerID, i+1)
+		composefsMount, err := maybeAddComposefsMount(lowerID, i+1, readWrite)
 		if err != nil {
 			return "", err
 		}
@@ -1656,8 +1660,6 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 	if len(composeFsLayers) > 0 {
 		optsList = append(optsList, "metacopy=on", "redirect_dir=on")
 	}
-
-	absLowers = append(absLowers, composeFsLayers...)
 
 	if len(absLowers) == 0 {
 		absLowers = append(absLowers, path.Join(dir, "empty"))
@@ -1752,11 +1754,20 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 		absLowers = newAbsDir
 	}
 
+	lowerDirs := strings.Join(absLowers, ":")
+	if len(composeFsLayers) > 0 {
+		composeFsLayersLowerDirs := strings.Join(composeFsLayers, "::")
+		lowerDirs = lowerDirs + "::" + composeFsLayersLowerDirs
+	}
+	// absLowers is not valid anymore now as we have added composeFsLayers to it, so prevent
+	// its usage.
+	absLowers = nil //nolint:ineffassign
+
 	var opts string
 	if readWrite {
-		opts = fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", strings.Join(absLowers, ":"), diffDir, workdir)
+		opts = fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", lowerDirs, diffDir, workdir)
 	} else {
-		opts = fmt.Sprintf("lowerdir=%s:%s", diffDir, strings.Join(absLowers, ":"))
+		opts = fmt.Sprintf("lowerdir=%s:%s", diffDir, lowerDirs)
 	}
 	if len(optsList) > 0 {
 		opts = fmt.Sprintf("%s,%s", opts, strings.Join(optsList, ","))
@@ -1800,9 +1811,9 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 		if readWrite {
 			diffDir := path.Join(id, "diff")
 			workDir := path.Join(id, "work")
-			opts = fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", strings.Join(absLowers, ":"), diffDir, workDir)
+			opts = fmt.Sprintf("lowerdir=%s,upperdir=%s,workdir=%s", lowerDirs, diffDir, workDir)
 		} else {
-			opts = fmt.Sprintf("lowerdir=%s:%s", diffDir, strings.Join(absLowers, ":"))
+			opts = fmt.Sprintf("lowerdir=%s:%s", diffDir, lowerDirs)
 		}
 		if len(optsList) > 0 {
 			opts = strings.Join(append([]string{opts}, optsList...), ",")
@@ -2009,11 +2020,34 @@ func (d *Driver) CleanupStagingDirectory(stagingDirectory string) error {
 	return os.RemoveAll(stagingDirectory)
 }
 
+func (d *Driver) supportsDataOnlyLayers() (bool, error) {
+	feature := "dataonly-layers"
+	overlayCacheResult, overlayCacheText, err := cachedFeatureCheck(d.runhome, feature)
+	if err == nil {
+		if overlayCacheResult {
+			logrus.Debugf("Cached value indicated that data-only layers for overlay are supported")
+			return true, nil
+		}
+		logrus.Debugf("Cached value indicated that data-only layers for overlay are not supported")
+		return false, errors.New(overlayCacheText)
+	}
+	supportsDataOnly, err := supportsDataOnlyLayers(d.home)
+	if err2 := cachedFeatureRecord(d.runhome, feature, supportsDataOnly, ""); err2 != nil {
+		return false, fmt.Errorf("recording overlay data-only layers support status: %w", err2)
+	}
+	return supportsDataOnly, err
+}
+
 func (d *Driver) useComposeFs() bool {
 	if !composeFsSupported() || unshare.IsRootless() {
 		return false
 	}
-	return true
+	supportsDataOnlyLayers, err := d.supportsDataOnlyLayers()
+	if err != nil {
+		logrus.Debugf("Check for data-only layers failed with: %v", err)
+		return false
+	}
+	return supportsDataOnlyLayers
 }
 
 // ApplyDiff applies the changes in the new layer using the specified function

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -1447,7 +1447,9 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 	needsIDMapping := !disableShifting && len(options.UidMaps) > 0 && len(options.GidMaps) > 0 && d.options.mountProgram == ""
 
 	if len(optsList) == 0 {
-		optsList = strings.Split(d.options.mountOptions, ",")
+		if d.options.mountOptions != "" {
+			optsList = strings.Split(d.options.mountOptions, ",")
+		}
 	} else {
 		// If metacopy=on is present in d.options.mountOptions it must be present in the mount
 		// options otherwise the kernel refuses to follow the metacopy xattr.

--- a/tests/apply-diff.bats
+++ b/tests/apply-diff.bats
@@ -44,3 +44,60 @@ load helpers
 	checkchanges
 	checkdiffs
 }
+
+@test "apply-diff-from-staging-directory" {
+	case "$STORAGE_DRIVER" in
+	overlay*)
+		;;
+	*)
+		skip "driver $STORAGE_DRIVER does not support diff-from-staging-directory"
+		;;
+	esac
+
+	SRC=$TESTDIR/source
+	mkdir -p $SRC
+	createrandom $SRC/file1
+	createrandom $SRC/file2
+	createrandom $SRC/file3
+
+	local sconf=$TESTDIR/storage.conf
+
+	local root=`storage status 2>&1 | awk '/^Root:/{print $2}'`
+	local runroot=`storage status 2>&1 | awk '/^Run Root:/{print $3}'`
+
+	cat >$sconf <<EOF
+[storage]
+driver="overlay"
+graphroot="$root"
+runroot="$runroot"
+
+[storage.options]
+pull_options = {enable_partial_images = "true" }
+EOF
+
+	# Create a layer.
+	CONTAINERS_STORAGE_CONF=$sconf run storage --debug=false create-layer
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	layer="$output"
+
+	CONTAINERS_STORAGE_CONF=$sconf run storage --debug=false applydiff-using-staging-dir $layer $SRC
+	[ "$status" -eq 0 ]
+
+	name=safe-image
+	CONTAINERS_STORAGE_CONF=$sconf run storage --debug=false create-image --name $name $layer
+	[ "$status" -eq 0 ]
+
+	ctrname=foo
+	CONTAINERS_STORAGE_CONF=$sconf run storage --debug=false create-container --name $ctrname $name
+        [ "$status" -eq 0 ]
+
+	CONTAINERS_STORAGE_CONF=$sconf run storage --debug=false mount $ctrname
+	[ "$status" -eq 0 ]
+	mount="$output"
+
+	for i in file1 file2 file3 ; do
+		run cmp $SRC/$i $mount/$i
+		[ "$status" -eq 0 ]
+	done
+}


### PR DESCRIPTION
use the new overlay data-only feature to mount the composefs data directory so there is no need for upper layers to create whiteouts to hide payload files.

The feature was added to Linux 6.5.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
