### PR TITLE
store: serialize container deletion

### DIFF
--- a/store.go
+++ b/store.go
@@ -2666,7 +2666,6 @@ func (s *store) DeleteContainer(id string) error {
 		}
 
 		var wg multierror.Group
-		wg.Go(func() error { return s.containerStore.Delete(id) })
 
 		middleDir := s.graphDriverName + "-containers"
 
@@ -2683,7 +2682,7 @@ func (s *store) DeleteContainer(id string) error {
 		if multierr := wg.Wait(); multierr != nil {
 			return multierr.ErrorOrNil()
 		}
-		return nil
+		return s.containerStore.Delete(id)
 	})
 }
 

--- a/store.go
+++ b/store.go
@@ -2672,21 +2672,11 @@ func (s *store) DeleteContainer(id string) error {
 
 		wg.Go(func() error {
 			gcpath := filepath.Join(s.GraphRoot(), middleDir, container.ID)
-			// attempt a simple rm -rf first
-			if err := os.RemoveAll(gcpath); err == nil {
-				return nil
-			}
-			// and if it fails get to the more complicated cleanup
 			return system.EnsureRemoveAll(gcpath)
 		})
 
 		wg.Go(func() error {
 			rcpath := filepath.Join(s.RunRoot(), middleDir, container.ID)
-			// attempt a simple rm -rf first
-			if err := os.RemoveAll(rcpath); err == nil {
-				return nil
-			}
-			// and if it fails get to the more complicated cleanup
 			return system.EnsureRemoveAll(rcpath)
 		})
 


### PR DESCRIPTION
serialize the call to containersStore.Delete(id) since it attempts to recursively remove the graphroot directory.

Doing so, it makes ineffective the other goroutine that attempts to remove safely the graphroot with EnsureRemoveAll.  Depending on what goroutine is faster, there can be a flake like:

2023-09-26T17:49:02.6708666Z   stderr: Error: cleaning up storage: removing container 6ebff2c6c6f5fe78c158956a88467ef7af6f6a7c3d40334d248c7b7409341230 root filesystem: 1 error occurred: * unlinkat /var/tmp/podman_test3482607530/root/overlay-containers/6ebff2c6c6f5fe78c158956a88467ef7af6f6a7c3d40334d248c7b7409341230/userdata/shm: device or resource busy

it is a difficult to trigger condition, but I am hitting it constantly in: https://github.com/containers/crun/pull/1312

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
