### PR TITLE
pkg/system: reduce retry timeout for EnsureRemoveAll

### DIFF
--- a/pkg/system/rm.go
+++ b/pkg/system/rm.go
@@ -38,7 +38,7 @@ func EnsureRemoveAll(dir string) error {
 
 	// Attempt to unmount anything beneath this dir first
 	if err := mount.RecursiveUnmount(dir); err != nil {
-		logrus.Debugf("RecusiveUnmount on %s failed: %v", dir, err)
+		logrus.Debugf("RecursiveUnmount on %s failed: %v", dir, err)
 	}
 
 	for {

--- a/pkg/system/rm.go
+++ b/pkg/system/rm.go
@@ -28,7 +28,7 @@ func EnsureRemoveAll(dir string) error {
 
 	// track retries
 	exitOnErr := make(map[string]int)
-	maxRetry := 100
+	maxRetry := 1000
 
 	// Attempt a simple remove all first, this avoids the more expensive
 	// RecursiveUnmount call if not needed.
@@ -94,6 +94,6 @@ func EnsureRemoveAll(dir string) error {
 			return err
 		}
 		exitOnErr[pe.Path]++
-		time.Sleep(100 * time.Millisecond)
+		time.Sleep(10 * time.Millisecond)
 	}
 }


### PR DESCRIPTION
reduce the waiting time for attempting again the removal to 10ms instead of the current 100ms.
    
Currently, if we hit the timeout, we add an artificial 100ms delay to the container cleanup, while with this we will react faster when the removal is possible.

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
