### PR TITLE
Define better error message for container name conflicts with external storage

### DIFF
--- a/containers.go
+++ b/containers.go
@@ -671,7 +671,7 @@ func (r *containerStore) create(id string, names []string, image, layer string, 
 	names = dedupeStrings(names)
 	for _, name := range names {
 		if _, nameInUse := r.byname[name]; nameInUse {
-			return nil, fmt.Errorf("the container name %q is already in use by %s. You have to remove that container to be able to reuse that name: %w", name, r.byname[name].ID, ErrDuplicateName)
+			return nil, fmt.Errorf("the container name %q is already in use by %s. You have to remove that container to be able to reuse that name: %w, or use --replace to instruct Podman to do so.", name, r.byname[name].ID, ErrDuplicateName)
 		}
 	}
 	if err := hasOverlappingRanges(options.UIDMap); err != nil {


### PR DESCRIPTION
Updated the error message to suggest user to use --replace option to instruct Podman to replace the existsing external container with a newly created one.

Closes [16759](https://github.com/containers/podman/issues/16759)