### PR TITLE
Don't call UpdateLayerIDMap when creating a layer with no parent

### DIFF
--- a/layers.go
+++ b/layers.go
@@ -1372,10 +1372,13 @@ func (r *layerStore) create(id string, parentLayer *Layer, names []string, mount
 				return nil, -1, fmt.Errorf("creating read-only layer with ID %q: %w", id, err)
 			}
 		}
-		oldMappings = parentMappings
+		if parentLayer != nil {
+			oldMappings = parentMappings
+		}
 	}
 
-	if !reflect.DeepEqual(oldMappings.UIDs(), idMappings.UIDs()) || !reflect.DeepEqual(oldMappings.GIDs(), idMappings.GIDs()) {
+	if oldMappings != nil &&
+		(!reflect.DeepEqual(oldMappings.UIDs(), idMappings.UIDs()) || !reflect.DeepEqual(oldMappings.GIDs(), idMappings.GIDs())) {
 		if err = r.driver.UpdateLayerIDMap(id, oldMappings, idMappings, mountLabel); err != nil {
 			cleanupFailureContext = "in UpdateLayerIDMap"
 			return nil, -1, err

--- a/layers.go
+++ b/layers.go
@@ -1245,8 +1245,8 @@ func (r *layerStore) create(id string, parentLayer *Layer, names []string, mount
 	if parentLayer != nil {
 		parent = parentLayer.ID
 	}
-	var parentMappings, templateIDMappings, oldMappings *idtools.IDMappings
 	var (
+		templateIDMappings         *idtools.IDMappings
 		templateMetadata           string
 		templateCompressedDigest   digest.Digest
 		templateCompressedSize     int64
@@ -1273,11 +1273,6 @@ func (r *layerStore) create(id string, parentLayer *Layer, names []string, mount
 		}
 	} else {
 		templateIDMappings = &idtools.IDMappings{}
-	}
-	if parentLayer != nil {
-		parentMappings = idtools.NewIDMappingsFromMaps(parentLayer.UIDMap, parentLayer.GIDMap)
-	} else {
-		parentMappings = &idtools.IDMappings{}
 	}
 	if mountLabel != "" {
 		selinux.ReserveLabel(mountLabel)
@@ -1353,6 +1348,12 @@ func (r *layerStore) create(id string, parentLayer *Layer, names []string, mount
 		IDMappings: idMappings,
 	}
 
+	var parentMappings, oldMappings *idtools.IDMappings
+	if parentLayer != nil {
+		parentMappings = idtools.NewIDMappingsFromMaps(parentLayer.UIDMap, parentLayer.GIDMap)
+	} else {
+		parentMappings = &idtools.IDMappings{}
+	}
 	if moreOptions.TemplateLayer != "" {
 		if err = r.driver.CreateFromTemplate(id, moreOptions.TemplateLayer, templateIDMappings, parent, parentMappings, &opts, writeable); err != nil {
 			cleanupFailureContext = fmt.Sprintf("creating a layer from template layer %q", moreOptions.TemplateLayer)


### PR DESCRIPTION
Warning: I don’t really know what I’m doing.

AFAICS this call is intended to "remap" the parent layer's contents to the desired IDMappings; but when there is no parent layer, there is nothing to remap.

Motivation: I’m trying to get c/image tests of c/storage working completely unprivileged. 

On macOS that actually works out of the box (where some potentially relevant points are that after #811 , `pkg/chrootarchive` does not chroot on Darwin, and that `pkg/idtools.SafeChown` does not really chown on Darwin).

On Linux, the out-of-the-box setup starts initializing `vfs` by chowning to (0, 0), and that fails. There is some pre-existing code in https://github.com/containers/image/blob/6bf0d1f0ae6682a5dd9a9d07d41f78be160d4383/storage/storage_test.go#L69-L78 to avoid that by remapping (“user-to-current”), and that _part_ seems to work on Linux…

… but with the “user-to-current” ID maps, on macOS, layer creation fails of the first (no-parent) layer fails, because the current logic gets the ID map from the new layer from the store’s configuration (”user-to-current”), but defaults the ID map of the (nonexistent) parent to empty, sees a difference, and triggers `UpdateLayerIDMap`. And that tries to really chroot, and fails.

(Ultimately, on Linux, layer extraction seems to always chroot, so I am failing with my overall goal. Anyway, this seems to be conceptually the right thing to do.)

---

So, this entirely avoids the `UpdateLayerIDMap` call. Again, warning: I don’t know what I’m doing.

Some alternatives:
- Currently, `Store.PutLayer` sets the ID maps from its options; but the nonexistent-parent ID map is set to entirely empty. Instead, `Store.PutLayer` could call `layerStore.create` with new options providing the store’s ID map to use as the nonexistent-parent ID map value. That would have the same effect, except that `layerStore.create` would think there _is_ a “parent ID map”. I think that’s more invasive, and conceptually a bit less correct (there is no parent, so there is no parent ID map at all).
- Maybe the `UpdateLayerIDMap` implementation should follow in steps of #811 and not chroot, even if it is called.

@nalind @giuseppe PTAL