### PR TITLE
store: Make additionalimagestores optional as layerstore source

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -507,6 +507,8 @@ func parseOptions(options []string) (*overlayOptions, error) {
 			}
 			for _, store := range strings.Split(val, ",") {
 				store = filepath.Clean(store)
+				intialStore := store
+				store := strings.Split(store, "|")[0]
 				if !filepath.IsAbs(store) {
 					return nil, fmt.Errorf("overlay: image path %q is not absolute.  Can not be relative", store)
 				}
@@ -517,7 +519,7 @@ func parseOptions(options []string) (*overlayOptions, error) {
 				if !st.IsDir() {
 					return nil, fmt.Errorf("overlay: image path %q must be a directory", store)
 				}
-				o.imageStores = append(o.imageStores, store)
+				o.imageStores = append(o.imageStores, intialStore)
 			}
 		case "additionallayerstore":
 			logrus.Debugf("overlay: additionallayerstore=%s", val)
@@ -1210,6 +1212,7 @@ func (d *Driver) dir2(id string) (string, string, bool) {
 	}
 	if _, err := os.Stat(newpath); err != nil {
 		for _, p := range d.AdditionalImageStores() {
+			p = strings.Split(p, "|")[0]
 			l := path.Join(p, d.name, id)
 			_, err = os.Stat(l)
 			if err == nil {
@@ -1592,6 +1595,7 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 		newpath := path.Join(d.home, l)
 		if st, err := os.Stat(newpath); err != nil {
 			for _, p := range d.AdditionalImageStores() {
+				p = strings.Split(p, "|")[0]
 				lower = path.Join(p, d.name, l)
 				if st2, err2 := os.Stat(lower); err2 == nil {
 					if !permsKnown {

--- a/store.go
+++ b/store.go
@@ -945,6 +945,7 @@ func (s *store) load() error {
 	s.containerStore = rcs
 
 	for _, store := range driver.AdditionalImageStores() {
+		store = strings.Split(store, "|")[0]
 		gipath := filepath.Join(store, driverPrefix+"images")
 		var ris roImageStore
 		if s.imageStoreDir != "" && store == s.graphRoot {
@@ -1109,6 +1110,14 @@ func (s *store) getROLayerStoresLocked() ([]roLayerStore, error) {
 		return nil, err
 	}
 	for _, store := range s.graphDriver.AdditionalImageStores() {
+		if strings.Contains(store, "|") {
+			parts := strings.Split(store, "|")
+			if len(parts) > 1 && parts[1] == "NO_REUSE" {
+				continue
+			} else {
+				store = strings.Split(store, "|")[0]
+			}
+		}
 		glpath := filepath.Join(store, driverPrefix+"layers")
 		rls, err := newROLayerStore(rlpath, glpath, s.graphDriver)
 		if err != nil {


### PR DESCRIPTION
Optionally make additionalImageStore independently maintainable by ensuring that layers are not shared between RO and RW storages so that updating/removing RO storages won't break images in RO ones

Closes: #20603