### PR TITLE
On Read/only additional stores, ignore Read/Only errors

### DIFF
--- a/store.go
+++ b/store.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"strings"
 	"sync"
+	"syscall"
 	"time"
 
 	// register all of the built-in drivers
@@ -961,6 +962,10 @@ func (s *store) load() error {
 		} else {
 			ris, err = newROImageStore(gipath)
 			if err != nil {
+				if errors.Is(err, syscall.EROFS) {
+					logrus.Debugf("Ignoring creation of lockfiles on read-only file systems %q, %v", gipath, err)
+					continue
+				}
 				return err
 			}
 		}


### PR DESCRIPTION
We want to setup empty additonal stores which could potentially be stored on a read-only mount point (ostree).  Currently empty stores work fine as long as the directory is read/write, because when we attempt to lock them, the code wants to create a lock file directory. This returns an error on read-only directories.

This patch ignores read-only addiitonal stores with no content.