### PR TITLE
Don't expose account names when creating tar files with hard-coded account IDs

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -534,6 +534,10 @@ func (ta *tarAppender) addTarFile(path, name string) error {
 	if ta.ChownOpts != nil {
 		hdr.Uid = ta.ChownOpts.UID
 		hdr.Gid = ta.ChownOpts.GID
+		// Don’t expose the user names from the local system; they probably don’t match the ta.ChownOpts value anyway,
+		// and they unnecessarily give recipients of the tar file potentially private data.
+		hdr.Uname = ""
+		hdr.Gname = ""
 	}
 
 	maybeTruncateHeaderModTime(hdr)


### PR DESCRIPTION
A prerequisite for fixing https://github.com/containers/image/issues/1627 .