### PR TITLE
chunked: reject unexpected data after TOC

### DIFF
--- a/pkg/chunked/cache_linux.go
+++ b/pkg/chunked/cache_linux.go
@@ -578,7 +578,10 @@ func unmarshalToc(manifest []byte) (*internal.TOC, error) {
 		return byteSliceAsString(buf.Bytes()[from:to])
 	}
 
-	iter = jsoniter.ParseBytes(jsoniter.ConfigFastest, manifest)
+	pool := iter.Pool()
+	pool.ReturnIterator(iter)
+	iter = pool.BorrowIterator(manifest)
+
 	for field := iter.ReadObject(); field != ""; field = iter.ReadObject() {
 		if strings.ToLower(field) == "version" {
 			toc.Version = iter.ReadInt()

--- a/pkg/chunked/cache_linux.go
+++ b/pkg/chunked/cache_linux.go
@@ -660,8 +660,17 @@ func unmarshalToc(manifest []byte) (*internal.TOC, error) {
 			}
 			toc.Entries = append(toc.Entries, m)
 		}
-		break
 	}
+
+	// validate there is no extra data in the provided input.  This is a security measure to avoid
+	// that the digest we calculate for the TOC refers to the entire document.
+	if iter.Error != nil && iter.Error != io.EOF {
+		return nil, iter.Error
+	}
+	if iter.WhatIsNext() != jsoniter.InvalidValue || !errors.Is(iter.Error, io.EOF) {
+		return nil, fmt.Errorf("unexpected data after manifest")
+	}
+
 	toc.StringsBuf = buf
 	return &toc, nil
 }

--- a/pkg/chunked/cache_linux_test.go
+++ b/pkg/chunked/cache_linux_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	graphdriver "github.com/containers/storage/drivers"
+	"github.com/stretchr/testify/assert"
 )
 
 const jsonTOC = `
@@ -55,6 +56,7 @@ const jsonTOC = `
       "chunkOffset": 17615,
       "chunkDigest": "sha256:2a9d3f1b6b37abc8bb35eb8fa98b893a2a2447bcb01184c3bafc8c6b40da099d"
     }
+  ]
 }
 `
 
@@ -187,4 +189,25 @@ func TestReadCache(t *testing.T) {
 	if !reflect.DeepEqual(cache, cacheRead) {
 		t.Errorf("read a different struct than what was written")
 	}
+}
+
+func TestUnmarshalToc(t *testing.T) {
+	toc, err := unmarshalToc([]byte(jsonTOC))
+	assert.NoError(t, err)
+	assert.Equal(t, 4, len(toc.Entries))
+
+	_, err = unmarshalToc([]byte(jsonTOC + "        \n\n\n\n    "))
+	assert.NoError(t, err)
+	_, err = unmarshalToc([]byte(jsonTOC + "aaaa"))
+	assert.Error(t, err)
+	_, err = unmarshalToc([]byte(jsonTOC + ","))
+	assert.Error(t, err)
+	_, err = unmarshalToc([]byte(jsonTOC + "{}"))
+	assert.Error(t, err)
+	_, err = unmarshalToc([]byte(jsonTOC + "[]"))
+	assert.Error(t, err)
+	_, err = unmarshalToc([]byte(jsonTOC + "\"aaaa\""))
+	assert.Error(t, err)
+	_, err = unmarshalToc([]byte(jsonTOC + "123"))
+	assert.Error(t, err)
 }


### PR DESCRIPTION
handle cases where there is unexpected data following the manifest in the JSON document.
    
Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
