### PR TITLE
pkg/unshare: return true from IsRootless if user is not root

### DIFF
--- a/pkg/unshare/unshare_unsupported.go
+++ b/pkg/unshare/unshare_unsupported.go
@@ -17,7 +17,7 @@ const (
 
 // IsRootless tells us if we are running in rootless mode
 func IsRootless() bool {
-	return false
+	return os.Getuid() != 0
 }
 
 // GetRootlessUID returns the UID of the user in the parent userNS


### PR DESCRIPTION
This helps to avoid a confusing error on FreeBSD when commands such as 'podman run' are attempted by a non-root user. Changing IsRootless to return true for these users allows types.DefaultConfigFile to return a user-accessible path for storage.conf which, in turn, allows 'podman run' to get as far as SetupRootless which will generate a more informative message than 'Error: stat
/var/db/containers/storage/libpod/bolt_state.db: permission denied'