### PR TITLE
chunked: flush the input tarball to the output

### DIFF
--- a/pkg/chunked/compressor/compressor.go
+++ b/pkg/chunked/compressor/compressor.go
@@ -420,6 +420,14 @@ func writeZstdChunkedStream(destFile io.Writer, outMetadata map[string]string, r
 		zstdWriter.Close()
 		return err
 	}
+
+	// make sure the entire tarball is flushed to the output as it might contain
+	// some trailing zeros that affect the checksum.
+	if _, err := io.Copy(zstdWriter, its); err != nil {
+		zstdWriter.Close()
+		return err
+	}
+
 	if err := zstdWriter.Flush(); err != nil {
 		zstdWriter.Close()
 		return err

--- a/pkg/chunked/compressor/compressor.go
+++ b/pkg/chunked/compressor/compressor.go
@@ -452,12 +452,12 @@ type zstdChunkedWriter struct {
 }
 
 func (w zstdChunkedWriter) Close() error {
-	err := <-w.tarSplitErr
-	if err != nil {
-		w.tarSplitOut.Close()
+	errClose := w.tarSplitOut.Close()
+
+	if err := <-w.tarSplitErr; err != nil && err != io.EOF {
 		return err
 	}
-	return w.tarSplitOut.Close()
+	return errClose
 }
 
 func (w zstdChunkedWriter) Write(p []byte) (int, error) {


### PR DESCRIPTION
Flush the entire input tarball to the output in the zstd:chunked stream writer.  This is needed to include any trailing zeros that affect the uncompressed digest.

Closes: https://github.com/containers/storage/issues/1771

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
