### PR TITLE
overlay: use `dir` for final `diff`/`merged` dirs

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -1598,7 +1598,7 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 		return dest, nil
 	}
 
-	diffDir := path.Join(workDirBase, "diff")
+	diffDir := path.Join(dir, "diff")
 
 	if dest, err := maybeAddComposefsMount(id, 0, readWrite); err != nil {
 		return "", err
@@ -1698,7 +1698,7 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 		return "", err
 	}
 
-	mergedDir := path.Join(workDirBase, "merged")
+	mergedDir := path.Join(dir, "merged")
 	// Create the driver merged dir
 	if err := idtools.MkdirAs(mergedDir, 0o700, rootUID, rootGID); err != nil && !os.IsExist(err) {
 		return "", err

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -1599,6 +1599,9 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 	}
 
 	diffDir := path.Join(dir, "diff")
+	if _, err := os.Stat(diffDir); os.IsNotExist(err) {
+		diffDir = path.Join(workDirBase, "diff")
+	}
 
 	if dest, err := maybeAddComposefsMount(id, 0, readWrite); err != nil {
 		return "", err
@@ -1698,9 +1701,9 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 		return "", err
 	}
 
-	mergedDir := path.Join(dir, "merged")
+	mergedDir := path.Join(workDirBase, "merged")
 	// Create the driver merged dir
-	if err := idtools.MkdirAs(mergedDir, 0o700, rootUID, rootGID); err != nil && !os.IsExist(err) {
+	if err := idtools.MkdirAllAs(mergedDir, 0o700, rootUID, rootGID); err != nil && !os.IsExist(err) {
 		return "", err
 	}
 	if count := d.ctr.Increment(mergedDir); count > 1 {


### PR DESCRIPTION
Dan suggested to open this as a PR and I'm happy to do this. For details see my short commit message below and the issue #1779. I did not open a PR initially because I don't have a test for my change (sorry for that!). I hope it's still useful and maybe someone more familiar with the codebase can write a regression test for this change. Feel free to close/rework as needed of course.

---

This commit fixes an issue with the `overlay.go:Driver.get()` code when the requested `id` comes from an extra storage dir that got specified with e.g. `podman --imagestore`. In this scenario the final layer with the `.../diff` dir must come from the extra storage dir instead of from the main storage (that is may not contain this id).

This fixes issue #1779 for my test case and I see no other issues in my "light" testing for the "normal" cases. However I'm not familiar with this code base and this is (of course) an extremly sensitive part of the code so please have a careful look.

More details in https://github.com/containers/storage/issues/1779