### PR TITLE
store: simplify imagestore implementation

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -310,16 +310,6 @@ func isNetworkFileSystem(fsMagic graphdriver.FsMagic) bool {
 // If overlay filesystem is not supported on the host, a wrapped graphdriver.ErrNotSupported is returned as error.
 // If an overlay filesystem is not supported over an existing filesystem then a wrapped graphdriver.ErrIncompatibleFS is returned.
 func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) {
-	// If custom --imagestore is selected never
-	// ditch the original graphRoot, instead add it as
-	// additionalImageStore so its images can still be
-	// read and used.
-	if options.ImageStore != "" {
-		graphRootAsAdditionalStore := fmt.Sprintf("AdditionalImageStore=%s", options.ImageStore)
-		options.DriverOptions = append(options.DriverOptions, graphRootAsAdditionalStore)
-		// complete base name with driver name included
-		options.ImageStore = filepath.Join(options.ImageStore, "overlay")
-	}
 	opts, err := parseOptions(options.DriverOptions)
 	if err != nil {
 		return nil, err
@@ -863,22 +853,15 @@ func (d *Driver) Status() [][2]string {
 // Metadata returns meta data about the overlay driver such as
 // LowerDir, UpperDir, WorkDir and MergeDir used to store data.
 func (d *Driver) Metadata(id string) (map[string]string, error) {
-	dir, imagestore, _ := d.dir2(id)
+	dir := d.dir(id)
 	if _, err := os.Stat(dir); err != nil {
 		return nil, err
 	}
-	workDirBase := dir
-	if imagestore != "" {
-		if _, err := os.Stat(dir); err != nil {
-			return nil, err
-		}
-		workDirBase = imagestore
-	}
 
 	metadata := map[string]string{
-		"WorkDir":   path.Join(workDirBase, "work"),
-		"MergedDir": path.Join(workDirBase, "merged"),
-		"UpperDir":  path.Join(workDirBase, "diff"),
+		"WorkDir":   path.Join(dir, "work"),
+		"MergedDir": path.Join(dir, "merged"),
+		"UpperDir":  path.Join(dir, "diff"),
 	}
 
 	lowerDirs, err := d.getLowerDirs(id)
@@ -992,8 +975,10 @@ func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) (retErr
 	return d.create(id, parent, opts, true)
 }
 
-func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts, disableQuota bool) (retErr error) {
-	dir, imageStore, _ := d.dir2(id)
+func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts, readOnly bool) (retErr error) {
+	dir, homedir, _ := d.dir2(id, readOnly)
+
+	disableQuota := readOnly
 
 	uidMaps := d.uidMaps
 	gidMaps := d.gidMaps
@@ -1004,7 +989,7 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts, disable
 	}
 
 	// Make the link directory if it does not exist
-	if err := idtools.MkdirAllAs(path.Join(d.home, linkDir), 0o755, 0, 0); err != nil {
+	if err := idtools.MkdirAllAs(path.Join(homedir, linkDir), 0o755, 0, 0); err != nil {
 		return err
 	}
 
@@ -1021,20 +1006,8 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts, disable
 	if err := idtools.MkdirAllAndChownNew(path.Dir(dir), 0o755, idPair); err != nil {
 		return err
 	}
-	workDirBase := dir
-	if imageStore != "" {
-		workDirBase = imageStore
-		if err := idtools.MkdirAllAndChownNew(path.Dir(imageStore), 0o755, idPair); err != nil {
-			return err
-		}
-	}
 	if parent != "" {
-		parentBase, parentImageStore, inAdditionalStore := d.dir2(parent)
-		// If parentBase path is additional image store, select the image contained in parentBase.
-		// See https://github.com/containers/podman/issues/19748
-		if parentImageStore != "" && !inAdditionalStore {
-			parentBase = parentImageStore
-		}
+		parentBase := d.dir(parent)
 		st, err := system.Stat(filepath.Join(parentBase, "diff"))
 		if err != nil {
 			return err
@@ -1055,22 +1028,12 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts, disable
 	if err := idtools.MkdirAllAndChownNew(dir, 0o700, idPair); err != nil {
 		return err
 	}
-	if imageStore != "" {
-		if err := idtools.MkdirAllAndChownNew(imageStore, 0o700, idPair); err != nil {
-			return err
-		}
-	}
 
 	defer func() {
 		// Clean up on failure
 		if retErr != nil {
 			if err2 := os.RemoveAll(dir); err2 != nil {
 				logrus.Errorf("While recovering from a failure creating a layer, error deleting %#v: %v", dir, err2)
-			}
-			if imageStore != "" {
-				if err2 := os.RemoveAll(workDirBase); err2 != nil {
-					logrus.Errorf("While recovering from a failure creating a layer, error deleting %#v: %v", workDirBase, err2)
-				}
 			}
 		}
 	}()
@@ -1094,11 +1057,6 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts, disable
 		if err := d.quotaCtl.SetQuota(dir, quota); err != nil {
 			return err
 		}
-		if imageStore != "" {
-			if err := d.quotaCtl.SetQuota(imageStore, quota); err != nil {
-				return err
-			}
-		}
 	}
 
 	perms := defaultPerms
@@ -1107,12 +1065,7 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts, disable
 	}
 
 	if parent != "" {
-		parentBase, parentImageStore, inAdditionalStore := d.dir2(parent)
-		// If parentBase path is additional image store, select the image contained in parentBase.
-		// See https://github.com/containers/podman/issues/19748
-		if parentImageStore != "" && !inAdditionalStore {
-			parentBase = parentImageStore
-		}
+		parentBase := d.dir(parent)
 		st, err := system.Stat(filepath.Join(parentBase, "diff"))
 		if err != nil {
 			return err
@@ -1120,17 +1073,14 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts, disable
 		perms = os.FileMode(st.Mode())
 	}
 
-	if err := idtools.MkdirAs(path.Join(workDirBase, "diff"), perms, rootUID, rootGID); err != nil {
+	if err := idtools.MkdirAs(path.Join(dir, "diff"), perms, rootUID, rootGID); err != nil {
 		return err
 	}
 
 	lid := generateID(idLength)
 
 	linkBase := path.Join("..", id, "diff")
-	if imageStore != "" {
-		linkBase = path.Join(imageStore, "diff")
-	}
-	if err := os.Symlink(linkBase, path.Join(d.home, linkDir, lid)); err != nil {
+	if err := os.Symlink(linkBase, path.Join(homedir, linkDir, lid)); err != nil {
 		return err
 	}
 
@@ -1139,10 +1089,10 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts, disable
 		return err
 	}
 
-	if err := idtools.MkdirAs(path.Join(workDirBase, "work"), 0o700, rootUID, rootGID); err != nil {
+	if err := idtools.MkdirAs(path.Join(dir, "work"), 0o700, rootUID, rootGID); err != nil {
 		return err
 	}
-	if err := idtools.MkdirAs(path.Join(workDirBase, "merged"), 0o700, rootUID, rootGID); err != nil {
+	if err := idtools.MkdirAs(path.Join(dir, "merged"), 0o700, rootUID, rootGID); err != nil {
 		return err
 	}
 
@@ -1224,26 +1174,39 @@ func (d *Driver) getLower(parent string) (string, error) {
 }
 
 func (d *Driver) dir(id string) string {
-	p, _, _ := d.dir2(id)
+	p, _, _ := d.dir2(id, false)
 	return p
 }
 
-func (d *Driver) dir2(id string) (string, string, bool) {
-	newpath := path.Join(d.home, id)
-	imageStore := ""
+func (d *Driver) getAllImageStores() []string {
+	additionalImageStores := d.AdditionalImageStores()
 	if d.imageStore != "" {
-		imageStore = path.Join(d.imageStore, id)
+		additionalImageStores = append([]string{d.imageStore}, additionalImageStores...)
 	}
+	return additionalImageStores
+}
+
+func (d *Driver) dir2(id string, useImageStore bool) (string, string, bool) {
+	var homedir string
+
+	if useImageStore && d.imageStore != "" {
+		homedir = path.Join(d.imageStore, d.name)
+	} else {
+		homedir = d.home
+	}
+
+	newpath := path.Join(homedir, id)
+
 	if _, err := os.Stat(newpath); err != nil {
-		for _, p := range d.AdditionalImageStores() {
+		for _, p := range d.getAllImageStores() {
 			l := path.Join(p, d.name, id)
 			_, err = os.Stat(l)
 			if err == nil {
-				return l, imageStore, true
+				return l, homedir, true
 			}
 		}
 	}
-	return newpath, imageStore, false
+	return newpath, homedir, false
 }
 
 func (d *Driver) getLowerDirs(id string) ([]string, error) {
@@ -1453,14 +1416,11 @@ func (d *Driver) Get(id string, options graphdriver.MountOpts) (string, error) {
 }
 
 func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountOpts) (_ string, retErr error) {
-	dir, imageStore, inAdditionalStore := d.dir2(id)
+	dir, _, inAdditionalStore := d.dir2(id, false)
 	if _, err := os.Stat(dir); err != nil {
 		return "", err
 	}
-	workDirBase := dir
-	if imageStore != "" {
-		workDirBase = imageStore
-	}
+
 	readWrite := !inAdditionalStore
 
 	if !d.SupportsShifting() || options.DisableShifting {
@@ -1565,7 +1525,7 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 	}()
 
 	composeFsLayers := []string{}
-	composeFsLayersDir := filepath.Join(workDirBase, "composefs-layers")
+	composeFsLayersDir := filepath.Join(dir, "composefs-layers")
 	maybeAddComposefsMount := func(lowerID string, i int, readWrite bool) (string, error) {
 		composefsBlob := d.getComposefsData(lowerID)
 		_, err = os.Stat(composefsBlob)
@@ -1599,7 +1559,7 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 		return dest, nil
 	}
 
-	diffDir := path.Join(workDirBase, "diff")
+	diffDir := path.Join(dir, "diff")
 
 	if dest, err := maybeAddComposefsMount(id, 0, readWrite); err != nil {
 		return "", err
@@ -1617,7 +1577,7 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 		lower := ""
 		newpath := path.Join(d.home, l)
 		if st, err := os.Stat(newpath); err != nil {
-			for _, p := range d.AdditionalImageStores() {
+			for _, p := range d.getAllImageStores() {
 				lower = path.Join(p, d.name, l)
 				if st2, err2 := os.Stat(lower); err2 == nil {
 					if !permsKnown {
@@ -1685,14 +1645,14 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 		optsList = append(optsList, "metacopy=on", "redirect_dir=on")
 	}
 
-	if len(absLowers) == 0 {
-		absLowers = append(absLowers, path.Join(dir, "empty"))
-	}
-
 	// user namespace requires this to move a directory from lower to upper.
 	rootUID, rootGID, err := idtools.GetRootUIDGID(options.UidMaps, options.GidMaps)
 	if err != nil {
 		return "", err
+	}
+
+	if len(absLowers) == 0 {
+		absLowers = append(absLowers, path.Join(dir, "empty"))
 	}
 
 	if err := idtools.MkdirAllAs(diffDir, perms, rootUID, rootGID); err != nil {
@@ -1705,7 +1665,7 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 		}
 	}
 
-	mergedDir := path.Join(workDirBase, "merged")
+	mergedDir := path.Join(dir, "merged")
 	// Create the driver merged dir
 	if err := idtools.MkdirAs(mergedDir, 0o700, rootUID, rootGID); err != nil && !os.IsExist(err) {
 		return "", err
@@ -1723,7 +1683,7 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 		}
 	}()
 
-	workdir := path.Join(workDirBase, "work")
+	workdir := path.Join(dir, "work")
 
 	if d.options.mountProgram == "" && unshare.IsRootless() {
 		optsList = append(optsList, "userxattr")
@@ -1873,7 +1833,7 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 
 // Put unmounts the mount path created for the give id.
 func (d *Driver) Put(id string) error {
-	dir, _, inAdditionalStore := d.dir2(id)
+	dir, _, inAdditionalStore := d.dir2(id, false)
 	if _, err := os.Stat(dir); err != nil {
 		return err
 	}
@@ -2234,12 +2194,8 @@ func (d *Driver) getComposefsData(id string) string {
 }
 
 func (d *Driver) getDiffPath(id string) (string, error) {
-	dir, imagestore, _ := d.dir2(id)
-	base := dir
-	if imagestore != "" {
-		base = imagestore
-	}
-	return redirectDiffIfAdditionalLayer(path.Join(base, "diff"))
+	dir := d.dir(id)
+	return redirectDiffIfAdditionalLayer(path.Join(dir, "diff"))
 }
 
 func (d *Driver) getLowerDiffPaths(id string) ([]string, error) {
@@ -2330,12 +2286,8 @@ func (d *Driver) AdditionalImageStores() []string {
 // by toContainer to those specified by toHost.
 func (d *Driver) UpdateLayerIDMap(id string, toContainer, toHost *idtools.IDMappings, mountLabel string) error {
 	var err error
-	dir, imagestore, _ := d.dir2(id)
-	base := dir
-	if imagestore != "" {
-		base = imagestore
-	}
-	diffDir := filepath.Join(base, "diff")
+	dir := d.dir(id)
+	diffDir := filepath.Join(dir, "diff")
 
 	rootUID, rootGID := 0, 0
 	if toHost != nil {

--- a/drivers/vfs/driver.go
+++ b/drivers/vfs/driver.go
@@ -31,8 +31,9 @@ func init() {
 func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) {
 	d := &Driver{
 		name:       "vfs",
-		homes:      []string{home},
+		home:       home,
 		idMappings: idtools.NewIDMappingsFromMaps(options.UIDMaps, options.GIDMaps),
+		imageStore: options.ImageStore,
 	}
 
 	rootIDs := d.idMappings.RootPair()
@@ -47,7 +48,7 @@ func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) 
 		key = strings.ToLower(key)
 		switch key {
 		case "vfs.imagestore", ".imagestore":
-			d.homes = append(d.homes, strings.Split(val, ",")...)
+			d.additionalHomes = append(d.additionalHomes, strings.Split(val, ",")...)
 			continue
 		case "vfs.mountopt":
 			return nil, fmt.Errorf("vfs driver does not support mount options")
@@ -62,12 +63,7 @@ func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) 
 			return nil, fmt.Errorf("vfs driver does not support %s options", key)
 		}
 	}
-	// If --imagestore is provided, lets add writable graphRoot
-	// to vfs's additional image store, as it is done for
-	// `overlay` driver.
-	if options.ImageStore != "" {
-		d.homes = append(d.homes, options.ImageStore)
-	}
+
 	d.updater = graphdriver.NewNaiveLayerIDMapUpdater(d)
 	d.naiveDiff = graphdriver.NewNaiveDiffDriver(d, d.updater)
 
@@ -80,11 +76,13 @@ func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) 
 // Driver must be wrapped in NaiveDiffDriver to be used as a graphdriver.Driver
 type Driver struct {
 	name              string
-	homes             []string
+	home              string
+	additionalHomes   []string
 	idMappings        *idtools.IDMappings
 	ignoreChownErrors bool
 	naiveDiff         graphdriver.DiffDriver
 	updater           graphdriver.LayerIDMapUpdater
+	imageStore        string
 }
 
 func (d *Driver) String() string {
@@ -158,7 +156,7 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts, ro bool
 		idMappings = opts.IDMappings
 	}
 
-	dir := d.dir(id)
+	dir := d.dir2(id, ro)
 	rootIDs := idMappings.RootPair()
 	if err := idtools.MkdirAllAndChown(filepath.Dir(dir), 0o700, rootIDs); err != nil {
 		return err
@@ -204,18 +202,32 @@ func (d *Driver) create(id, parent string, opts *graphdriver.CreateOpts, ro bool
 	return nil
 }
 
-func (d *Driver) dir(id string) string {
-	for i, home := range d.homes {
-		if i > 0 {
-			home = filepath.Join(home, d.String())
+func (d *Driver) dir2(id string, useImageStore bool) string {
+	var homedir string
+
+	if useImageStore && d.imageStore != "" {
+		homedir = filepath.Join(d.imageStore, d.String(), "dir", filepath.Base(id))
+	} else {
+		homedir = filepath.Join(d.home, "dir", filepath.Base(id))
+	}
+	if _, err := os.Stat(homedir); err != nil {
+		additionalHomes := d.additionalHomes[:]
+		if d.imageStore != "" {
+			additionalHomes = append(additionalHomes, d.imageStore)
 		}
-		candidate := filepath.Join(home, "dir", filepath.Base(id))
-		fi, err := os.Stat(candidate)
-		if err == nil && fi.IsDir() {
-			return candidate
+		for _, home := range additionalHomes {
+			candidate := filepath.Join(home, d.String(), "dir", filepath.Base(id))
+			fi, err := os.Stat(candidate)
+			if err == nil && fi.IsDir() {
+				return candidate
+			}
 		}
 	}
-	return filepath.Join(d.homes[0], "dir", filepath.Base(id))
+	return homedir
+}
+
+func (d *Driver) dir(id string) string {
+	return d.dir2(id, false)
 }
 
 // Remove deletes the content from the directory for a given id.
@@ -263,7 +275,7 @@ func (d *Driver) Exists(id string) bool {
 
 // List layers (not including additional image stores)
 func (d *Driver) ListLayers() ([]string, error) {
-	entries, err := os.ReadDir(filepath.Join(d.homes[0], "dir"))
+	entries, err := os.ReadDir(filepath.Join(d.home, "dir"))
 	if err != nil {
 		return nil, err
 	}
@@ -285,8 +297,8 @@ func (d *Driver) ListLayers() ([]string, error) {
 
 // AdditionalImageStores returns additional image stores supported by the driver
 func (d *Driver) AdditionalImageStores() []string {
-	if len(d.homes) > 1 {
-		return d.homes[1:]
+	if len(d.additionalHomes) > 0 {
+		return d.additionalHomes
 	}
 	return nil
 }

--- a/layers.go
+++ b/layers.go
@@ -334,10 +334,71 @@ type rwLayerStore interface {
 	GarbageCollect() error
 }
 
+type multipleLockFile struct {
+	lockfiles []*lockfile.LockFile
+}
+
+func (l multipleLockFile) Lock() {
+	for _, lock := range l.lockfiles {
+		lock.Lock()
+	}
+}
+
+func (l multipleLockFile) RLock() {
+	for _, lock := range l.lockfiles {
+		lock.RLock()
+	}
+}
+
+func (l multipleLockFile) Unlock() {
+	for _, lock := range l.lockfiles {
+		lock.Unlock()
+	}
+}
+
+func (l multipleLockFile) ModifiedSince(lastWrite lockfile.LastWrite) (lockfile.LastWrite, bool, error) {
+	// Look up only the first lockfile, since this is the value returned by RecordWrite().
+	return l.lockfiles[0].ModifiedSince(lastWrite)
+}
+
+func (l multipleLockFile) AssertLockedForWriting() {
+	for _, lock := range l.lockfiles {
+		lock.AssertLockedForWriting()
+	}
+}
+
+func (l multipleLockFile) GetLastWrite() (lockfile.LastWrite, error) {
+	return l.lockfiles[0].GetLastWrite()
+}
+
+func (l multipleLockFile) RecordWrite() (lockfile.LastWrite, error) {
+	var lastWrite *lockfile.LastWrite
+	for _, lock := range l.lockfiles {
+		lw, err := lock.RecordWrite()
+		if err != nil {
+			return lw, err
+		}
+		// Return the first value we get so we know that
+		// all the locks have a write time >= to this one.
+		if lastWrite == nil {
+			lastWrite = &lw
+		}
+	}
+	return *lastWrite, nil
+}
+
+func (l multipleLockFile) IsReadWrite() bool {
+	return l.lockfiles[0].IsReadWrite()
+}
+
+func newMultipleLockFile(l ...*lockfile.LockFile) *multipleLockFile {
+	return &multipleLockFile{lockfiles: l}
+}
+
 type layerStore struct {
 	// The following fields are only set when constructing layerStore, and must never be modified afterwards.
 	// They are safe to access without any other locking.
-	lockfile       *lockfile.LockFile // lockfile.IsReadWrite can be used to distinguish between read-write and read-only layer stores.
+	lockfile       *multipleLockFile  // lockfile.IsReadWrite can be used to distinguish between read-write and read-only layer stores.
 	mountsLockfile *lockfile.LockFile // Can _only_ be obtained with inProcessLock held.
 	rundir         string
 	jsonPath       [numLayerLocationIndex]string
@@ -1048,7 +1109,7 @@ func (s *store) newLayerStore(rundir string, layerdir string, driver drivers.Dri
 		volatileDir = rundir
 	}
 	rlstore := layerStore{
-		lockfile:       lockFile,
+		lockfile:       newMultipleLockFile(lockFile),
 		mountsLockfile: mountsLockfile,
 		rundir:         rundir,
 		jsonPath: [numLayerLocationIndex]string{
@@ -1085,7 +1146,7 @@ func newROLayerStore(rundir string, layerdir string, driver drivers.Driver) (roL
 		return nil, err
 	}
 	rlstore := layerStore{
-		lockfile:       lockfile,
+		lockfile:       newMultipleLockFile(lockfile),
 		mountsLockfile: nil,
 		rundir:         rundir,
 		jsonPath: [numLayerLocationIndex]string{

--- a/store.go
+++ b/store.go
@@ -972,11 +972,13 @@ func (s *store) load() error {
 	if err := os.MkdirAll(gipath, 0o700); err != nil {
 		return err
 	}
-	ris, err := newImageStore(gipath)
+	imageStore, err := newImageStore(gipath)
 	if err != nil {
 		return err
 	}
-	s.imageStore = ris
+	s.imageStore = imageStore
+
+	s.rwImageStores = []rwImageStore{imageStore}
 
 	gcpath := filepath.Join(s.graphRoot, driverPrefix+"containers")
 	if err := os.MkdirAll(gcpath, 0o700); err != nil {
@@ -994,13 +996,16 @@ func (s *store) load() error {
 
 	s.containerStore = rcs
 
-	for _, store := range driver.AdditionalImageStores() {
+	additionalImageStores := s.graphDriver.AdditionalImageStores()
+	if s.imageStoreDir != "" {
+		additionalImageStores = append([]string{s.graphRoot}, additionalImageStores...)
+	}
+
+	for _, store := range additionalImageStores {
 		gipath := filepath.Join(store, driverPrefix+"images")
 		var ris roImageStore
-		if s.imageStoreDir != "" && store == s.graphRoot {
-			// If --imagestore was set and current store
-			// is `graphRoot` then mount it as a `rw` additional
-			// store instead of `readonly` additional store.
+		// both the graphdriver and the imagestore must be used read-write.
+		if store == s.imageStoreDir || store == s.graphRoot {
 			imageStore, err := newImageStore(gipath)
 			if err != nil {
 				return err
@@ -1085,15 +1090,9 @@ func (s *store) stopUsingGraphDriver() {
 // Almost all users should use startUsingGraphDriver instead.
 // The caller must hold s.graphLock.
 func (s *store) createGraphDriverLocked() (drivers.Driver, error) {
-	driverRoot := s.imageStoreDir
-	imageStoreBase := s.graphRoot
-	if driverRoot == "" {
-		driverRoot = s.graphRoot
-		imageStoreBase = ""
-	}
 	config := drivers.Options{
-		Root:           driverRoot,
-		ImageStore:     imageStoreBase,
+		Root:           s.graphRoot,
+		ImageStore:     s.imageStoreDir,
 		RunRoot:        s.runRoot,
 		DriverPriority: s.graphDriverPriority,
 		DriverOptions:  s.graphOptions,
@@ -1162,8 +1161,10 @@ func (s *store) getROLayerStoresLocked() ([]roLayerStore, error) {
 	if err := os.MkdirAll(rlpath, 0o700); err != nil {
 		return nil, err
 	}
+
 	for _, store := range s.graphDriver.AdditionalImageStores() {
 		glpath := filepath.Join(store, driverPrefix+"layers")
+
 		rls, err := newROLayerStore(rlpath, glpath, s.graphDriver)
 		if err != nil {
 			return nil, err
@@ -2590,7 +2591,7 @@ func (s *store) DeleteImage(id string, commit bool) (layers []string, err error)
 	if err := s.writeToAllStores(func(rlstore rwLayerStore) error {
 		// Delete image from all available imagestores configured to be used.
 		imageFound := false
-		for _, is := range append([]rwImageStore{s.imageStore}, s.rwImageStores...) {
+		for _, is := range s.rwImageStores {
 			if is != s.imageStore {
 				// This is an additional writeable image store
 				// so we must perform lock

--- a/store.go
+++ b/store.go
@@ -1122,15 +1122,15 @@ func (s *store) getLayerStoreLocked() (rwLayerStore, error) {
 	if err := os.MkdirAll(rlpath, 0o700); err != nil {
 		return nil, err
 	}
-	imgStoreRoot := s.imageStoreDir
-	if imgStoreRoot == "" {
-		imgStoreRoot = s.graphRoot
-	}
-	glpath := filepath.Join(imgStoreRoot, driverPrefix+"layers")
+	glpath := filepath.Join(s.graphRoot, driverPrefix+"layers")
 	if err := os.MkdirAll(glpath, 0o700); err != nil {
 		return nil, err
 	}
-	rls, err := s.newLayerStore(rlpath, glpath, s.graphDriver, s.transientStore)
+	ilpath := ""
+	if s.imageStoreDir != "" {
+		ilpath = filepath.Join(s.imageStoreDir, driverPrefix+"layers")
+	}
+	rls, err := s.newLayerStore(rlpath, glpath, ilpath, s.graphDriver, s.transientStore)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
simplify the imagestore implementation and use it as a first-class store.  It reduces the amount of code to deal with an image store in the driver (only overlay supports it at the moment).

Closes: https://github.com/containers/storage/issues/1779

Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>