### PR TITLE
chunked: validate converted images

### DIFF
--- a/pkg/chunked/storage_unsupported.go
+++ b/pkg/chunked/storage_unsupported.go
@@ -9,9 +9,10 @@ import (
 
 	storage "github.com/containers/storage"
 	graphdriver "github.com/containers/storage/drivers"
+	digest "github.com/opencontainers/go-digest"
 )
 
 // GetDiffer returns a differ than can be used with ApplyDiffWithDiffer.
-func GetDiffer(ctx context.Context, store storage.Store, blobSize int64, annotations map[string]string, iss ImageSourceSeekable) (graphdriver.Differ, error) {
+func GetDiffer(ctx context.Context, store storage.Store, blobDigest digest.Digest, blobSize int64, annotations map[string]string, iss ImageSourceSeekable) (graphdriver.Differ, error) {
 	return nil, errors.New("format not supported on this system")
 }


### PR DESCRIPTION
validate that the retrieved data for converted images matches the expected digest.

The related change in c/image:

```diff
diff --git a/storage/storage_dest.go b/storage/storage_dest.go
index 0cd4392a..56f16461 100644
--- a/storage/storage_dest.go
+++ b/storage/storage_dest.go
@@ -279,7 +279,7 @@ func (s *storageImageDestination) PutBlobPartial(ctx context.Context, chunkAcces
                blobInfo:      srcInfo,
        }
 
-       differ, err := chunked.GetDiffer(ctx, s.imageRef.transport.store, srcInfo.Size, srcInfo.Annotations, &fetcher)
+       differ, err := chunked.GetDiffer(ctx, s.imageRef.transport.store, &srcInfo.Digest, srcInfo.Size, srcInfo.Annotations, &fetcher)
        if err != nil {
                return private.UploadedBlob{}, err
        }
```