### PR TITLE
Store: add ImageDirectory() and ImageRunDirectory()

### DIFF
--- a/cmd/containers-storage/image.go
+++ b/cmd/containers-storage/image.go
@@ -131,6 +131,24 @@ func getImageBigDataDigest(flags *mflag.FlagSet, action string, m storage.Store,
 	return 0, nil
 }
 
+func getImageDir(flags *mflag.FlagSet, action string, m storage.Store, args []string) (int, error) {
+	path, err := m.ImageDirectory(args[0])
+	if err != nil {
+		return 1, err
+	}
+	fmt.Printf("%s\n", path)
+	return 0, nil
+}
+
+func getImageRunDir(flags *mflag.FlagSet, action string, m storage.Store, args []string) (int, error) {
+	path, err := m.ImageRunDirectory(args[0])
+	if err != nil {
+		return 1, err
+	}
+	fmt.Printf("%s\n", path)
+	return 0, nil
+}
+
 func setImageBigData(flags *mflag.FlagSet, action string, m storage.Store, args []string) (int, error) {
 	image, err := m.Image(args[0])
 	if err != nil {
@@ -216,5 +234,21 @@ func init() {
 			addFlags: func(flags *mflag.FlagSet, cmd *command) {
 				flags.StringVar(&paramImageDataFile, []string{"-file", "f"}, paramImageDataFile, "Read data from file")
 			},
+		},
+		command{
+			names:       []string{"get-image-dir", "getimagedir"},
+			optionsHelp: "[options [...]] imageNameOrID",
+			usage:       "Find the image's associated data directory",
+			action:      getImageDir,
+			minArgs:     1,
+			maxArgs:     1,
+		},
+		command{
+			names:       []string{"get-image-run-dir", "getimagerundir"},
+			optionsHelp: "[options [...]] imageNameOrID",
+			usage:       "Find the image's associated runtime directory",
+			action:      getImageRunDir,
+			minArgs:     1,
+			maxArgs:     1,
 		})
 }

--- a/docs/containers-storage-get-image-dir.md
+++ b/docs/containers-storage-get-image-dir.md
@@ -1,0 +1,17 @@
+## containers-storage-get-image-dir 1 "January 2024"
+
+## NAME
+containers-storage get-image-dir - Find lookaside directory for an image
+
+## SYNOPSIS
+**containers-storage** **get-image-dir** [*options* [...]] *imageNameOrID*
+
+## DESCRIPTION
+Prints the location of a directory which the caller can use to store lookaside
+information which should be cleaned up when the image is deleted.
+
+## EXAMPLE
+**containers-storage get-image-dir my-image**
+
+## SEE ALSO
+containers-storage-get-image-run-dir(1)

--- a/docs/containers-storage-get-image-run-dir.md
+++ b/docs/containers-storage-get-image-run-dir.md
@@ -1,0 +1,17 @@
+## containers-storage-get-image-run-dir 1 "January 2024"
+
+## NAME
+containers-storage get-image-run-dir - Find runtime lookaside directory for an image
+
+## SYNOPSIS
+**containers-storage** **get-image-run-dir** [*options* [...]] *imageNameOrID*
+
+## DESCRIPTION
+Prints the location of a directory which the caller can use to store lookaside
+information which should be cleaned up when the host is rebooted.
+
+## EXAMPLE
+**containers-storage get-image-run-dir my-image**
+
+## SEE ALSO
+containers-storage-get-image-dir(1)

--- a/tests/image-dirs.bats
+++ b/tests/image-dirs.bats
@@ -1,0 +1,39 @@
+#!/usr/bin/env bats
+
+load helpers
+
+@test "image-dirs" {
+	# Create a layer.
+	run storage --debug=false create-layer
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	layer=$output
+
+	# Check that the layer can be found.
+	storage exists -l $layer
+
+	# Create an image using the layer.
+	run storage --debug=false create-image -m danger $layer
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	image=${output%%	*}
+
+	# Check that the image can be found.
+	storage exists -i $image
+
+	# Check that the image's user data directory is somewhere under the root.
+	run storage --debug=false get-image-dir $image
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	dir=${output%%	*}
+	touch "$dir"/dirfile
+	echo "$dir"/dirfile | grep -q ^"${TESTDIR}/root/"
+
+	# Check that the image's user run data directory is somewhere under the run root.
+	run storage --debug=false get-image-run-dir $image
+	[ "$status" -eq 0 ]
+	[ "$output" != "" ]
+	rundir=${output%%	*}
+	touch "$rundir"/rundirfile
+	echo "$rundir"/rundirfile | grep -q ^"${TESTDIR}/runroot/"
+}


### PR DESCRIPTION
Add ImageDirectory() and ImageRunDirectory(), which return the paths of directories which the caller can use to store image-specific data which will be cleaned up automatically when the image is removed or the system is restarted, respectively.