### PR TITLE
Fix windows runtime dir

### DIFF
--- a/pkg/homedir/homedir_others.go
+++ b/pkg/homedir/homedir_others.go
@@ -1,5 +1,5 @@
-//go:build !linux && !darwin && !freebsd
-// +build !linux,!darwin,!freebsd
+//go:build !linux && !darwin && !freebsd && !windows
+// +build !linux,!darwin,!freebsd,!windows
 
 package homedir
 

--- a/pkg/homedir/homedir_windows.go
+++ b/pkg/homedir/homedir_windows.go
@@ -5,6 +5,7 @@ package homedir
 
 import (
 	"os"
+	"path/filepath"
 )
 
 // Key returns the env var name for the user's home dir based on
@@ -25,8 +26,36 @@ func Get() string {
 	return home
 }
 
+// GetConfigHome returns the home directory of the current user with the help of
+// environment variables depending on the target operating system.
+// Returned path should be used with "path/filepath" to form new paths.
+func GetConfigHome() (string, error) {
+	return filepath.Join(Get(), ".config"), nil
+}
+
 // GetShortcutString returns the string that is shortcut to user's home directory
 // in the native shell of the platform running on.
 func GetShortcutString() string {
 	return "%USERPROFILE%" // be careful while using in format functions
+}
+
+// StickRuntimeDirContents is a no-op on Windows
+func StickRuntimeDirContents(files []string) ([]string, error) {
+	return nil, nil
+}
+
+// GetRuntimeDir returns a directory suitable to store runtime files.
+// The function will try to use the XDG_RUNTIME_DIR env variable if it is set.
+// XDG_RUNTIME_DIR is typically configured via pam_systemd.
+// If XDG_RUNTIME_DIR is not set, GetRuntimeDir will try to find a suitable
+// directory for the current user.
+//
+// See also https://standards.freedesktop.org/basedir-spec/latest/ar01s03.html
+func GetRuntimeDir() (string, error) {
+	data, err := GetDataHome()
+	if err != nil {
+		return "", err
+	}
+	runtimeDir := filepath.Join(data, "containers", "podman")
+	return runtimeDir, nil
 }


### PR DESCRIPTION
Needed to un-break podman win main.

Needs to be vendored into common, then into podman. 