### PR TITLE
overlay: fix build of composefs without cgo

### DIFF
--- a/drivers/overlay/overlay_nocgo.go
+++ b/drivers/overlay/overlay_nocgo.go
@@ -4,6 +4,7 @@
 package overlay
 
 import (
+	"fmt"
 	"path"
 
 	"github.com/containers/storage/pkg/directory"
@@ -14,4 +15,16 @@ import (
 // finding the size of the "diff" directory.
 func (d *Driver) ReadWriteDiskUsage(id string) (*directory.DiskUsage, error) {
 	return directory.Usage(path.Join(d.dir(id), "diff"))
+}
+
+func getComposeFsHelper() (string, error) {
+	return "", fmt.Errorf("composefs not supported on this build")
+}
+
+func mountComposefsBlob(dataDir, mountPoint string) error {
+	return fmt.Errorf("composefs not supported on this build")
+}
+
+func generateComposeFsBlob(verityDigests map[string]string, toc interface{}, composefsDir string) error {
+	return fmt.Errorf("composefs not supported on this build")
 }


### PR DESCRIPTION
Closes: https://github.com/containers/storage/issues/1816