### PR TITLE
Extend PutLayer to optimize reusing data from existing layers

### DIFF
--- a/layers.go
+++ b/layers.go
@@ -2286,7 +2286,7 @@ func (r *layerStore) applyDiffWithOptions(to string, layerOptions *LayerOptions,
 	if layerOptions != nil && layerOptions.UncompressedDigest != "" &&
 		layerOptions.UncompressedDigest.Algorithm() == digest.Canonical {
 		uncompressedDigest = layerOptions.UncompressedDigest
-	} else {
+	} else if compression != archive.Uncompressed {
 		uncompressedDigester = digest.Canonical.Digester()
 	}
 
@@ -2364,6 +2364,9 @@ func (r *layerStore) applyDiffWithOptions(to string, layerOptions *LayerOptions,
 	}
 	if uncompressedDigester != nil {
 		uncompressedDigest = uncompressedDigester.Digest()
+	}
+	if uncompressedDigest == "" && compression == archive.Uncompressed {
+		uncompressedDigest = compressedDigest
 	}
 
 	updateDigestMap(&r.bycompressedsum, layer.CompressedDigest, compressedDigest, layer.ID)

--- a/layers.go
+++ b/layers.go
@@ -2371,7 +2371,11 @@ func (r *layerStore) applyDiffWithOptions(to string, layerOptions *LayerOptions,
 
 	updateDigestMap(&r.bycompressedsum, layer.CompressedDigest, compressedDigest, layer.ID)
 	layer.CompressedDigest = compressedDigest
-	layer.CompressedSize = compressedCounter.Count
+	if layerOptions != nil && layerOptions.OriginalDigest != "" && layerOptions.OriginalSize != nil {
+		layer.CompressedSize = *layerOptions.OriginalSize
+	} else {
+		layer.CompressedSize = compressedCounter.Count
+	}
 	updateDigestMap(&r.byuncompressedsum, layer.UncompressedDigest, uncompressedDigest, layer.ID)
 	layer.UncompressedDigest = uncompressedDigest
 	layer.UncompressedSize = uncompressedCounter.Count

--- a/store.go
+++ b/store.go
@@ -580,10 +580,19 @@ type LayerOptions struct {
 	// initialize this layer.  If set, it should be a child of the layer
 	// which we want to use as the parent of the new layer.
 	TemplateLayer string
-	// OriginalDigest specifies a digest of the tarstream (diff), if one is
+	// OriginalDigest specifies a digest of the (possibly-compressed) tarstream (diff), if one is
 	// provided along with these LayerOptions, and reliably known by the caller.
+	// The digest might not be exactly the digest of the provided tarstream
+	// (e.g. the digest might be of a compressed representation, while providing
+	// an uncompressed one); in that case the caller is responsible for the two matching.
 	// Use the default "" if this fields is not applicable or the value is not known.
 	OriginalDigest digest.Digest
+	// OriginalSize specifies a size of the (possibly-compressed) tarstream corresponding
+	// to OriginalDigest.
+	// If the digest does not match the provided tarstream, OriginalSize must match OriginalDigest,
+	// not the tarstream.
+	// Use nil if not applicable or not known.
+	OriginalSize *int64
 	// UncompressedDigest specifies a digest of the uncompressed version (“DiffID”)
 	// of the tarstream (diff), if one is provided along with these LayerOptions,
 	// and reliably known by the caller.
@@ -1485,6 +1494,7 @@ func (s *store) PutLayer(id, parent string, names []string, mountLabel string, w
 	}
 	layerOptions := LayerOptions{
 		OriginalDigest:     options.OriginalDigest,
+		OriginalSize:       options.OriginalSize,
 		UncompressedDigest: options.UncompressedDigest,
 		Flags:              options.Flags,
 	}


### PR DESCRIPTION
- If the caller does not provide digests (e.g. when reusing a layer found by `LayersByTOCDigest`), only digest uncompressed input once, not twice
- Let the caller provide a `CompressedSize` value to match `CompressedDigest`, so that we don't create layers with incorrect metadata.

Motivated by https://github.com/containers/image/pull/2288 .

Cc: @giuseppe (fairly low priority)