### PR TITLE
storage: enable partial images by default

### DIFF
--- a/docs/containers-storage.conf.5.md
+++ b/docs/containers-storage.conf.5.md
@@ -84,7 +84,7 @@ The `storage.options` table supports the following options:
 **additionalimagestores**=[]
   Paths to additional container image stores. Usually these are read/only and stored on remote network shares.
 
-**pull_options** = {enable_partial_images = "false", use_hard_links = "false", ostree_repos=""}
+**pull_options** = {enable_partial_images = "true", use_hard_links = "false", ostree_repos=""}
 
 Allows specification of how storage is populated when pulling images. This
 option can speed the pulling process of images compressed with format zstd:chunked. Containers/storage looks

--- a/pkg/chunked/storage_linux.go
+++ b/pkg/chunked/storage_linux.go
@@ -1701,7 +1701,7 @@ func (c *chunkedDiffer) ApplyDiff(dest string, options *archive.TarOptions, diff
 		UncompressedDigest: uncompressedDigest,
 	}
 
-	if !parseBooleanPullOption(c.storeOpts, "enable_partial_images", false) {
+	if !parseBooleanPullOption(c.storeOpts, "enable_partial_images", true) {
 		return output, errors.New("enable_partial_images not configured")
 	}
 

--- a/pkg/chunked/storage_linux.go
+++ b/pkg/chunked/storage_linux.go
@@ -241,6 +241,10 @@ func GetDiffer(ctx context.Context, store storage.Store, blobDigest digest.Diges
 		return nil, err
 	}
 
+	if !parseBooleanPullOption(&storeOpts, "enable_partial_images", true) {
+		return nil, errors.New("enable_partial_images not configured")
+	}
+
 	_, hasZstdChunkedTOC := annotations[internal.ManifestChecksumKey]
 	_, hasEstargzTOC := annotations[estargz.TOCJSONDigestAnnotation]
 
@@ -1699,10 +1703,6 @@ func (c *chunkedDiffer) ApplyDiff(dest string, options *archive.TarOptions, diff
 		},
 		TOCDigest:          c.tocDigest,
 		UncompressedDigest: uncompressedDigest,
-	}
-
-	if !parseBooleanPullOption(c.storeOpts, "enable_partial_images", true) {
-		return output, errors.New("enable_partial_images not configured")
 	}
 
 	// When the hard links deduplication is used, file attributes are ignored because setting them

--- a/storage.conf
+++ b/storage.conf
@@ -70,7 +70,7 @@ additionalimagestores = [
 #     Tells containers/storage where an ostree repository exists that might have
 #     previously pulled content which can be used when attempting to avoid
 #     pulling content from the container registry
-pull_options = {enable_partial_images = "false", use_hard_links = "false", ostree_repos=""}
+pull_options = {enable_partial_images = "true", use_hard_links = "false", ostree_repos=""}
 
 # Remap-UIDs/GIDs is the mapping from UIDs/GIDs as they should appear inside of
 # a container, to the UIDs/GIDs as they should appear outside of the container,


### PR DESCRIPTION
by default enable pulling a partial image, it is still possible to disable the feature through the configuration file.

@rhatdan @mtrmac 