### PR TITLE
overlay: drop FHGFSFs from network file systems

### DIFF
--- a/drivers/overlay/.#overlay.go
+++ b/drivers/overlay/.#overlay.go
@@ -1,0 +1,1 @@
+gscrivano@carbon.4886:1708280976

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -296,7 +296,7 @@ func isNetworkFileSystem(fsMagic graphdriver.FsMagic) bool {
 	// a bunch of network file systems...
 	case graphdriver.FsMagicNfsFs, graphdriver.FsMagicSmbFs, graphdriver.FsMagicAcfs,
 		graphdriver.FsMagicAfs, graphdriver.FsMagicCephFs, graphdriver.FsMagicCIFS,
-		graphdriver.FsMagicFHGFSFs, graphdriver.FsMagicGPFS, graphdriver.FsMagicIBRIX,
+		graphdriver.FsMagicGPFS, graphdriver.FsMagicIBRIX,
 		graphdriver.FsMagicKAFS, graphdriver.FsMagicLUSTRE, graphdriver.FsMagicNCP,
 		graphdriver.FsMagicNFSD, graphdriver.FsMagicOCFS2, graphdriver.FsMagicPANFS,
 		graphdriver.FsMagicPRLFS, graphdriver.FsMagicSMB2, graphdriver.FsMagicSNFS,


### PR DESCRIPTION
it seems to honor user namespaces, so no need to treat it as a network file system.

Feedback got as part of the discussion on the issue.

Closes: https://github.com/containers/storage/issues/1839