### PR TITLE
chunked: add chunk size to cache file

### DIFF
--- a/pkg/chunked/cache_linux_test.go
+++ b/pkg/chunked/cache_linux_test.go
@@ -130,7 +130,7 @@ func TestWriteCache(t *testing.T) {
 			if digest != r.Digest {
 				t.Error("wrong file found")
 			}
-			expectedLocation := generateFileLocation(r.Name, 0)
+			expectedLocation := generateFileLocation(r.Name, 0, uint64(r.Size))
 			location := cache.vdata[off : off+len]
 			if !bytes.Equal(location, expectedLocation) {
 				t.Errorf("wrong file found %q instead of %q", location, expectedLocation)
@@ -149,7 +149,7 @@ func TestWriteCache(t *testing.T) {
 			if digest != fingerprint {
 				t.Error("wrong file found")
 			}
-			expectedLocation = generateFileLocation(r.Name, 0)
+			expectedLocation = generateFileLocation(r.Name, 0, uint64(r.Size))
 			location = cache.vdata[off : off+len]
 			if !bytes.Equal(location, expectedLocation) {
 				t.Errorf("wrong file found %q instead of %q", location, expectedLocation)
@@ -164,7 +164,7 @@ func TestWriteCache(t *testing.T) {
 			if digest != r.ChunkDigest {
 				t.Error("wrong digest found")
 			}
-			expectedLocation := generateFileLocation(r.Name, uint64(r.ChunkOffset))
+			expectedLocation := generateFileLocation(r.Name, uint64(r.ChunkOffset), uint64(r.ChunkSize))
 			location := cache.vdata[off : off+len]
 			if !bytes.Equal(location, expectedLocation) {
 				t.Errorf("wrong file found %q instead of %q", location, expectedLocation)


### PR DESCRIPTION
include the chunk length in the generated  file location format, This enhancement is designed to facilitate the use of the cache by external tools which may not have knowledge of the chunk size.