### PR TITLE
Stop putting `user.overlay.*` into container layer

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -416,7 +416,7 @@ func ReadUserXattrToTarHeader(path string, hdr *tar.Header) error {
 		return err
 	}
 	for _, key := range xattrs {
-		if strings.HasPrefix(key, "user.") {
+		if strings.HasPrefix(key, "user.") && !strings.HasPrefix(key, "user.overlay.") {
 			value, err := system.Lgetxattr(path, key)
 			if err != nil {
 				if errors.Is(err, system.E2BIG) {


### PR DESCRIPTION
**EDIT its this known limitation of docker 25: https://docs.docker.com/engine/release-notes/25.0/#known-limitations**

To reprodce the bug caused by this attribute in docker rootless dind containers you can do

```
containerid="$(docker run -d --privileged --rm -it docker:dind-rootless)"
docker exec -it "$containerid" sh
DOCKER_HOST=unix:///var/run/user/1000/docker.sock docker run --rm -it  ghcr.io/catthehacker/ubuntu:act-latest-20240222
Unable to find image 'ghcr.io/catthehacker/ubuntu:act-latest-20240222' locally
act-latest-20240222: Pulling from catthehacker/ubuntu
6ddad66377a0: Already exists 
a8ffa4da65b6: Already exists 
6f031e49d16f: Already exists 
e8bedde87c3d: Already exists 
d1f12f89b682: Extracting  204.5MB/204.5MB
4ca545ee6d5d: Download complete 
docker: failed to register layer: lsetxattr user.overlay.origin /etc: operation not supported.
See 'docker run --help'.

```

_The old image was built with buildah release included in ubuntu 22.04_

_The newer image `ghcr.io/catthehacker/ubuntu:act-latest-20240228` is built with a patched buildah and works without issues_

References
- https://gitea.com/gitea/act_runner/issues/497
- https://github.com/catthehacker/docker_images/issues/122

It is possible that this is a bug in docker 25.x and not here, since older dind rootless images with 24.x and older are working

In the meantime I built my images with a fork of buildah using this patch, it is up to you to decide if this is a good or bad change.