### PR TITLE
Revert commit that breaks podman backwards compatibility

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -1706,6 +1706,10 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 	}
 
 	mergedDir := path.Join(workDirBase, "merged")
+	// Create the driver merged dir
+	if err := idtools.MkdirAs(mergedDir, 0o700, rootUID, rootGID); err != nil && !os.IsExist(err) {
+		return "", err
+	}
 	if count := d.ctr.Increment(mergedDir); count > 1 {
 		return mergedDir, nil
 	}


### PR DESCRIPTION


Revert "overlay: do not recreate "merged" dir"

This reverts commit https://github.com/containers/storage/commit/de38d80855503aac0c46de79b121588cb4d57966.

Podman upgrade tests are faiing because of this[1]. A start of container
created with a previous version is now failing because of the missing
merged dir.

A very simple reproducer is to run a container with a older versin then
update to one with this commit and try to start the container again:
podman run --name test quay.io/libpod/testimage:20240123 echo hi
<-- update podman to a storage version with the reverted commit
podman start -a test
<-- now failing while trying to mount the container

[1] https://api.cirrus-ci.com/v1/artifact/task/5918496639418368/html/upgrade_test-podman-fedora-39-root-host.log.html


