### PR TITLE
Cirrus-CI: Give success a name

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -116,6 +116,7 @@ debian_testing_task: &debian_testing
 
 
 lint_task:
+    alias: lint
     env:
         CIRRUS_WORKING_DIR: "/go/src/github.com/containers/storage"
     container:
@@ -134,6 +135,7 @@ lint_task:
 
 # Update metadata on VM images referenced by this repository state
 meta_task:
+    alias: meta
 
     container:
         image: "quay.io/libpod/imgts:latest"
@@ -156,6 +158,7 @@ meta_task:
 
 
 vendor_task:
+    alias: vendor
     container:
         image: golang
     modules_cache:
@@ -166,13 +169,20 @@ vendor_task:
 
 
 cross_task:
+    alias: cross
     container:
         image: golang:1.20
     build_script: make cross
 
 
-# Represent overall pass/fail status from required dependent tasks
+# Status aggregator for all tests.  This task simply ensures a defined
+# set of tasks all passed, and allows confirming that based on the status
+# of this task.
 success_task:
+    alias: success
+    # N/B: The prow merge-bot (tide) is sensitized to this exact name, DO NOT CHANGE IT.
+    # Ref: https://github.com/openshift/release/pull/49820
+    name: "Total Success"
     depends_on:
         - lint
         - fedora_testing


### PR DESCRIPTION
This and the referenced openshift/release PR will make prow (via the tide bot) block merges unless the success aggregation task is green. This must be configured independently from branch-protection rules which tide does/can not manage due to write-only access.