### PR TITLE
chunked: store cache as binary and use a bloom filter

### DIFF
--- a/pkg/chunked/bloom_filter.go
+++ b/pkg/chunked/bloom_filter.go
@@ -1,0 +1,84 @@
+package chunked
+
+import (
+	"encoding/binary"
+	"hash/crc32"
+	"io"
+)
+
+type bloomFilter struct {
+	bitArray []uint64
+	k        uint32
+}
+
+func newBloomFilter(size int, k uint32) *bloomFilter {
+	numElements := (size + 63) / 64
+	return &bloomFilter{
+		bitArray: make([]uint64, numElements),
+		k:        k,
+	}
+}
+
+func newBloomFilterFromArray(bitArray []uint64, k uint32) *bloomFilter {
+	return &bloomFilter{
+		bitArray: bitArray,
+		k:        k,
+	}
+}
+
+func (bf *bloomFilter) hashFn(item []byte, seed uint32) (uint64, uint64) {
+	if len(item) == 0 {
+		return 0, 0
+	}
+	mod := uint32(len(bf.bitArray) * 64)
+	seedSplit := seed % uint32(len(item))
+	hash := (crc32.ChecksumIEEE(item[:seedSplit]) ^ crc32.ChecksumIEEE(item[seedSplit:])) % mod
+	return uint64(hash / 64), uint64(1 << (hash % 64))
+}
+
+func (bf *bloomFilter) add(item []byte) {
+	for i := uint32(0); i < bf.k; i++ {
+		index, mask := bf.hashFn(item, i)
+		bf.bitArray[index] |= mask
+	}
+}
+
+func (bf *bloomFilter) maybeContains(item []byte) bool {
+	for i := uint32(0); i < bf.k; i++ {
+		index, mask := bf.hashFn(item, i)
+		if bf.bitArray[index]&mask == 0 {
+			return false
+		}
+	}
+	return true
+}
+
+func (bf *bloomFilter) writeTo(writer io.Writer) error {
+	if err := binary.Write(writer, binary.LittleEndian, uint64(len(bf.bitArray))); err != nil {
+		return err
+	}
+	if err := binary.Write(writer, binary.LittleEndian, uint32(bf.k)); err != nil {
+		return err
+	}
+	if err := binary.Write(writer, binary.LittleEndian, bf.bitArray); err != nil {
+		return err
+	}
+	return nil
+}
+
+func readBloomFilter(reader io.Reader) (*bloomFilter, error) {
+	var bloomFilterLen uint64
+	var k uint32
+
+	if err := binary.Read(reader, binary.LittleEndian, &bloomFilterLen); err != nil {
+		return nil, err
+	}
+	if err := binary.Read(reader, binary.LittleEndian, &k); err != nil {
+		return nil, err
+	}
+	bloomFilterArray := make([]uint64, bloomFilterLen)
+	if err := binary.Read(reader, binary.LittleEndian, &bloomFilterArray); err != nil {
+		return nil, err
+	}
+	return newBloomFilterFromArray(bloomFilterArray, k), nil
+}

--- a/pkg/chunked/bloom_filter_test.go
+++ b/pkg/chunked/bloom_filter_test.go
@@ -29,6 +29,7 @@ var (
 func initCache(sizeCache int) (*cacheFile, string, string, *bloomFilter) {
 	var tagsBuffer bytes.Buffer
 	var vdata bytes.Buffer
+	var fnames bytes.Buffer
 	tags := [][]byte{}
 	tagLen := 0
 	digestLen := 64
@@ -59,7 +60,7 @@ func initCache(sizeCache int) (*cacheFile, string, string, *bloomFilter) {
 	hash.Write([]byte("1"))
 	notPresentDigest = digester.Digest().String()
 
-	writeCacheFileToWriter(io.Discard, bloomFilter, tags, tagLen, digestLen, vdata, &tagsBuffer)
+	writeCacheFileToWriter(io.Discard, bloomFilter, tags, tagLen, digestLen, vdata, fnames, &tagsBuffer)
 
 	cache := &cacheFile{
 		digestLen: digestLen,

--- a/pkg/chunked/bloom_filter_test.go
+++ b/pkg/chunked/bloom_filter_test.go
@@ -59,7 +59,7 @@ func initCache(sizeCache int) (*cacheFile, string, string, *bloomFilter) {
 	hash.Write([]byte("1"))
 	notPresentDigest = digester.Digest().String()
 
-	writeCacheFileToWriter(io.Discard, tags, tagLen, digestLen, &vdata, &tagsBuffer)
+	writeCacheFileToWriter(io.Discard, bloomFilter, tags, tagLen, digestLen, vdata, &tagsBuffer)
 
 	cache := &cacheFile{
 		digestLen: digestLen,

--- a/pkg/chunked/bloom_filter_test.go
+++ b/pkg/chunked/bloom_filter_test.go
@@ -1,0 +1,126 @@
+package chunked
+
+import (
+	"bytes"
+	"io"
+	"testing"
+
+	digest "github.com/opencontainers/go-digest"
+	"github.com/stretchr/testify/assert"
+)
+
+var (
+	presentDigestInCache          string
+	notPresentDigestInCache       string
+	presentDigestInCacheBinary    []byte
+	notPresentDigestInCacheBinary []byte
+	preloadedCache                *cacheFile
+	preloadedbloomFilter          *bloomFilter
+	benchmarkN                    int = 100000
+)
+
+// Using 3 hashes functions and n/m = 10 gives a false positive rate of ~1.7%:
+// https://pages.cs.wisc.edu/~cao/papers/summary-cache/node8.html
+var (
+	factorNM     int    = 10
+	numberHashes uint32 = 3
+)
+
+func initCache(sizeCache int) (*cacheFile, string, string, *bloomFilter) {
+	var tagsBuffer bytes.Buffer
+	var vdata bytes.Buffer
+	tags := [][]byte{}
+	tagLen := 0
+	digestLen := 64
+	var presentDigest, notPresentDigest string
+
+	bloomFilter := newBloomFilter(sizeCache*factorNM, numberHashes)
+
+	digester := digest.Canonical.Digester()
+	hash := digester.Hash()
+	for i := 0; i < sizeCache; i++ {
+		hash.Write([]byte("1"))
+		d := digester.Digest().String()
+		digestLen = len(d)
+		presentDigest = d
+		tag, err := appendTag([]byte(d), 0, 0)
+		if err != nil {
+			panic(err)
+		}
+		tagLen = len(tag)
+		tags = append(tags, tag)
+		bd, err := makeBinaryDigest(d)
+		if err != nil {
+			panic(err)
+		}
+		bloomFilter.add(bd)
+	}
+
+	hash.Write([]byte("1"))
+	notPresentDigest = digester.Digest().String()
+
+	writeCacheFileToWriter(io.Discard, tags, tagLen, digestLen, &vdata, &tagsBuffer)
+
+	cache := &cacheFile{
+		digestLen: digestLen,
+		tagLen:    tagLen,
+		tags:      tagsBuffer.Bytes(),
+		vdata:     vdata.Bytes(),
+	}
+	return cache, presentDigest, notPresentDigest, bloomFilter
+}
+
+func init() {
+	var err error
+	preloadedCache, presentDigestInCache, notPresentDigestInCache, preloadedbloomFilter = initCache(10000)
+	presentDigestInCacheBinary, err = makeBinaryDigest(presentDigestInCache)
+	if err != nil {
+		panic(err)
+	}
+	notPresentDigestInCacheBinary, err = makeBinaryDigest(notPresentDigestInCache)
+	if err != nil {
+		panic(err)
+	}
+}
+
+func BenchmarkLookupBloomFilter(b *testing.B) {
+	for i := 0; i < benchmarkN; i++ {
+		if preloadedbloomFilter.maybeContains(notPresentDigestInCacheBinary) {
+			findTag(notPresentDigestInCache, preloadedCache)
+		}
+		if preloadedbloomFilter.maybeContains(presentDigestInCacheBinary) {
+			findTag(presentDigestInCache, preloadedCache)
+		}
+	}
+}
+
+func BenchmarkLookupBloomRaw(b *testing.B) {
+	for i := 0; i < benchmarkN; i++ {
+		findTag(notPresentDigestInCache, preloadedCache)
+		findTag(presentDigestInCache, preloadedCache)
+	}
+}
+
+func TestBloomFilter(t *testing.T) {
+	bloomFilter := newBloomFilter(1000, 1)
+	digester := digest.Canonical.Digester()
+	hash := digester.Hash()
+	for i := 0; i < 1000; i++ {
+		hash.Write([]byte("1"))
+		d := digester.Digest().String()
+		bd, err := makeBinaryDigest(d)
+		assert.NoError(t, err)
+		contains := bloomFilter.maybeContains(bd)
+		assert.False(t, contains)
+	}
+	for i := 0; i < 1000; i++ {
+		hash.Write([]byte("1"))
+		d := digester.Digest().String()
+		bd, err := makeBinaryDigest(d)
+		assert.NoError(t, err)
+		bloomFilter.add(bd)
+
+		contains := bloomFilter.maybeContains(bd)
+		assert.True(t, contains)
+	}
+}

--- a/pkg/chunked/cache_linux.go
+++ b/pkg/chunked/cache_linux.go
@@ -26,7 +26,7 @@ import (
 
 const (
 	cacheKey     = "chunked-manifest-cache"
-	cacheVersion = 2
+	cacheVersion = 3
 
 	digestSha256Empty = "sha256:e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
 

--- a/pkg/chunked/cache_linux_test.go
+++ b/pkg/chunked/cache_linux_test.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"path/filepath"
 	"reflect"
-	"strconv"
 	"strings"
 	"testing"
 
@@ -164,16 +163,11 @@ func TestWriteCache(t *testing.T) {
 				t.Error("wrong file found")
 			}
 			location := cache.vdata[off : off+lenTag]
-			parts := strings.SplitN(string(location), ":", 3)
-
-			assert.Equal(t, len(parts), 3)
-			offFile, err := strconv.ParseInt(parts[0], 10, 64)
-			assert.NoError(t, err)
-			fileSize, err := strconv.ParseInt(parts[1], 10, 64)
+			_, offFile, fileSize, err := parseFileLocation(location)
 			assert.NoError(t, err)
 
-			assert.Equal(t, fileSize, int64(r.Size))
-			assert.Equal(t, offFile, int64(0))
+			assert.Equal(t, fileSize, uint64(r.Size))
+			assert.Equal(t, offFile, uint64(0))
 
 			fingerprint, err := calculateHardLinkFingerprint(r)
 			if err != nil {
@@ -189,16 +183,11 @@ func TestWriteCache(t *testing.T) {
 				t.Error("wrong file found")
 			}
 			location = cache.vdata[off : off+lenTag]
-			parts = strings.SplitN(string(location), ":", 3)
-
-			assert.Equal(t, len(parts), 3)
-			offFile, err = strconv.ParseInt(parts[0], 10, 64)
-			assert.NoError(t, err)
-			fileSize, err = strconv.ParseInt(parts[1], 10, 64)
+			_, offFile, fileSize, err = parseFileLocation(location)
 			assert.NoError(t, err)
 
-			assert.Equal(t, fileSize, int64(r.Size))
-			assert.Equal(t, offFile, int64(0))
+			assert.Equal(t, fileSize, uint64(r.Size))
+			assert.Equal(t, offFile, uint64(0))
 		}
 		if r.ChunkDigest != "" {
 			// find the element in the cache by the chunk digest checksum

--- a/pkg/chunked/cache_linux_test.go
+++ b/pkg/chunked/cache_linux_test.go
@@ -133,8 +133,8 @@ func TestWriteCache(t *testing.T) {
 	if err != nil {
 		t.Errorf("got error from writeCache: %v", err)
 	}
-	if digest, _, _ := findTag("foobar", cache); digest != "" {
-		t.Error("found invalid tag")
+	if digest, _, _ := findTag("sha256:99fe908c699dc068438b23e28319cadff1f2153c3043bafb8e83a430bba0a2c2", cache); digest != "" {
+		t.Error("a present tag was not found")
 	}
 
 	for _, r := range toc {
@@ -230,4 +230,17 @@ func TestUnmarshalToc(t *testing.T) {
 	assert.Equal(t, toc.Entries[4].Name, "usr/lib/systemd/system/system-systemd\\x2dcryptsetup.slice", "invalid name escaped")
 	assert.Equal(t, toc.Entries[5].Name, "usr/lib/systemd/system/system-systemd\\x2dcryptsetup-hardlink.slice", "invalid name escaped")
 	assert.Equal(t, toc.Entries[5].Linkname, "usr/lib/systemd/system/system-systemd\\x2dcryptsetup.slice", "invalid link name escaped")
+}
+
+func TestMakeBinaryDigest(t *testing.T) {
+	binDigest, err := makeBinaryDigest("sha256:5891b5b522d5df086d0ff0b110fbd9d21bb4fc7163af34d08286a2e846f6be03")
+	assert.NoError(t, err)
+	expected := []byte{0x73, 0x68, 0x61, 0x32, 0x35, 0x36, 0x3a, 0x58, 0x91, 0xb5, 0xb5, 0x22, 0xd5, 0xdf, 0x8, 0x6d, 0xf, 0xf0, 0xb1, 0x10, 0xfb, 0xd9, 0xd2, 0x1b, 0xb4, 0xfc, 0x71, 0x63, 0xaf, 0x34, 0xd0, 0x82, 0x86, 0xa2, 0xe8, 0x46, 0xf6, 0xbe, 0x3}
+	assert.Equal(t, expected, binDigest)
+
+	_, err = makeBinaryDigest("sha256:foo")
+	assert.Error(t, err)
+
+	_, err = makeBinaryDigest("noAlgorithm")
+	assert.Error(t, err)
 }

--- a/pkg/chunked/cache_linux_test.go
+++ b/pkg/chunked/cache_linux_test.go
@@ -120,6 +120,21 @@ func (b *bigDataToBuffer) SetLayerBigData(id, key string, data io.Reader) error 
 	return err
 }
 
+func findTag(digest string, cacheFile *cacheFile) (string, uint64, uint64) {
+	binaryDigest, err := makeBinaryDigest(digest)
+	if err != nil {
+		return "", 0, 0
+	}
+	if len(binaryDigest) != cacheFile.digestLen {
+		return "", 0, 0
+	}
+	found, off, len := findBinaryTag(binaryDigest, cacheFile)
+	if found {
+		return digest, off, len
+	}
+	return "", 0, 0
+}
+
 func TestWriteCache(t *testing.T) {
 	toc, err := prepareCacheFile([]byte(jsonTOC), graphdriver.DifferOutputFormatDir)
 	if err != nil {


### PR DESCRIPTION
The bloom filter itself is useful to reduce page faults with the mmap'ed cache files, as it reduces lookups.

Storing the file as a binary instead reduces the file size considerably, with the `quay.io/giuseppe/zstd-chunked:fedora-{38,39,40}{,-updated}` images I see:

before:
```
# find -name '=Y2h1bmtlZC1tYW5pZmVzdC1jYWNoZQ==' -exec stat -c '%s' \{\} \;2547644
2575163
2547644
2476816
2462835
2533346
```

after:
```
# find -name '=Y2h1bmtlZC1tYW5pZmVzdC1jYWNoZQ==' -exec stat -c '%s' \{\} \;
1319206
1312332
1275803
1270629
1297565
```

so it is ~50% size reduction