### PR TITLE
fileutils: make (Le|E)xists return os.PathError

### DIFF
--- a/pkg/fileutils/exists_test.go
+++ b/pkg/fileutils/exists_test.go
@@ -28,6 +28,13 @@ func TestExist(t *testing.T) {
 		if err1 == nil {
 			return
 		}
+
+		var pathErr1 *os.PathError
+		var pathErr2 *os.PathError
+		assert.ErrorAs(t, err1, &pathErr1, "wrong error type")
+		assert.ErrorAs(t, err2, &pathErr2, "wrong error type")
+		assert.Equal(t, pathErr1.Path, pathErr1.Path, "different file path")
+
 		// on Linux validates that the syscall error is the same
 		if runtime.GOOS == "linux" {
 			var syscallErr1 syscall.Errno

--- a/pkg/fileutils/exists_unix.go
+++ b/pkg/fileutils/exists_unix.go
@@ -4,6 +4,8 @@
 package fileutils
 
 import (
+	"os"
+
 	"golang.org/x/sys/unix"
 )
 
@@ -12,7 +14,11 @@ import (
 func Exists(path string) error {
 	// It uses unix.Faccessat which is a faster operation compared to os.Stat for
 	// simply checking the existence of a file.
-	return unix.Faccessat(unix.AT_FDCWD, path, unix.F_OK, 0)
+	err := unix.Faccessat(unix.AT_FDCWD, path, unix.F_OK, 0)
+	if err != nil {
+		return &os.PathError{Op: "faccessat", Path: path, Err: err}
+	}
+	return nil
 }
 
 // Lexists checks whether a file or directory exists at the given path.
@@ -20,5 +26,9 @@ func Exists(path string) error {
 func Lexists(path string) error {
 	// It uses unix.Faccessat which is a faster operation compared to os.Stat for
 	// simply checking the existence of a file.
-	return unix.Faccessat(unix.AT_FDCWD, path, unix.F_OK, unix.AT_SYMLINK_NOFOLLOW)
+	err := unix.Faccessat(unix.AT_FDCWD, path, unix.F_OK, unix.AT_SYMLINK_NOFOLLOW)
+	if err != nil {
+		return &os.PathError{Op: "faccessat", Path: path, Err: err}
+	}
+	return nil
 }


### PR DESCRIPTION
wrap the returned error in a os.PathError so the error includes the file path.