### PR TITLE
Add support for drop-in config

### DIFF
--- a/store.go
+++ b/store.go
@@ -3710,7 +3710,7 @@ func DefaultConfigFile() (string, error) {
 // the configuration in storeOptions.
 // Deprecated: Use types.ReloadConfigurationFile, which can return an error.
 func ReloadConfigurationFile(configFile string, storeOptions *types.StoreOptions) {
-	_ = types.ReloadConfigurationFile(configFile, storeOptions)
+	_ = types.ReloadConfigurationFile(configFile, storeOptions, true)
 }
 
 // GetDefaultMountOptions returns the default mountoptions defined in container/storage

--- a/types/options_darwin.go
+++ b/types/options_darwin.go
@@ -8,8 +8,6 @@ const (
 	SystemConfigFile        = "/usr/share/containers/storage.conf"
 )
 
-var defaultOverrideConfigFile = "/etc/containers/storage.conf"
-
 // canUseRootlessOverlay returns true if the overlay driver can be used for rootless containers
 func canUseRootlessOverlay(home, runhome string) bool {
 	return false

--- a/types/options_freebsd.go
+++ b/types/options_freebsd.go
@@ -8,11 +8,6 @@ const (
 	SystemConfigFile        = "/usr/local/share/containers/storage.conf"
 )
 
-// defaultConfigFile path to the system wide storage.conf file
-var (
-	defaultOverrideConfigFile = "/usr/local/etc/containers/storage.conf"
-)
-
 // canUseRootlessOverlay returns true if the overlay driver can be used for rootless containers
 func canUseRootlessOverlay(home, runhome string) bool {
 	return false

--- a/types/options_linux.go
+++ b/types/options_linux.go
@@ -16,11 +16,6 @@ const (
 	SystemConfigFile        = "/usr/share/containers/storage.conf"
 )
 
-// defaultConfigFile path to the system wide storage.conf file
-var (
-	defaultOverrideConfigFile = "/etc/containers/storage.conf"
-)
-
 // canUseRootlessOverlay returns true if the overlay driver can be used for rootless containers
 func canUseRootlessOverlay(home, runhome string) bool {
 	// we check first for fuse-overlayfs since it is cheaper.

--- a/types/options_windows.go
+++ b/types/options_windows.go
@@ -8,11 +8,6 @@ const (
 	SystemConfigFile        = "/usr/share/containers/storage.conf"
 )
 
-// defaultConfigFile path to the system wide storage.conf file
-var (
-	defaultOverrideConfigFile = "/etc/containers/storage.conf"
-)
-
 // canUseRootlessOverlay returns true if the overlay driver can be used for rootless containers
 func canUseRootlessOverlay(home, runhome string) bool {
 	return false

--- a/types/utils.go
+++ b/types/utils.go
@@ -66,7 +66,7 @@ func reloadConfigurationFileIfNeeded(configFile string, storeOptions *StoreOptio
 		return
 	}
 
-	ReloadConfigurationFile(configFile, storeOptions)
+	ReloadConfigurationFile(configFile, storeOptions, true)
 
 	prevReloadConfig.storeOptions = storeOptions
 	prevReloadConfig.mod = mtime


### PR DESCRIPTION
Helps in use cases where a drop-in config could help by allowing users to update a subsection of the config instead of touching an entire config file. 

e.g.

1. https://github.com/containers/storage/issues/1306
2. https://github.com/openshift/enhancements/pull/1600/files#diff-10bfa811cdabc678cbfd947dbeaf04b63ebd24e8d9ab5a05c7abbb998cb72f8aR135
3. https://github.com/kubernetes/enhancements/issues/4191


