### PR TITLE
Refactor to make it clearer that we return the validated TOC value

### DIFF
--- a/pkg/chunked/compression_linux.go
+++ b/pkg/chunked/compression_linux.go
@@ -145,7 +145,7 @@ func readZstdChunkedManifest(blobStream ImageSourceSeekable, blobSize int64, toc
 
 	if offsetMetadata := annotations[internal.ManifestInfoKey]; offsetMetadata != "" {
 		var err error
-		footerData, err = internal.ReadFooterDataFromAnnotations(tocDigest, annotations)
+		footerData, err = internal.ReadFooterDataFromAnnotations(annotations)
 		if err != nil {
 			return nil, nil, 0, err
 		}
@@ -233,7 +233,7 @@ func readZstdChunkedManifest(blobStream ImageSourceSeekable, blobSize int64, toc
 		return nil, nil, 0, err
 	}
 
-	decodedBlob, err := decodeAndValidateBlob(manifest, footerData.LengthUncompressed, footerData.ChecksumAnnotation)
+	decodedBlob, err := decodeAndValidateBlob(manifest, footerData.LengthUncompressed, tocDigest.String())
 	if err != nil {
 		return nil, nil, 0, err
 	}

--- a/pkg/chunked/compression_linux.go
+++ b/pkg/chunked/compression_linux.go
@@ -135,7 +135,7 @@ func readEstargzChunkedManifest(blobStream ImageSourceSeekable, blobSize int64, 
 // readZstdChunkedManifest reads the zstd:chunked manifest from the seekable stream blobStream.  The blob total size must
 // be specified.
 // This function uses the io.github.containers.zstd-chunked. annotations when specified.
-func readZstdChunkedManifest(blobStream ImageSourceSeekable, blobSize int64, annotations map[string]string) ([]byte, []byte, int64, error) {
+func readZstdChunkedManifest(blobStream ImageSourceSeekable, blobSize int64, tocDigest digest.Digest, annotations map[string]string) ([]byte, []byte, int64, error) {
 	footerSize := int64(internal.FooterSizeSupported)
 	if blobSize <= footerSize {
 		return nil, nil, 0, errors.New("blob too small")
@@ -145,7 +145,7 @@ func readZstdChunkedManifest(blobStream ImageSourceSeekable, blobSize int64, ann
 
 	if offsetMetadata := annotations[internal.ManifestInfoKey]; offsetMetadata != "" {
 		var err error
-		footerData, err = internal.ReadFooterDataFromAnnotations(annotations)
+		footerData, err = internal.ReadFooterDataFromAnnotations(tocDigest, annotations)
 		if err != nil {
 			return nil, nil, 0, err
 		}

--- a/pkg/chunked/internal/compression.go
+++ b/pkg/chunked/internal/compression.go
@@ -231,13 +231,10 @@ func footerDataToBlob(footer ZstdChunkedFooterData) []byte {
 }
 
 // ReadFooterDataFromAnnotations reads the zstd:chunked footer data from the given annotations.
-func ReadFooterDataFromAnnotations(annotations map[string]string) (ZstdChunkedFooterData, error) {
+func ReadFooterDataFromAnnotations(tocDigest digest.Digest, annotations map[string]string) (ZstdChunkedFooterData, error) {
 	var footerData ZstdChunkedFooterData
 
-	footerData.ChecksumAnnotation = annotations[ManifestChecksumKey]
-	if footerData.ChecksumAnnotation == "" {
-		return footerData, fmt.Errorf("manifest checksum annotation %q not found", ManifestChecksumKey)
-	}
+	footerData.ChecksumAnnotation = tocDigest.String()
 
 	offsetMetadata := annotations[ManifestInfoKey]
 

--- a/pkg/chunked/internal/compression.go
+++ b/pkg/chunked/internal/compression.go
@@ -183,7 +183,6 @@ func WriteZstdChunkedManifest(dest io.Writer, outMetadata map[string]string, off
 		Offset:                     manifestOffset,
 		LengthCompressed:           uint64(len(compressedManifest)),
 		LengthUncompressed:         uint64(len(manifest)),
-		ChecksumAnnotation:         "", // unused
 		OffsetTarSplit:             uint64(tarSplitOffset),
 		LengthCompressedTarSplit:   uint64(len(tarSplitData.Data)),
 		LengthUncompressedTarSplit: uint64(tarSplitData.UncompressedSize),
@@ -207,7 +206,6 @@ type ZstdChunkedFooterData struct {
 	Offset             uint64
 	LengthCompressed   uint64
 	LengthUncompressed uint64
-	ChecksumAnnotation string // Only used when reading a layer, not when creating it
 
 	OffsetTarSplit             uint64
 	LengthCompressedTarSplit   uint64
@@ -231,10 +229,8 @@ func footerDataToBlob(footer ZstdChunkedFooterData) []byte {
 }
 
 // ReadFooterDataFromAnnotations reads the zstd:chunked footer data from the given annotations.
-func ReadFooterDataFromAnnotations(tocDigest digest.Digest, annotations map[string]string) (ZstdChunkedFooterData, error) {
+func ReadFooterDataFromAnnotations(annotations map[string]string) (ZstdChunkedFooterData, error) {
 	var footerData ZstdChunkedFooterData
-
-	footerData.ChecksumAnnotation = tocDigest.String()
 
 	offsetMetadata := annotations[ManifestInfoKey]
 

--- a/pkg/chunked/internal/compression_test.go
+++ b/pkg/chunked/internal/compression_test.go
@@ -15,7 +15,6 @@ func TestGenerateAndReadFooter(t *testing.T) {
 		Offset:                     2,
 		LengthCompressed:           3,
 		LengthUncompressed:         4,
-		ChecksumAnnotation:         "", // unused
 		OffsetTarSplit:             5,
 		LengthCompressedTarSplit:   6,
 		LengthUncompressedTarSplit: 7,

--- a/pkg/chunked/storage_linux.go
+++ b/pkg/chunked/storage_linux.go
@@ -25,6 +25,7 @@ import (
 	"github.com/containers/storage/pkg/archive"
 	"github.com/containers/storage/pkg/chunked/compressor"
 	"github.com/containers/storage/pkg/chunked/internal"
+	"github.com/containers/storage/pkg/chunked/toc"
 	"github.com/containers/storage/pkg/fsverity"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/system"
@@ -264,7 +265,7 @@ func GetDiffer(ctx context.Context, store storage.Store, blobDigest digest.Diges
 		return nil, errors.New("enable_partial_images not configured")
 	}
 
-	_, hasZstdChunkedTOC := annotations[internal.ManifestChecksumKey]
+	zstdChunkedTOCDigestString, hasZstdChunkedTOC := annotations[internal.ManifestChecksumKey]
 	estargzTOCDigestString, hasEstargzTOC := annotations[estargz.TOCJSONDigestAnnotation]
 
 	if hasZstdChunkedTOC && hasEstargzTOC {
@@ -272,7 +273,11 @@ func GetDiffer(ctx context.Context, store storage.Store, blobDigest digest.Diges
 	}
 
 	if hasZstdChunkedTOC {
-		return makeZstdChunkedDiffer(ctx, store, blobSize, annotations, iss, &storeOpts)
+		zstdChunkedTOCDigest, err := digest.Parse(zstdChunkedTOCDigestString)
+		if err != nil {
+			return nil, fmt.Errorf("parsing zstd:chunked TOC digest %q: %w", zstdChunkedTOCDigestString, err)
+		}
+		return makeZstdChunkedDiffer(ctx, store, blobSize, zstdChunkedTOCDigest, annotations, iss, &storeOpts)
 	}
 	if hasEstargzTOC {
 		estargzTOCDigest, err := digest.Parse(estargzTOCDigestString)
@@ -307,19 +312,14 @@ func makeConvertFromRawDiffer(ctx context.Context, store storage.Store, blobDige
 	}, nil
 }
 
-func makeZstdChunkedDiffer(ctx context.Context, store storage.Store, blobSize int64, annotations map[string]string, iss ImageSourceSeekable, storeOpts *types.StoreOptions) (*chunkedDiffer, error) {
-	manifest, tarSplit, tocOffset, err := readZstdChunkedManifest(iss, blobSize, annotations)
+func makeZstdChunkedDiffer(ctx context.Context, store storage.Store, blobSize int64, tocDigest digest.Digest, annotations map[string]string, iss ImageSourceSeekable, storeOpts *types.StoreOptions) (*chunkedDiffer, error) {
+	manifest, tarSplit, tocOffset, err := readZstdChunkedManifest(iss, blobSize, tocDigest, annotations)
 	if err != nil {
 		return nil, fmt.Errorf("read zstd:chunked manifest: %w", err)
 	}
 	layersCache, err := getLayersCache(store)
 	if err != nil {
 		return nil, err
-	}
-
-	tocDigest, err := digest.Parse(annotations[internal.ManifestChecksumKey])
-	if err != nil {
-		return nil, fmt.Errorf("parse TOC digest %q: %w", annotations[internal.ManifestChecksumKey], err)
 	}
 
 	return &chunkedDiffer{
@@ -1691,7 +1691,14 @@ func (c *chunkedDiffer) ApplyDiff(dest string, options *archive.TarOptions, diff
 		blobFile.Close()
 		blobFile = nil
 
-		manifest, tarSplit, tocOffset, err := readZstdChunkedManifest(fileSource, c.blobSize, annotations)
+		tocDigest, err := toc.GetTOCDigest(annotations)
+		if err != nil {
+			return graphdriver.DriverWithDifferOutput{}, fmt.Errorf("internal error: parsing just-created zstd:chunked TOC digest: %w", err)
+		}
+		if tocDigest == nil {
+			return graphdriver.DriverWithDifferOutput{}, fmt.Errorf("internal error: just-created zstd:chunked missing TOC digest")
+		}
+		manifest, tarSplit, tocOffset, err := readZstdChunkedManifest(fileSource, c.blobSize, *tocDigest, annotations)
 		if err != nil {
 			return graphdriver.DriverWithDifferOutput{}, fmt.Errorf("read zstd:chunked manifest: %w", err)
 		}

--- a/pkg/chunked/zstdchunked_test.go
+++ b/pkg/chunked/zstdchunked_test.go
@@ -12,8 +12,10 @@ import (
 	"testing"
 
 	"github.com/containers/storage/pkg/chunked/internal"
+	"github.com/containers/storage/pkg/chunked/toc"
 	"github.com/klauspost/compress/zstd"
 	"github.com/opencontainers/go-digest"
+	"github.com/stretchr/testify/require"
 )
 
 type seekable struct {
@@ -148,7 +150,10 @@ func TestGenerateAndParseManifest(t *testing.T) {
 		t:            t,
 	}
 
-	manifest, _, _, err := readZstdChunkedManifest(s, 8192, annotations)
+	tocDigest, err := toc.GetTOCDigest(annotations)
+	require.NoError(t, err)
+	require.NotNil(t, tocDigest)
+	manifest, _, _, err := readZstdChunkedManifest(s, 8192, *tocDigest, annotations)
 	if err != nil {
 		t.Error(err)
 	}


### PR DESCRIPTION
Primarily, this ensures that the value in `ApplyDiff`’s `DriverWithDifferOutput.TOCDigest` is really exactly the value we used to validate the digest, by only reading it once and passing it around.

That’s to simplify auditing and make the relationship clear, but it should not change behavior.

Incidentally, this also should fix #1886 — but I still think the binary footer code path should be removed entirely.

Cc: @giuseppe 