### PR TITLE
chunked: fix escape of space

### DIFF
--- a/pkg/chunked/dump/dump.go
+++ b/pkg/chunked/dump/dump.go
@@ -52,7 +52,7 @@ func escaped(val string, escape int) string {
 			if noescapeSpace {
 				hexEscape = !unicode.IsPrint(rune(c))
 			} else {
-				hexEscape = !unicode.IsGraphic(rune(c))
+				hexEscape = !unicode.IsPrint(rune(c)) || unicode.IsSpace(rune(c))
 			}
 		}
 

--- a/pkg/chunked/dump/dump_test.go
+++ b/pkg/chunked/dump/dump_test.go
@@ -14,7 +14,6 @@ func TestEscaped(t *testing.T) {
 		escape int
 		want   string
 	}{
-		{"Hello, World!", 0, "Hello, World!"},
 		{"12345", 0, "12345"},
 		{"", 0, ""},
 		{"\n", 0, "\\n"},
@@ -25,9 +24,12 @@ func TestEscaped(t *testing.T) {
 		{"foo=bar", ESCAPE_EQUAL, "foo\\x3dbar"},
 		{"-", ESCAPE_LONE_DASH, "\\x2d"},
 		{"\n", NOESCAPE_SPACE, "\\n"},
+		{" ", 0, "\\x20"},
 		{" ", NOESCAPE_SPACE, " "},
 		{"\t", NOESCAPE_SPACE, "\\t"},
 		{"\n\t", NOESCAPE_SPACE, "\\n\\t"},
+		{"Hello World!", 0, "Hello\\x20World!"},
+		{"Hello World!", NOESCAPE_SPACE, "Hello World!"},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
the code was copied from the composefs C version:

	if (noescape_space)
		hex_escape = !isprint(c);
	else
		hex_escape = !isgraph(c);

but unicode.IsGraphic() seems to behave differently and includes the space:

isgraph(' ') -> 0
unicode.IsGraphic(' ') -> true