### PR TITLE
overlay: support AdditionalImagesStore on vfs

### DIFF
--- a/drivers/aufs/aufs.go
+++ b/drivers/aufs/aufs.go
@@ -268,8 +268,8 @@ func (a *Driver) ListLayers() ([]string, error) {
 }
 
 // AdditionalImageStores returns additional image stores supported by the driver
-func (a *Driver) AdditionalImageStores() []string {
-	return nil
+func (a *Driver) AdditionalImageStores() ([]string, []string) {
+	return nil, nil
 }
 
 // CreateFromTemplate creates a layer with the same contents and parent as another layer.

--- a/drivers/btrfs/btrfs.go
+++ b/drivers/btrfs/btrfs.go
@@ -691,6 +691,6 @@ func (d *Driver) ListLayers() ([]string, error) {
 }
 
 // AdditionalImageStores returns additional image stores supported by the driver
-func (d *Driver) AdditionalImageStores() []string {
-	return nil
+func (d *Driver) AdditionalImageStores() ([]string, []string) {
+	return nil, nil
 }

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -138,7 +138,7 @@ type ProtoDriver interface {
 	Cleanup() error
 	// AdditionalImageStores returns additional image stores supported by the driver
 	// This API is experimental and can be changed without bumping the major version number.
-	AdditionalImageStores() []string
+	AdditionalImageStores() ([]string, []string)
 }
 
 // DiffDriver is the interface to use to implement graph diffs

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -1180,7 +1180,7 @@ func (d *Driver) dir(id string) string {
 }
 
 func (d *Driver) getAllImageStores() []string {
-	additionalImageStores := d.AdditionalImageStores()
+	additionalImageStores, _ := d.AdditionalImageStores()
 	if d.imageStore != "" {
 		additionalImageStores = append([]string{d.imageStore}, additionalImageStores...)
 	}
@@ -2282,8 +2282,8 @@ func (d *Driver) Changes(id string, idMappings *idtools.IDMappings, parent strin
 }
 
 // AdditionalImageStores returns additional image stores supported by the driver
-func (d *Driver) AdditionalImageStores() []string {
-	return d.options.imageStores
+func (d *Driver) AdditionalImageStores() ([]string, []string) {
+	return d.options.imageStores, []string{d.name}
 }
 
 // UpdateLayerIDMap updates ID mappings in a from matching the ones specified

--- a/drivers/vfs/driver.go
+++ b/drivers/vfs/driver.go
@@ -21,17 +21,20 @@ import (
 	"github.com/vbatts/tar-split/tar/storage"
 )
 
-const defaultPerms = os.FileMode(0o555)
+const (
+	defaultPerms = os.FileMode(0o555)
+	Name         = "vfs"
+)
 
 func init() {
-	graphdriver.MustRegister("vfs", Init)
+	graphdriver.MustRegister(Name, Init)
 }
 
 // Init returns a new VFS driver.
 // This sets the home directory for the driver and returns NaiveDiffDriver.
 func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) {
 	d := &Driver{
-		name:       "vfs",
+		name:       Name,
 		home:       home,
 		idMappings: idtools.NewIDMappingsFromMaps(options.UIDMaps, options.GIDMaps),
 		imageStore: options.ImageStore,
@@ -87,7 +90,7 @@ type Driver struct {
 }
 
 func (d *Driver) String() string {
-	return "vfs"
+	return Name
 }
 
 // Status is used for implementing the graphdriver.ProtoDriver interface. VFS does not currently have any status information.

--- a/drivers/vfs/driver.go
+++ b/drivers/vfs/driver.go
@@ -297,11 +297,11 @@ func (d *Driver) ListLayers() ([]string, error) {
 }
 
 // AdditionalImageStores returns additional image stores supported by the driver
-func (d *Driver) AdditionalImageStores() []string {
+func (d *Driver) AdditionalImageStores() ([]string, []string) {
 	if len(d.additionalHomes) > 0 {
-		return d.additionalHomes
+		return d.additionalHomes, []string{d.name}
 	}
-	return nil
+	return nil, []string{d.name}
 }
 
 // SupportsShifting tells whether the driver support shifting of the UIDs/GIDs in an userNS

--- a/drivers/windows/windows.go
+++ b/drivers/windows/windows.go
@@ -971,8 +971,8 @@ func (d *Driver) DiffGetter(id string) (graphdriver.FileGetCloser, error) {
 }
 
 // AdditionalImageStores returns additional image stores supported by the driver
-func (d *Driver) AdditionalImageStores() []string {
-	return nil
+func (d *Driver) AdditionalImageStores() ([]string, []string) {
+	return nil, nil
 }
 
 // UpdateLayerIDMap changes ownerships in the layer's filesystem tree from

--- a/drivers/zfs/zfs.go
+++ b/drivers/zfs/zfs.go
@@ -513,6 +513,6 @@ func (d *Driver) ListLayers() ([]string, error) {
 }
 
 // AdditionalImageStores returns additional image stores supported by the driver
-func (d *Driver) AdditionalImageStores() []string {
-	return nil
+func (d *Driver) AdditionalImageStores() ([]string, []string) {
+	return nil, nil
 }

--- a/store.go
+++ b/store.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"io/fs"
 	"os"
 	"path/filepath"
 	"reflect"
@@ -20,6 +21,7 @@ import (
 	drivers "github.com/containers/storage/drivers"
 	"github.com/containers/storage/pkg/archive"
 	"github.com/containers/storage/pkg/directory"
+	"github.com/containers/storage/pkg/fileutils"
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/ioutils"
 	"github.com/containers/storage/pkg/lockfile"
@@ -1005,6 +1007,10 @@ func (s *store) load() error {
 		for _, driver := range additionalGraphDrivers {
 			gipath := filepath.Join(store, driver+"-images")
 			var ris roImageStore
+			if err := fileutils.Exists(gipath); err != nil && errors.Is(err, fs.ErrNotExist) {
+				// if the store doesn't exist, ignore it
+				continue
+			}
 			// both the graphdriver and the imagestore must be used read-write.
 			if store == s.imageStoreDir || store == s.graphRoot {
 				imageStore, err := newImageStore(gipath)


### PR DESCRIPTION
extend the overlay driver to use an additional image store on a vfs backend.

It works as overlay can simply use the upper most vfs layer as the only lower layer for the container.

It is useful on a system already protected by composefs, to distribute images as part of the operating system itself.  The read-only store cannot be on overlay since composefs itself is using overlay, and it causes conflicts with whiteout files