### PR TITLE
chunked: downgrade loading cache file msg to info

### DIFF
--- a/pkg/chunked/cache_linux.go
+++ b/pkg/chunked/cache_linux.go
@@ -268,7 +268,7 @@ func (c *layersCache) load() error {
 		// try to read the existing cache file.
 		l, err := c.loadLayerCache(r.ID)
 		if err != nil {
-			logrus.Warningf("Error loading cache file for layer %q: %v", r.ID, err)
+			logrus.Infof("Error loading cache file for layer %q: %v", r.ID, err)
 		}
 		if l != nil {
 			newLayers = append(newLayers, l)


### PR DESCRIPTION
it can happen for any reason, like for example using a new cache file format, in this case the file is recreated with the last version. This is internal only and should not be displayed by default.

Closes: https://github.com/containers/storage/issues/1905