### PR TITLE
Update to Go 1.21

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -171,7 +171,7 @@ vendor_task:
 cross_task:
     alias: cross
     container:
-        image: golang:1.20
+        image: golang:1.21
     build_script: make cross
 
 
@@ -191,6 +191,6 @@ success_task:
         - vendor
         - cross
     container:
-        image: golang:1.20
+        image: golang:1.21
     clone_script: 'mkdir -p "$CIRRUS_WORKING_DIR"'  # Source code not needed
     script: /bin/true

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,7 @@
-go 1.20
+go 1.21
+
+// Warning: Ensure the "go" and "toolchain" versions match exactly to prevent unwanted auto-updates
+toolchain go1.21.0
 
 module github.com/containers/storage
 

--- a/go.sum
+++ b/go.sum
@@ -131,6 +131,7 @@ golang.org/x/net v0.0.0-20190311183353-d8887717615a/go.mod h1:t9HGtf8HONx5eT2rtn
 golang.org/x/net v0.0.0-20190404232315-eb5bcb51f2a3/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20201110031124-69a78807bb2b/go.mod h1:sp8m0HH+o8qH0wwXwYZr8TS3Oi6o0r6Gce1SSxlDquU=
 golang.org/x/net v0.17.0 h1:pVaXccu2ozPjCXewfr1S7xza/zcXTity9cCdXQYSjIM=
+golang.org/x/net v0.17.0/go.mod h1:NxSsAGuq816PNPmqtQdLE42eU2Fs7NoRIZrHJAlaCOE=
 golang.org/x/oauth2 v0.0.0-20180821212333-d2e6202438be/go.mod h1:N/0e6XlmueqKjAGxoOufVs8QHGRruUQn6yWY3a++T0U=
 golang.org/x/sync v0.0.0-20180314180146-1d60e4601c6f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20181108010431-42b317875d0f/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
@@ -148,6 +149,7 @@ golang.org/x/sys v0.19.0/go.mod h1:/VUhepiaJMQUp4+oa/7Zr1D23ma6VTLIYjOOTFZPUcA=
 golang.org/x/text v0.3.0/go.mod h1:NqM8EUOU14njkJ3fqMW+pc6Ldnwhi/IjpwHt7yyuwOQ=
 golang.org/x/text v0.3.3/go.mod h1:5Zoc/QRtKVWzQhOtBMvqHzDpF6irO9z98xDceosuGiQ=
 golang.org/x/text v0.13.0 h1:ablQoSUd0tRdKxZewP80B+BaqeKJuVhuRxj/dkrun3k=
+golang.org/x/text v0.13.0/go.mod h1:TvPlkZtksWOMsz7fbANvkp4WM8x/WCo/om8BMLbz+aE=
 golang.org/x/tools v0.0.0-20180917221912-90fa682c2a6e/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190114222345-bf090417da8b/go.mod h1:n7NCudcB/nEzxVGmLbDWY5pfWTLqBcC2KZ6jyYvM4mQ=
 golang.org/x/tools v0.0.0-20190226205152-f727befe758c/go.mod h1:9Yl7xja0Znq3iFh3HoIrodX9oNMXvdceNzlUR8zjMvY=

--- a/idset_test.go
+++ b/idset_test.go
@@ -6,17 +6,7 @@ import (
 
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/google/go-intervals/intervalset"
-	"github.com/stretchr/testify/assert"
 )
-
-func TestMinMaxInt(t *testing.T) {
-	assert.Equal(t, 5, minInt(5, 8))
-	assert.Equal(t, 3, minInt(10, 3))
-	assert.Equal(t, 2, minInt(2, 2))
-	assert.Equal(t, 8, maxInt(5, 8))
-	assert.Equal(t, 10, maxInt(10, 3))
-	assert.Equal(t, 2, maxInt(2, 2))
-}
 
 func allIntervals(s *idSet) []interval {
 	iterator, cancel := s.iterator()

--- a/pkg/archive/changes_test.go
+++ b/pkg/archive/changes_test.go
@@ -14,13 +14,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func max(x, y int) int {
-	if x >= y {
-		return x
-	}
-	return y
-}
-
 func copyDir(src, dst string) error {
 	cmd := exec.Command("cp", "-a", src, dst)
 	if runtime.GOOS == solaris {


### PR DESCRIPTION
We are already doing that for downstream consumers, so let’s do it here as well, so that we not surprised by a dependency requiring Go 1.21 suddenly forcing an upgrade.

This is a _very minimal_ update; the code could benefit from some of the new features, e.g. quite a few of the global `sync.Once` variables could be replaced by `sync.OnceValue`/`sync.OnceValues`.

Cc: @nalind @cevich 