### PR TITLE
chunked: skip cache file for non-partial layers

### DIFF
--- a/pkg/chunked/cache_linux.go
+++ b/pkg/chunked/cache_linux.go
@@ -199,6 +199,8 @@ func (c *layersCache) loadLayerCache(layerID string) (_ *layer, errRet error) {
 	return c.createLayer(layerID, cacheFile, mmapBuffer)
 }
 
+// createCacheFileFromTOC attempts to create a cache file for the specified layer.
+// If a TOC is not available, the cache won't be created and nil is returned.
 func (c *layersCache) createCacheFileFromTOC(layerID string) (*layer, error) {
 	clFile, err := c.store.LayerBigData(layerID, chunkedLayerDataKey)
 	if err != nil && !errors.Is(err, os.ErrNotExist) {
@@ -219,6 +221,10 @@ func (c *layersCache) createCacheFileFromTOC(layerID string) (*layer, error) {
 	}
 	manifestReader, err := c.store.LayerBigData(layerID, bigDataKey)
 	if err != nil {
+		// the cache file is not needed since there is no manifest file.
+		if errors.Is(err, os.ErrNotExist) {
+			return nil, nil
+		}
 		return nil, err
 	}
 	defer manifestReader.Close()


### PR DESCRIPTION
if the layer does not have a manifest TOC, just ignore it instead of raising a warning.  There is no need to create a cache file since there is no manifest file to parse.

Closes: https://github.com/containers/storage/issues/1909