### PR TITLE
CI VMs: bump to new versions with tmpfs /tmp

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -23,7 +23,7 @@ env:
     # GCE project where images live
     IMAGE_PROJECT: "libpod-218412"
     # VM Image built in containers/automation_images
-    IMAGE_SUFFIX: "c20240320t153921z-f39f38d13"
+    IMAGE_SUFFIX: "c20240411t124913z-f39f38d13"
     FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"
     DEBIAN_CACHE_IMAGE_NAME: "debian-${IMAGE_SUFFIX}"
 


### PR DESCRIPTION
For the last long time, Fedora CI VMs have had a disk /tmp. Real-world setups typically have tmpfs /tmp. This switches to CI VMs that reflect the real world.

See https://github.com/containers/automation_images/pull/340