### PR TITLE
overlay: lock staging directories

### DIFF
--- a/cmd/containers-storage/diff.go
+++ b/cmd/containers-storage/diff.go
@@ -185,8 +185,14 @@ func applyDiffUsingStagingDirectory(flags *mflag.FlagSet, action string, m stora
 	if err != nil {
 		return 1, err
 	}
-	if err := m.ApplyDiffFromStagingDirectory(layer, out.Target, out, &options); err != nil {
-		m.CleanupStagingDirectory(out.Target)
+
+	applyStagedLayerArgs := storage.ApplyStagedLayerOptions{
+		ID:          layer,
+		DiffOutput:  out,
+		DiffOptions: &options,
+	}
+	if _, err := m.ApplyStagedLayer(applyStagedLayerArgs); err != nil {
+		m.CleanupStagedLayer(out)
 		return 1, err
 	}
 	return 0, nil

--- a/deprecated.go
+++ b/deprecated.go
@@ -208,8 +208,6 @@ type LayerStore interface {
 	ParentOwners(id string) (uids, gids []int, err error)
 	ApplyDiff(to string, diff io.Reader) (int64, error)
 	ApplyDiffWithDiffer(to string, options *drivers.ApplyDiffOpts, differ drivers.Differ) (*drivers.DriverWithDifferOutput, error)
-	CleanupStagingDirectory(stagingDirectory string) error
-	ApplyDiffFromStagingDirectory(id, stagingDirectory string, diffOutput *drivers.DriverWithDifferOutput, options *drivers.ApplyDiffOpts) error
 	DifferTarget(id string) (string, error)
 	LoadLocked() error
 	PutAdditionalLayer(id string, parentLayer *Layer, names []string, aLayer drivers.AdditionalLayer) (layer *Layer, err error)

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -876,9 +876,9 @@ func (d *Driver) Metadata(id string) (map[string]string, error) {
 	return metadata, nil
 }
 
-// Cleanup any state created by overlay which should be cleaned when daemon
-// is being shutdown. For now, we just have to unmount the bind mounted
-// we had created.
+// Cleanup any state created by overlay which should be cleaned when
+// the storage is being shutdown.  The only state created by the driver
+// is the bind mount on the home directory.
 func (d *Driver) Cleanup() error {
 	_ = os.RemoveAll(filepath.Join(d.home, stagingDir))
 	return mount.Unmount(d.home)
@@ -2050,8 +2050,8 @@ func supportsDataOnlyLayersCached(home, runhome string) (bool, error) {
 	return supportsDataOnly, err
 }
 
-// ApplyDiff applies the changes in the new layer using the specified function
-func (d *Driver) ApplyDiffWithDiffer(id, parent string, options *graphdriver.ApplyDiffWithDifferOpts, differ graphdriver.Differ) (output graphdriver.DriverWithDifferOutput, err error) {
+// ApplyDiffWithDiffer applies the changes in the new layer using the specified function
+func (d *Driver) ApplyDiffWithDiffer(id, parent string, options *graphdriver.ApplyDiffWithDifferOpts, differ graphdriver.Differ) (output graphdriver.DriverWithDifferOutput, errRet error) {
 	var idMappings *idtools.IDMappings
 	if options != nil {
 		idMappings = options.Mappings

--- a/pkg/lockfile/lockfile.go
+++ b/pkg/lockfile/lockfile.go
@@ -138,6 +138,20 @@ func (l *LockFile) RLock() {
 	l.lock(readLock)
 }
 
+// TryLock attempts to lock the lockfile as a writer.  Panic if the lock is a read-only one.
+func (l *LockFile) TryLock() error {
+	if l.ro {
+		panic("can't take write lock on read-only lock file")
+	} else {
+		return l.tryLock(writeLock)
+	}
+}
+
+// TryRLock attempts to lock the lockfile as a reader.
+func (l *LockFile) TryRLock() error {
+	return l.tryLock(readLock)
+}
+
 // Unlock unlocks the lockfile.
 func (l *LockFile) Unlock() {
 	l.stateMutex.Lock()
@@ -401,9 +415,47 @@ func (l *LockFile) lock(lType lockType) {
 		// Optimization: only use the (expensive) syscall when
 		// the counter is 0.  In this case, we're either the first
 		// reader lock or a writer lock.
-		lockHandle(l.fd, lType)
+		lockHandle(l.fd, lType, false)
 	}
 	l.lockType = lType
 	l.locked = true
 	l.counter++
+}
+
+// lock locks the lockfile via syscall based on the specified type and
+// command.
+func (l *LockFile) tryLock(lType lockType) error {
+	var success bool
+	if lType == readLock {
+		success = l.rwMutex.TryRLock()
+	} else {
+		success = l.rwMutex.TryLock()
+	}
+	if !success {
+		return fmt.Errorf("resource temporarily unavailable")
+	}
+	l.stateMutex.Lock()
+	defer l.stateMutex.Unlock()
+	if l.counter == 0 {
+		// If we're the first reference on the lock, we need to open the file again.
+		fd, err := openLock(l.file, l.ro)
+		if err != nil {
+			l.rwMutex.Unlock()
+			return err
+		}
+		l.fd = fd
+
+		// Optimization: only use the (expensive) syscall when
+		// the counter is 0.  In this case, we're either the first
+		// reader lock or a writer lock.
+		if err = lockHandle(l.fd, lType, true); err != nil {
+			closeHandle(fd)
+			l.rwMutex.Unlock()
+			return err
+		}
+	}
+	l.lockType = lType
+	l.locked = true
+	l.counter++
+	return nil
 }

--- a/pkg/lockfile/lockfile.go
+++ b/pkg/lockfile/lockfile.go
@@ -133,7 +133,7 @@ func (l *LockFile) Lock() {
 	}
 }
 
-// LockRead locks the lockfile as a reader.
+// RLock locks the lockfile as a reader.
 func (l *LockFile) RLock() {
 	l.lock(readLock)
 }

--- a/pkg/lockfile/lockfile_unix.go
+++ b/pkg/lockfile/lockfile_unix.go
@@ -74,7 +74,7 @@ func openHandle(path string, mode int) (fileHandle, error) {
 	return fileHandle(fd), err
 }
 
-func lockHandle(fd fileHandle, lType lockType) {
+func lockHandle(fd fileHandle, lType lockType, nonblocking bool) error {
 	fType := unix.F_RDLCK
 	if lType != readLock {
 		fType = unix.F_WRLCK
@@ -85,11 +85,23 @@ func lockHandle(fd fileHandle, lType lockType) {
 		Start:  0,
 		Len:    0,
 	}
-	for unix.FcntlFlock(uintptr(fd), unix.F_SETLKW, &lk) != nil {
+	cmd := unix.F_SETLKW
+	if nonblocking {
+		cmd = unix.F_SETLK
+	}
+	for {
+		err := unix.FcntlFlock(uintptr(fd), cmd, &lk)
+		if err == nil || nonblocking {
+			return err
+		}
 		time.Sleep(10 * time.Millisecond)
 	}
 }
 
 func unlockAndCloseHandle(fd fileHandle) {
+	unix.Close(int(fd))
+}
+
+func closeHandle(fd fileHandle) {
 	unix.Close(int(fd))
 }

--- a/pkg/lockfile/lockfile_windows.go
+++ b/pkg/lockfile/lockfile_windows.go
@@ -81,19 +81,30 @@ func openHandle(path string, mode int) (fileHandle, error) {
 	return fileHandle(fd), err
 }
 
-func lockHandle(fd fileHandle, lType lockType) {
+func lockHandle(fd fileHandle, lType lockType, nonblocking bool) error {
 	flags := 0
 	if lType != readLock {
 		flags = windows.LOCKFILE_EXCLUSIVE_LOCK
 	}
+	if nonblocking {
+		flags |= windows.LOCKFILE_FAIL_IMMEDIATELY
+	}
 	ol := new(windows.Overlapped)
 	if err := windows.LockFileEx(windows.Handle(fd), uint32(flags), reserved, allBytes, allBytes, ol); err != nil {
+		if nonblocking {
+			return err
+		}
 		panic(err)
 	}
+	return nil
 }
 
 func unlockAndCloseHandle(fd fileHandle) {
 	ol := new(windows.Overlapped)
 	windows.UnlockFileEx(windows.Handle(fd), reserved, allBytes, allBytes, ol)
+	closeHandle(fd)
+}
+
+func closeHandle(fd fileHandle) {
 	windows.Close(windows.Handle(fd))
 }

--- a/store.go
+++ b/store.go
@@ -330,17 +330,9 @@ type Store interface {
 	// successfully applied with ApplyDiffFromStagingDirectory.
 	ApplyDiffWithDiffer(to string, options *drivers.ApplyDiffWithDifferOpts, differ drivers.Differ) (*drivers.DriverWithDifferOutput, error)
 
-	// ApplyDiffFromStagingDirectory uses stagingDirectory to create the diff.
-	// Deprecated: it will be removed soon.  Use ApplyStagedLayer instead.
-	ApplyDiffFromStagingDirectory(to, stagingDirectory string, diffOutput *drivers.DriverWithDifferOutput, options *drivers.ApplyDiffWithDifferOpts) error
-
-	// CleanupStagingDirectory cleanups the staging directory.  It can be used to cleanup the staging directory on errors
-	// Deprecated: it will be removed soon.  Use CleanupStagedLayer instead.
-	CleanupStagingDirectory(stagingDirectory string) error
-
-	// ApplyStagedLayer combines the functions of CreateLayer and ApplyDiffFromStagingDirectory,
-	// marking the layer for automatic removal if applying the diff fails
-	// for any reason.
+	// ApplyStagedLayer combines the functions of creating a layer and using the staging
+	// directory to populate it.
+	// It marks the layer for automatic removal if applying the diff fails for any reason.
 	ApplyStagedLayer(args ApplyStagedLayerOptions) (*Layer, error)
 
 	// CleanupStagedLayer cleanups the staging directory.  It can be used to cleanup the staging directory on errors
@@ -3002,19 +2994,6 @@ func (s *store) Diff(from, to string, options *DiffOptions) (io.ReadCloser, erro
 	return nil, ErrLayerUnknown
 }
 
-func (s *store) ApplyDiffFromStagingDirectory(to, stagingDirectory string, diffOutput *drivers.DriverWithDifferOutput, options *drivers.ApplyDiffWithDifferOpts) error {
-	if stagingDirectory != diffOutput.Target {
-		return fmt.Errorf("invalid value for staging directory, it must be the same as the differ target directory")
-	}
-	_, err := writeToLayerStore(s, func(rlstore rwLayerStore) (struct{}, error) {
-		if !rlstore.Exists(to) {
-			return struct{}{}, ErrLayerUnknown
-		}
-		return struct{}{}, rlstore.applyDiffFromStagingDirectory(to, diffOutput, options)
-	})
-	return err
-}
-
 func (s *store) ApplyStagedLayer(args ApplyStagedLayerOptions) (*Layer, error) {
 	rlstore, rlstores, err := s.bothLayerStoreKinds()
 	if err != nil {
@@ -3046,13 +3025,6 @@ func (s *store) ApplyStagedLayer(args ApplyStagedLayerOptions) (*Layer, error) {
 	}
 	layer, _, err = s.putLayer(rlstore, rlstores, args.ID, args.ParentLayer, args.Names, args.MountLabel, args.Writeable, args.LayerOptions, nil, &slo)
 	return layer, err
-}
-
-func (s *store) CleanupStagingDirectory(stagingDirectory string) error {
-	_, err := writeToLayerStore(s, func(rlstore rwLayerStore) (struct{}, error) {
-		return struct{}{}, rlstore.CleanupStagingDirectory(stagingDirectory)
-	})
-	return err
 }
 
 func (s *store) CleanupStagedLayer(diffOutput *drivers.DriverWithDifferOutput) error {


### PR DESCRIPTION
lock any staging directory while it is being used so that another process cannot delete it.
    
Now the Cleanup() function deletes only the staging directories that are not locked by any other user.
    
Closes: https://github.com/containers/storage/issues/1915
    
Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
