### PR TITLE
pkg/unshare: fix implicit declaration of basename function

### DIFF
--- a/pkg/unshare/unshare.c
+++ b/pkg/unshare/unshare.c
@@ -15,6 +15,7 @@
 #include <termios.h>
 #include <errno.h>
 #include <unistd.h>
+#include <libgen.h>
 #include <sys/vfs.h>
 #include <sys/mount.h>
 #include <linux/limits.h>


### PR DESCRIPTION
[POSIX requires the prototype of the basename function to be declared in the libgen.h header file](https://pubs.opengroup.org/onlinepubs/007904975/functions/basename.html). Therefore, this header file needs to be included in order to make use of this function in a POSIX environment. The `unshare.c` source file uses this function here (without including `libgen.h`):

https://github.com/containers/storage/blob/b193f00d94a4540dc6bbdf73f409ab8f3f00004d/pkg/unshare/unshare.c#L235

Some implementations, e.g. glibc, also define this function in string.h. However, musl (for example) [only defines it in libgen.h](https://git.musl-libc.org/cgit/musl/commit/?id=725e17ed6dff4d0cd22487bb64470881e86a92e7) causing it be implicitly declared (with an `int` return type) which [is by no means cosmetic and can lead to severe miscompilations](https://wiki.gentoo.org/wiki/Modern_C_porting#Is_this_cosmetic.3F).