### PR TITLE
Fix assignment of quota IDs for XFS quotas

### DIFF
--- a/drivers/quota/projectquota_supported.go
+++ b/drivers/quota/projectquota_supported.go
@@ -19,16 +19,6 @@ package quota
 #include <linux/quota.h>
 #include <linux/dqblk_xfs.h>
 
-#ifndef FS_XFLAG_PROJINHERIT
-struct fsxattr {
-	__u32		fsx_xflags;
-	__u32		fsx_extsize;
-	__u32		fsx_nextents;
-	__u32		fsx_projid;
-	unsigned char	fsx_pad[12];
-};
-#define FS_XFLAG_PROJINHERIT	0x00000200
-#endif
 #ifndef FS_IOC_FSGETXATTR
 #define FS_IOC_FSGETXATTR		_IOR ('X', 31, struct fsxattr)
 #endif
@@ -357,7 +347,6 @@ func setProjectID(targetPath string, projectID uint32) error {
 		return fmt.Errorf("failed to get projid for %s: %w", targetPath, errno)
 	}
 	fsx.fsx_projid = C.__u32(projectID)
-	fsx.fsx_xflags |= C.FS_XFLAG_PROJINHERIT
 	_, _, errno = unix.Syscall(unix.SYS_IOCTL, getDirFd(dir), C.FS_IOC_FSSETXATTR,
 		uintptr(unsafe.Pointer(&fsx)))
 	if errno != 0 {


### PR DESCRIPTION
It appears that setting the FS_XFLAG_PROJINHERIT flag when assigning a quota to a directory overrides any requested project ID set (even in the same ioctl!) if a parent directory already has a project ID. And our parent directories always do, as we set the top-level directory to the base project ID for all volumes.

The result of this is that the inherit flag forces every subdirectory to share the same project ID, and thus every time we set a quota, it's set for everything using quotas - not just the single directory we wanted to set it on.

Lacking the inherit flag made me a bit worried about subdirectories, but I can confirm that the quotas themselves are still function (creating a subdirectory in a dir with a quota set and creating files in that directory still applies their size towards the quota). There's a chance it would impact doing a separate project ID in a subdirectory of a subdirectory but from my read of the code that isn't supported at all right now.

Fixes RH Jira RHEL-18038