### PR TITLE
[Additional Layer Store] Use TOCDigest as ID of each layer (patch for c/storage)

### DIFF
--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -298,8 +298,8 @@ type AdditionalLayerStoreDriver interface {
 	Driver
 
 	// LookupAdditionalLayer looks up additional layer store by the specified
-	// digest and ref and returns an object representing that layer.
-	LookupAdditionalLayer(d digest.Digest, ref string) (AdditionalLayer, error)
+	// TOC digest and ref and returns an object representing that layer.
+	LookupAdditionalLayer(tocDigest digest.Digest, ref string) (AdditionalLayer, error)
 
 	// LookupAdditionalLayer looks up additional layer store by the specified
 	// ID and returns an object representing that layer.

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -885,11 +885,11 @@ func (d *Driver) Cleanup() error {
 }
 
 // LookupAdditionalLayer looks up additional layer store by the specified
-// digest and ref and returns an object representing that layer.
+// TOC digest and ref and returns an object representing that layer.
 // This API is experimental and can be changed without bumping the major version number.
 // TODO: to remove the comment once it's no longer experimental.
-func (d *Driver) LookupAdditionalLayer(dgst digest.Digest, ref string) (graphdriver.AdditionalLayer, error) {
-	l, err := d.getAdditionalLayerPath(dgst, ref)
+func (d *Driver) LookupAdditionalLayer(tocDigest digest.Digest, ref string) (graphdriver.AdditionalLayer, error) {
+	l, err := d.getAdditionalLayerPath(tocDigest, ref)
 	if err != nil {
 		return nil, err
 	}
@@ -2405,14 +2405,14 @@ func nameWithSuffix(name string, number int) string {
 	return fmt.Sprintf("%s%d", name, number)
 }
 
-func (d *Driver) getAdditionalLayerPath(dgst digest.Digest, ref string) (string, error) {
+func (d *Driver) getAdditionalLayerPath(tocDigest digest.Digest, ref string) (string, error) {
 	refElem := base64.StdEncoding.EncodeToString([]byte(ref))
 	for _, ls := range d.options.layerStores {
 		ref := ""
 		if ls.withReference {
 			ref = refElem
 		}
-		target := path.Join(ls.path, ref, dgst.String())
+		target := path.Join(ls.path, ref, tocDigest.String())
 		// Check if all necessary files exist
 		for _, p := range []string{
 			filepath.Join(target, "diff"),
@@ -2427,7 +2427,7 @@ func (d *Driver) getAdditionalLayerPath(dgst digest.Digest, ref string) (string,
 		return target, nil
 	}
 
-	return "", fmt.Errorf("additional layer (%q, %q) not found: %w", dgst, ref, graphdriver.ErrLayerUnknown)
+	return "", fmt.Errorf("additional layer (%q, %q) not found: %w", tocDigest, ref, graphdriver.ErrLayerUnknown)
 }
 
 func (d *Driver) releaseAdditionalLayerByID(id string) {

--- a/store.go
+++ b/store.go
@@ -549,14 +549,14 @@ type Store interface {
 	GetDigestLock(digest.Digest) (Locker, error)
 
 	// LayerFromAdditionalLayerStore searches the additional layer store and returns an object
-	// which can create a layer with the specified digest associated with the specified image
+	// which can create a layer with the specified TOC digest associated with the specified image
 	// reference. Note that this hasn't been stored to this store yet: the actual creation of
 	// a usable layer is done by calling the returned object's PutAs() method.  After creating
 	// a layer, the caller must then call the object's Release() method to free any temporary
 	// resources which were allocated for the object by this method or the object's PutAs()
 	// method.
 	// This API is experimental and can be changed without bumping the major version number.
-	LookupAdditionalLayer(d digest.Digest, imageref string) (AdditionalLayer, error)
+	LookupAdditionalLayer(tocDigest digest.Digest, imageref string) (AdditionalLayer, error)
 
 	// Tries to clean up remainders of previous containers or layers that are not
 	// references in the json files. These can happen in the case of unclean
@@ -578,8 +578,8 @@ type AdditionalLayer interface {
 	// layer store.
 	PutAs(id, parent string, names []string) (*Layer, error)
 
-	// UncompressedDigest returns the uncompressed digest of this layer
-	UncompressedDigest() digest.Digest
+	// TOCDigest returns the digest of TOC of this layer. Returns "" if unknown.
+	TOCDigest() digest.Digest
 
 	// CompressedSize returns the compressed size of this layer
 	CompressedSize() int64
@@ -3213,7 +3213,7 @@ func (s *store) Layer(id string) (*Layer, error) {
 	return nil, ErrLayerUnknown
 }
 
-func (s *store) LookupAdditionalLayer(d digest.Digest, imageref string) (AdditionalLayer, error) {
+func (s *store) LookupAdditionalLayer(tocDigest digest.Digest, imageref string) (AdditionalLayer, error) {
 	var adriver drivers.AdditionalLayerStoreDriver
 	if err := func() error { // A scope for defer
 		if err := s.startUsingGraphDriver(); err != nil {
@@ -3230,7 +3230,7 @@ func (s *store) LookupAdditionalLayer(d digest.Digest, imageref string) (Additio
 		return nil, err
 	}
 
-	al, err := adriver.LookupAdditionalLayer(d, imageref)
+	al, err := adriver.LookupAdditionalLayer(tocDigest, imageref)
 	if err != nil {
 		if errors.Is(err, drivers.ErrLayerUnknown) {
 			return nil, ErrLayerUnknown
@@ -3255,8 +3255,8 @@ type additionalLayer struct {
 	s       *store
 }
 
-func (al *additionalLayer) UncompressedDigest() digest.Digest {
-	return al.layer.UncompressedDigest
+func (al *additionalLayer) TOCDigest() digest.Digest {
+	return al.layer.TOCDigest
 }
 
 func (al *additionalLayer) CompressedSize() int64 {


### PR DESCRIPTION
Needs: https://github.com/containers/image/pull/2416

This commit changes the store implementation to use TOCDigset as the ID of each layer. This ensures the runtime to pass TOCDigest to the FUSE backend everytime requiring a layer.

This commit modifies c/storage's `LookupAdditionalLayer` to receive a TOCDigest as one of the arguments. Then that TOCDigest is passed to Additional Layer Store as one of the path elements of the FUSE fs. For example, the extracted view of a layer diff contents is provided in the following path:

```
 <mountpoint>/base64(imageref)/<TOCDigest>/diff
```

Additional Layer Store implementation attempts lazy pulling of the layer that has the specified TOCDigest in the image.
If that image doesn't contain the layer matching to the TOCDigest, accessing to the layer directly results in an error.

Example draft implementation of Additional Layer Store is at https://github.com/containerd/stargz-snapshotter/pull/1673
