### PR TITLE
archive: always fix mode for root dir with ForceMask

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -1113,8 +1113,11 @@ loop:
 		}
 	}
 
-	if options.ForceMask != nil && rootHdr != nil {
-		value := fmt.Sprintf("%d:%d:0%o", rootHdr.Uid, rootHdr.Gid, rootHdr.Mode)
+	if options.ForceMask != nil {
+		value := "0:0:0755"
+		if rootHdr != nil {
+			value = fmt.Sprintf("%d:%d:0%o", rootHdr.Uid, rootHdr.Gid, rootHdr.Mode)
+		}
 		if err := system.Lsetxattr(dest, idtools.ContainersOverrideXattr, []byte(value), 0); err != nil {
 			return err
 		}


### PR DESCRIPTION
We used to override the root directory permission only when the record for the root directory exists in the archive. However, docker.io/ubuntu:jammy-20240427 lacks such a record and not overriding the root directory permission makes all other permission overrides invalid.