### PR TITLE
chunked: change auto merge threshold to 1024

### DIFF
--- a/pkg/chunked/storage_linux.go
+++ b/pkg/chunked/storage_linux.go
@@ -42,7 +42,7 @@ import (
 
 const (
 	maxNumberMissingChunks  = 1024
-	autoMergePartsThreshold = 128 // if the gap between two ranges is below this threshold, automatically merge them.
+	autoMergePartsThreshold = 1024 // if the gap between two ranges is below this threshold, automatically merge them.
 	newFileFlags            = (unix.O_CREAT | unix.O_TRUNC | unix.O_EXCL | unix.O_WRONLY)
 	containersOverrideXattr = "user.containers.override_stat"
 	bigDataKey              = "zstd-chunked-manifest"


### PR DESCRIPTION
Increase the threshold for auto-merging parts from 128 to 1024. This change aims to reduce the number of parts in an HTTP multi-range request, thus increasing the likelihood that the server will accept the request.

The previous threshold of 128 often resulted in a large number of small ranges, which could lead to HTTP multi-range requests being rejected by servers due to the excessive number of parts.

It partially addresses the reported issue.

Reported-by: https://github.com/containers/storage/issues/1928