### PR TITLE
dump: use the sanitized path for root check

### DIFF
--- a/pkg/chunked/dump/dump.go
+++ b/pkg/chunked/dump/dump.go
@@ -113,7 +113,7 @@ func dumpNode(out io.Writer, added map[string]struct{}, links map[string]int, ve
 	path := sanitizeName(entry.Name)
 
 	parent := filepath.Dir(path)
-	if _, found := added[parent]; !found && entry.Name != "/" {
+	if _, found := added[parent]; !found && path != "/" {
 		parentEntry := &internal.FileMetadata{
 			Name: parent,
 			Type: internal.TypeDir,


### PR DESCRIPTION
otherwise if the root is stored as "./", it ends up adding the root node twice causing mkcomposefs to fail.

Closes: https://github.com/containers/storage/issues/1941