### PR TITLE
chunked: Fix two minor linter issues

### DIFF
--- a/pkg/chunked/cache_linux.go
+++ b/pkg/chunked/cache_linux.go
@@ -901,7 +901,7 @@ func unmarshalToc(manifest []byte) (*internal.TOC, error) {
 			s := iter.ReadString()
 			d, err := digest.Parse(s)
 			if err != nil {
-				return nil, fmt.Errorf("Invalid tarSplitDigest %q: %w", s, err)
+				return nil, fmt.Errorf("invalid tarSplitDigest %q: %w", s, err)
 			}
 			toc.TarSplitDigest = d
 

--- a/pkg/chunked/filesystem_linux.go
+++ b/pkg/chunked/filesystem_linux.go
@@ -107,7 +107,7 @@ func setFileAttrs(dirfd int, file *os.File, mode os.FileMode, metadata *fileMeta
 	if metadata.skipSetAttrs {
 		return nil
 	}
-	if file == nil || file.Fd() < 0 {
+	if file == nil {
 		return errors.New("invalid file")
 	}
 	fd := int(file.Fd())


### PR DESCRIPTION
My IDE runs a linter by default, and these two show up. For the file one, it's because `Fd()` returns `uintptr` which is unsigned and can't be negative.  IOW, a `File` object should always be a valid opened fd.