### PR TITLE
chunked: use Fprint instead of Fprintf

### DIFF
--- a/pkg/chunked/dump/dump.go
+++ b/pkg/chunked/dump/dump.go
@@ -170,7 +170,7 @@ func dumpNode(out io.Writer, added map[string]struct{}, links map[string]int, ve
 		}
 	}
 
-	if _, err := fmt.Fprintf(out, escapedOptional(payload, ESCAPE_LONE_DASH)); err != nil {
+	if _, err := fmt.Fprint(out, escapedOptional(payload, ESCAPE_LONE_DASH)); err != nil {
 		return err
 	}
 
@@ -184,7 +184,7 @@ func dumpNode(out io.Writer, added map[string]struct{}, links map[string]int, ve
 		return err
 	}
 	digest := verityDigests[payload]
-	if _, err := fmt.Fprintf(out, escapedOptional(digest, ESCAPE_LONE_DASH)); err != nil {
+	if _, err := fmt.Fprint(out, escapedOptional(digest, ESCAPE_LONE_DASH)); err != nil {
 		return err
 	}
 


### PR DESCRIPTION
replace Fprintf(file, string) with Fprint(file, string) since the argument is a raw string and it should not be treated as a formatting directive.

Closes: https://github.com/containers/storage/issues/1955