### PR TITLE
pkg/archive.statDifferent(): care about mtime for directories

### DIFF
--- a/pkg/archive/changes_test.go
+++ b/pkg/archive/changes_test.go
@@ -338,6 +338,7 @@ func TestChangesDirsMutated(t *testing.T) {
 	expectedChanges := []Change{
 		{"/dir1", ChangeDelete},
 		{"/dir2", ChangeModify},
+		{"/dir3", ChangeModify},
 		{"/dirnew", ChangeAdd},
 		{"/file1", ChangeDelete},
 		{"/file2", ChangeModify},

--- a/pkg/archive/changes_unix.go
+++ b/pkg/archive/changes_unix.go
@@ -31,9 +31,9 @@ func statDifferent(oldStat *system.StatT, oldInfo *FileInfo, newStat *system.Sta
 		ownerChanged ||
 		oldStat.Rdev() != newStat.Rdev() ||
 		oldStat.Flags() != newStat.Flags() ||
+		!sameFsTimeSpec(oldStat.Mtim(), newStat.Mtim()) ||
 		// Don't look at size for dirs, its not a good measure of change
-		(oldStat.Mode()&unix.S_IFDIR != unix.S_IFDIR &&
-			(!sameFsTimeSpec(oldStat.Mtim(), newStat.Mtim()) || (oldStat.Size() != newStat.Size()))) {
+		(!sameFsTimeSpec(oldStat.Mtim(), newStat.Mtim()) || (oldStat.Size() != newStat.Size())) {
 		return true
 	}
 	return false


### PR DESCRIPTION
When considering changes, don't ignore differences between directories when their mtimes are the only thing we check that's changed.  This creates a difference in behavior between the vfs and overlay drivers that shows up in build conformance tests, such as in https://github.com/containers/buildah/pull/5492.