### PR TITLE
chunked: honor store configuration

### DIFF
--- a/pkg/chunked/storage_linux.go
+++ b/pkg/chunked/storage_linux.go
@@ -151,7 +151,7 @@ func GetDiffer(ctx context.Context, store storage.Store, blobDigest digest.Diges
 		return nil, err
 	}
 
-	if !parseBooleanPullOption(&storeOpts, "enable_partial_images", true) {
+	if !parseBooleanPullOption(storeOpts.PullOptions, "enable_partial_images", true) {
 		return nil, errors.New("enable_partial_images not configured")
 	}
 
@@ -181,7 +181,7 @@ func GetDiffer(ctx context.Context, store storage.Store, blobDigest digest.Diges
 }
 
 func makeConvertFromRawDiffer(ctx context.Context, store storage.Store, blobDigest digest.Digest, blobSize int64, annotations map[string]string, iss ImageSourceSeekable, storeOpts *types.StoreOptions) (*chunkedDiffer, error) {
-	if !parseBooleanPullOption(storeOpts, "convert_images", false) {
+	if !parseBooleanPullOption(storeOpts.PullOptions, "convert_images", false) {
 		return nil, errors.New("convert_images not configured")
 	}
 
@@ -974,8 +974,8 @@ type hardLinkToCreate struct {
 	metadata *fileMetadata
 }
 
-func parseBooleanPullOption(storeOpts *storage.StoreOptions, name string, def bool) bool {
-	if value, ok := storeOpts.PullOptions[name]; ok {
+func parseBooleanPullOption(pullOptions map[string]string, name string, def bool) bool {
+	if value, ok := pullOptions[name]; ok {
 		return strings.ToLower(value) == "true"
 	}
 	return def
@@ -1233,7 +1233,7 @@ func (c *chunkedDiffer) ApplyDiff(dest string, options *archive.TarOptions, diff
 
 	// When the hard links deduplication is used, file attributes are ignored because setting them
 	// modifies the source file as well.
-	useHardLinks := parseBooleanPullOption(c.storeOpts, "use_hard_links", false)
+	useHardLinks := parseBooleanPullOption(c.storeOpts.PullOptions, "use_hard_links", false)
 
 	// List of OSTree repositories to use for deduplication
 	ostreeRepos := strings.Split(c.storeOpts.PullOptions["ostree_repos"], ":")

--- a/pkg/chunked/storage_linux.go
+++ b/pkg/chunked/storage_linux.go
@@ -93,7 +93,7 @@ type chunkedDiffer struct {
 
 	blobSize int64
 
-	storeOpts *types.StoreOptions
+	pullOptions map[string]string
 
 	useFsVerity     graphdriver.DifferFsVerity
 	fsVerityDigests map[string]string
@@ -167,21 +167,21 @@ func GetDiffer(ctx context.Context, store storage.Store, blobDigest digest.Diges
 		if err != nil {
 			return nil, fmt.Errorf("parsing zstd:chunked TOC digest %q: %w", zstdChunkedTOCDigestString, err)
 		}
-		return makeZstdChunkedDiffer(ctx, store, blobSize, zstdChunkedTOCDigest, annotations, iss, &storeOpts)
+		return makeZstdChunkedDiffer(ctx, store, blobSize, zstdChunkedTOCDigest, annotations, iss, storeOpts.PullOptions)
 	}
 	if hasEstargzTOC {
 		estargzTOCDigest, err := digest.Parse(estargzTOCDigestString)
 		if err != nil {
 			return nil, fmt.Errorf("parsing estargz TOC digest %q: %w", estargzTOCDigestString, err)
 		}
-		return makeEstargzChunkedDiffer(ctx, store, blobSize, estargzTOCDigest, iss, &storeOpts)
+		return makeEstargzChunkedDiffer(ctx, store, blobSize, estargzTOCDigest, iss, storeOpts.PullOptions)
 	}
 
-	return makeConvertFromRawDiffer(ctx, store, blobDigest, blobSize, annotations, iss, &storeOpts)
+	return makeConvertFromRawDiffer(ctx, store, blobDigest, blobSize, annotations, iss, storeOpts.PullOptions)
 }
 
-func makeConvertFromRawDiffer(ctx context.Context, store storage.Store, blobDigest digest.Digest, blobSize int64, annotations map[string]string, iss ImageSourceSeekable, storeOpts *types.StoreOptions) (*chunkedDiffer, error) {
-	if !parseBooleanPullOption(storeOpts.PullOptions, "convert_images", false) {
+func makeConvertFromRawDiffer(ctx context.Context, store storage.Store, blobDigest digest.Digest, blobSize int64, annotations map[string]string, iss ImageSourceSeekable, pullOptions map[string]string) (*chunkedDiffer, error) {
+	if !parseBooleanPullOption(pullOptions, "convert_images", false) {
 		return nil, errors.New("convert_images not configured")
 	}
 
@@ -197,12 +197,12 @@ func makeConvertFromRawDiffer(ctx context.Context, store storage.Store, blobDige
 		convertToZstdChunked: true,
 		copyBuffer:           makeCopyBuffer(),
 		layersCache:          layersCache,
-		storeOpts:            storeOpts,
+		pullOptions:          pullOptions,
 		stream:               iss,
 	}, nil
 }
 
-func makeZstdChunkedDiffer(ctx context.Context, store storage.Store, blobSize int64, tocDigest digest.Digest, annotations map[string]string, iss ImageSourceSeekable, storeOpts *types.StoreOptions) (*chunkedDiffer, error) {
+func makeZstdChunkedDiffer(ctx context.Context, store storage.Store, blobSize int64, tocDigest digest.Digest, annotations map[string]string, iss ImageSourceSeekable, pullOptions map[string]string) (*chunkedDiffer, error) {
 	manifest, toc, tarSplit, tocOffset, err := readZstdChunkedManifest(iss, tocDigest, annotations)
 	if err != nil {
 		return nil, fmt.Errorf("read zstd:chunked manifest: %w", err)
@@ -221,14 +221,14 @@ func makeZstdChunkedDiffer(ctx context.Context, store storage.Store, blobSize in
 		layersCache:     layersCache,
 		manifest:        manifest,
 		toc:             toc,
-		storeOpts:       storeOpts,
+		pullOptions:     pullOptions,
 		stream:          iss,
 		tarSplit:        tarSplit,
 		tocOffset:       tocOffset,
 	}, nil
 }
 
-func makeEstargzChunkedDiffer(ctx context.Context, store storage.Store, blobSize int64, tocDigest digest.Digest, iss ImageSourceSeekable, storeOpts *types.StoreOptions) (*chunkedDiffer, error) {
+func makeEstargzChunkedDiffer(ctx context.Context, store storage.Store, blobSize int64, tocDigest digest.Digest, iss ImageSourceSeekable, pullOptions map[string]string) (*chunkedDiffer, error) {
 	manifest, tocOffset, err := readEstargzChunkedManifest(iss, blobSize, tocDigest)
 	if err != nil {
 		return nil, fmt.Errorf("read zstd:chunked manifest: %w", err)
@@ -246,7 +246,7 @@ func makeEstargzChunkedDiffer(ctx context.Context, store storage.Store, blobSize
 		fileType:        fileTypeEstargz,
 		layersCache:     layersCache,
 		manifest:        manifest,
-		storeOpts:       storeOpts,
+		pullOptions:     pullOptions,
 		stream:          iss,
 		tocOffset:       tocOffset,
 	}, nil
@@ -1233,10 +1233,10 @@ func (c *chunkedDiffer) ApplyDiff(dest string, options *archive.TarOptions, diff
 
 	// When the hard links deduplication is used, file attributes are ignored because setting them
 	// modifies the source file as well.
-	useHardLinks := parseBooleanPullOption(c.storeOpts.PullOptions, "use_hard_links", false)
+	useHardLinks := parseBooleanPullOption(c.pullOptions, "use_hard_links", false)
 
 	// List of OSTree repositories to use for deduplication
-	ostreeRepos := strings.Split(c.storeOpts.PullOptions["ostree_repos"], ":")
+	ostreeRepos := strings.Split(c.pullOptions["ostree_repos"], ":")
 
 	whiteoutConverter := archive.GetWhiteoutConverter(options.WhiteoutFormat, options.WhiteoutData)
 


### PR DESCRIPTION
honor the pull_options configuration set for the current store instead of using the default configuration.
    
Needed by Podman to override the pull options from the command line for a single command.
    
Signed-off-by: Giuseppe Scrivano <gscrivan@redhat.com>
