### PR TITLE
Decide on tar-split usage based on trusted data in TOC

### DIFF
--- a/pkg/chunked/compression_linux.go
+++ b/pkg/chunked/compression_linux.go
@@ -209,18 +209,26 @@ func readZstdChunkedManifest(blobStream ImageSourceSeekable, tocDigest digest.Di
 	}
 
 	decodedTarSplit := []byte{}
-	if tarSplitChunk.Offset > 0 {
-		// we must consume the data to not block the producer
+	if toc.TarSplitDigest != "" {
+		if tarSplitChunk.Offset <= 0 {
+			return nil, nil, nil, 0, fmt.Errorf("TOC requires a tar-split, but the %s annotation does not describe a position", internal.TarSplitInfoKey)
+		}
 		tarSplit, err := readBlob(tarSplitChunk.Length)
 		if err != nil {
 			return nil, nil, nil, 0, err
 		}
-		// but ignore it when the digest is not present, because we can’t authenticate it against tocDigest
-		if toc.TarSplitDigest != "" {
-			decodedTarSplit, err = decodeAndValidateBlob(tarSplit, tarSplitLengthUncompressed, toc.TarSplitDigest.String())
-			if err != nil {
-				return nil, nil, nil, 0, fmt.Errorf("validating and decompressing tar-split: %w", err)
-			}
+		decodedTarSplit, err = decodeAndValidateBlob(tarSplit, tarSplitLengthUncompressed, toc.TarSplitDigest.String())
+		if err != nil {
+			return nil, nil, nil, 0, fmt.Errorf("validating and decompressing tar-split: %w", err)
+		}
+	} else if tarSplitChunk.Offset > 0 {
+		// We must ignore the tar-split when the digest is not present in the TOC, because we can’t authenticate it.
+		//
+		// But if we asked for the chunk, now we must consume the data to not block the producer.
+		// Ideally the GetBlobAt API should be changed so that this is not necessary.
+		_, err := readBlob(tarSplitChunk.Length)
+		if err != nil {
+			return nil, nil, nil, 0, err
 		}
 	}
 	return decodedBlob, toc, decodedTarSplit, int64(manifestChunk.Offset), err


### PR DESCRIPTION
Don't ignore the tar-split when the TOC requires one, otherwise we could deduplicate a layer without tar-split with a layer with tar-split.

Fixes a bug discovered during review in https://github.com/containers/storage/pull/1936#pullrequestreview-2094139878 .

Cc: @giuseppe 