### PR TITLE
pkg/archive.statDifferent(): fix the previous change

### DIFF
--- a/pkg/archive/changes_unix.go
+++ b/pkg/archive/changes_unix.go
@@ -33,7 +33,7 @@ func statDifferent(oldStat *system.StatT, oldInfo *FileInfo, newStat *system.Sta
 		oldStat.Flags() != newStat.Flags() ||
 		!sameFsTimeSpec(oldStat.Mtim(), newStat.Mtim()) ||
 		// Don't look at size for dirs, its not a good measure of change
-		(!sameFsTimeSpec(oldStat.Mtim(), newStat.Mtim()) || (oldStat.Size() != newStat.Size())) {
+		((oldStat.Mode()&unix.S_IFDIR != unix.S_IFDIR) && (oldStat.Size() != newStat.Size())) {
 		return true
 	}
 	return false


### PR DESCRIPTION
Make the logic match the comment for real this time: instead of comparing the datestamps a second time, check the ModeType bits.  h/t to @mtrmac for spotting it at https://github.com/containers/storage/pull/1962/files#r1636517199.