### PR TITLE
overlay: drop check for mount_program AND force_mask

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -375,9 +375,6 @@ func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) 
 			return nil, err
 		}
 	} else {
-		if opts.forceMask != nil {
-			return nil, errors.New("'force_mask' is supported only with 'mount_program'")
-		}
 		// check if they are running over btrfs, aufs, overlay, or ecryptfs
 		switch fsMagic {
 		case graphdriver.FsMagicAufs, graphdriver.FsMagicOverlay, graphdriver.FsMagicEcryptfs:
@@ -983,6 +980,10 @@ func (d *Driver) CreateReadWrite(id, parent string, opts *graphdriver.CreateOpts
 		opts = &graphdriver.CreateOpts{
 			StorageOpt: map[string]string{},
 		}
+	}
+
+	if d.options.forceMask != nil && d.options.mountProgram == "" {
+		return fmt.Errorf("overlay: force_mask option for writeable layers is only supported with a mount_program")
 	}
 
 	if _, ok := opts.StorageOpt["size"]; !ok {

--- a/drivers/overlay/overlay_test.go
+++ b/drivers/overlay/overlay_test.go
@@ -5,7 +5,6 @@ package overlay
 
 import (
 	"os"
-	"os/exec"
 	"testing"
 
 	graphdriver "github.com/containers/storage/drivers"
@@ -42,15 +41,10 @@ func skipIfNaive(t *testing.T) {
 // This test is placed before TestOverlaySetup() because it uses driver options
 // different from the other tests.
 func TestContainersOverlayXattr(t *testing.T) {
-	path, err := exec.LookPath("fuse-overlayfs")
-	if err != nil {
-		t.Skipf("fuse-overlayfs unavailable")
-	}
-
-	driver := graphtest.GetDriver(t, driverName, "force_mask=700", "mount_program="+path)
+	driver := graphtest.GetDriver(t, driverName, "force_mask=700")
 	defer graphtest.PutDriver(t)
 	require.NoError(t, driver.Create("lower", "", nil))
-	graphtest.ReconfigureDriver(t, driverName, "mount_program="+path)
+	graphtest.ReconfigureDriver(t, driverName)
 	require.NoError(t, driver.Create("upper", "lower", nil))
 
 	root, err := driver.Get("upper", graphdriver.MountOpts{})


### PR DESCRIPTION
Using a mount_program is not a necessary requirement for users creating a shared store, as the store can be consumed by other users.

Stop enforcing this rule.