### PR TITLE
Fix warnings (SA9003, SA4023, SA1019)

### DIFF
--- a/drivers/copy/copy_linux.go
+++ b/drivers/copy/copy_linux.go
@@ -50,13 +50,13 @@ func CopyRegularToFile(srcPath string, dstFile *os.File, fileinfo os.FileInfo, c
 	defer srcFile.Close()
 
 	if *copyWithFileClone {
-		_, _, err = unix.Syscall(unix.SYS_IOCTL, dstFile.Fd(), C.FICLONE, srcFile.Fd())
-		if err == nil {
+		_, _, errno := unix.Syscall(unix.SYS_IOCTL, dstFile.Fd(), C.FICLONE, srcFile.Fd())
+		if errno == 0 {
 			return nil
 		}
 
 		*copyWithFileClone = false
-		if err == unix.EXDEV {
+		if errno == unix.EXDEV {
 			*copyWithFileRange = false
 		}
 	}

--- a/drivers/graphtest/graphbench_unix.go
+++ b/drivers/graphtest/graphbench_unix.go
@@ -175,8 +175,7 @@ func DriverBenchDiffApplyN(b *testing.B, fileCount int, drivername string, drive
 		arch.Close()
 
 		if applyDiffSize != diffSize {
-			// TODO: enforce this
-			// b.Fatalf("Apply diff size different, got %d, expected %s", applyDiffSize, diffSize)
+			b.Fatalf("Apply diff size different, got %d, expected %d\n", applyDiffSize, diffSize)
 		}
 		if err := checkManyFiles(driver, diff, fileCount, 6); err != nil {
 			b.Fatal(err)

--- a/lockfile_compat.go
+++ b/lockfile_compat.go
@@ -5,7 +5,7 @@ import (
 )
 
 // Deprecated: Use lockfile.*LockFile.
-type Locker = lockfile.Locker //lint:ignore SA1019 // lockfile.Locker is deprecated
+type Locker = lockfile.Locker //nolint:staticcheck // SA1019 lockfile.Locker is deprecated
 
 // Deprecated: Use lockfile.GetLockFile.
 func GetLockfile(path string) (lockfile.Locker, error) {


### PR DESCRIPTION
This PR fixes warnings (SA9003, SA4023, SA1019) found by `golangci` when the `staticcheck` linter is enabled. 

Partially fixes:
- #1579


