### PR TITLE
Fix deprecated use of `capability.NewPid` (SA1019)

### DIFF
--- a/pkg/chrootarchive/chroot_linux.go
+++ b/pkg/chrootarchive/chroot_linux.go
@@ -19,8 +19,11 @@ import (
 // Old root is removed after the call to pivot_root so it is no longer available under the new root.
 // This is similar to how libcontainer sets up a container's rootfs
 func chroot(path string) (err error) {
-	caps, err := capability.NewPid(0)
+	caps, err := capability.NewPid2(0)
 	if err != nil {
+		return err
+	}
+	if err := caps.Load(); err != nil {
 		return err
 	}
 

--- a/pkg/unshare/unshare_linux.go
+++ b/pkg/unshare/unshare_linux.go
@@ -526,8 +526,11 @@ func MaybeReexecUsingUserNamespace(evenForRoot bool) {
 	} else {
 		// If we have CAP_SYS_ADMIN, then we don't need to create a new namespace in order to be able
 		// to use unshare(), so don't bother creating a new user namespace at this point.
-		capabilities, err := capability.NewPid(0)
+		capabilities, err := capability.NewPid2(0)
+		bailOnError(err, "Initializing a new Capabilities object of pid 0")
+		err = capabilities.Load()
 		bailOnError(err, "Reading the current capabilities sets")
+
 		if capabilities.Get(capability.EFFECTIVE, capability.CAP_SYS_ADMIN) {
 			return
 		}


### PR DESCRIPTION
This PR fixes warning deprecated use of `capability.NewPid` (SA1019) found by `golangci` when the `staticcheck` linter is enabled. 

Partially fixes:
- #1579