### PR TITLE
Fix deprecated use of `tar.TypeRegA` (SA1019)

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -668,7 +668,7 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, L
 			}
 		}
 
-	case tar.TypeReg, tar.TypeRegA:
+	case tar.TypeReg:
 		// Source is regular file. We use system.OpenFileSequential to use sequential
 		// file access to avoid depleting the standby list on Windows.
 		// On Linux, this equates to a regular os.OpenFile

--- a/pkg/chunked/internal/compression.go
+++ b/pkg/chunked/internal/compression.go
@@ -89,7 +89,6 @@ const (
 
 var TarTypes = map[byte]string{
 	tar.TypeReg:     TypeReg,
-	tar.TypeRegA:    TypeReg,
 	tar.TypeLink:    TypeLink,
 	tar.TypeChar:    TypeChar,
 	tar.TypeBlock:   TypeBlock,


### PR DESCRIPTION
This PR fixes warning deprecated use of `tar.TypeRegA` (SA1019) found by `golangci` when the `staticcheck` linter is enabled. 

Partially fixes:
- #1579