### PR TITLE
Fix the issue where compiling containers-storage with exclude_disk_qu…

### DIFF
--- a/drivers/overlay/overlay_disk_quota.go
+++ b/drivers/overlay/overlay_disk_quota.go
@@ -1,0 +1,22 @@
+//go:build linux && cgo && !exclude_disk_quota
+// +build linux,cgo,!exclude_disk_quota
+
+package overlay
+
+import (
+	"path"
+
+	"github.com/containers/storage/pkg/directory"
+)
+
+// ReadWriteDiskUsage returns the disk usage of the writable directory for the ID.
+// For Overlay, it attempts to check the XFS quota for size, and falls back to
+// finding the size of the "diff" directory.
+func (d *Driver) ReadWriteDiskUsage(id string) (*directory.DiskUsage, error) {
+	usage := &directory.DiskUsage{}
+	if d.quotaCtl != nil {
+		err := d.quotaCtl.GetDiskUsage(d.dir(id), usage)
+		return usage, err
+	}
+	return directory.Usage(path.Join(d.dir(id), "diff"))
+}

--- a/drivers/overlay/overlay_disk_quota_unsupported.go
+++ b/drivers/overlay/overlay_disk_quota_unsupported.go
@@ -1,5 +1,6 @@
-//go:build linux && cgo
-// +build linux,cgo
+//go:build linux && (!cgo || exclude_disk_quota)
+// +build linux
+// +build !cgo exclude_disk_quota
 
 package overlay
 
@@ -13,10 +14,5 @@ import (
 // For Overlay, it attempts to check the XFS quota for size, and falls back to
 // finding the size of the "diff" directory.
 func (d *Driver) ReadWriteDiskUsage(id string) (*directory.DiskUsage, error) {
-	usage := &directory.DiskUsage{}
-	if d.quotaCtl != nil {
-		err := d.quotaCtl.GetDiskUsage(d.dir(id), usage)
-		return usage, err
-	}
 	return directory.Usage(path.Join(d.dir(id), "diff"))
 }

--- a/drivers/overlay/overlay_nocgo.go
+++ b/drivers/overlay/overlay_nocgo.go
@@ -5,17 +5,7 @@ package overlay
 
 import (
 	"fmt"
-	"path"
-
-	"github.com/containers/storage/pkg/directory"
 )
-
-// ReadWriteDiskUsage returns the disk usage of the writable directory for the ID.
-// For Overlay, it attempts to check the XFS quota for size, and falls back to
-// finding the size of the "diff" directory.
-func (d *Driver) ReadWriteDiskUsage(id string) (*directory.DiskUsage, error) {
-	return directory.Usage(path.Join(d.dir(id), "diff"))
-}
 
 func getComposeFsHelper() (string, error) {
 	return "", fmt.Errorf("composefs not supported on this build")


### PR DESCRIPTION
Reference:
https://github.com/containers/storage/pull/1978#issuecomment-2181193195
---

To ensure that getComposeFsHelper and others are included, I attempted to move the ReadWriteDiskUsage function from no nocgo into a separate file, creating overlay_disk_quota_unsupported.go. However, the overlay_cgo.go file should not be moved out as it would then be an empty file, and it does not affect the existing logic. What are your thoughts on this modification?

Compile:
```bash
root@syx:/storage# make clean
rm -f -f containers-storage containers-storage.* docs/*.1 docs/*.5
root@syx:/storage# make binary
go build -compiler gc -tags " libdm_no_deferred_remove   exclude_disk_quota"  ./cmd/containers-storage
root@syx:/storage# vim Makefile 
root@syx:/storage# make binary
go build -compiler gc -tags " libdm_no_deferred_remove  "  ./cmd/containers-storage
root@syx:/storage#
```