### PR TITLE
Fix deprecated use of `hdr.Xattrs` (SA1019)

### DIFF
--- a/pkg/archive/archive_linux.go
+++ b/pkg/archive/archive_linux.go
@@ -48,8 +48,8 @@ func (o overlayWhiteoutConverter) ConvertWrite(hdr *tar.Header, path string, fi 
 			return nil, err
 		}
 		if len(opaque) == 1 && opaque[0] == 'y' {
-			if hdr.Xattrs != nil {
-				delete(hdr.Xattrs, getOverlayOpaqueXattrName())
+			if hdr.PAXRecords != nil {
+				delete(hdr.PAXRecords, PaxSchilyXattr+getOverlayOpaqueXattrName())
 			}
 			// If there are no lower layers, then it can't have been deleted in this layer.
 			if len(o.rolayers) == 0 {

--- a/pkg/chunked/compressor/compressor.go
+++ b/pkg/chunked/compressor/compressor.go
@@ -9,7 +9,9 @@ import (
 	"bytes"
 	"encoding/base64"
 	"io"
+	"strings"
 
+	"github.com/containers/storage/pkg/archive"
 	"github.com/containers/storage/pkg/chunked/internal"
 	"github.com/containers/storage/pkg/ioutils"
 	"github.com/klauspost/compress/zstd"
@@ -374,8 +376,12 @@ func writeZstdChunkedStream(destFile io.Writer, outMetadata map[string]string, r
 			return err
 		}
 		xattrs := make(map[string]string)
-		for k, v := range hdr.Xattrs {
-			xattrs[k] = base64.StdEncoding.EncodeToString([]byte(v))
+		for k, v := range hdr.PAXRecords {
+			xattrKey, ok := strings.CutPrefix(k, archive.PaxSchilyXattr)
+			if !ok {
+				continue
+			}
+			xattrs[xattrKey] = base64.StdEncoding.EncodeToString([]byte(v))
 		}
 		entries := []internal.FileMetadata{
 			{


### PR DESCRIPTION
This PR fixes warning deprecated use of `hdr.Xattrs` (SA1019) found by `golangci` when the `staticcheck` linter is enabled. 

Partially fixes:
- #1579