### PR TITLE
Fix `TestSafeLink` on ARM64

### DIFF
--- a/pkg/chunked/filesystem_linux_test.go
+++ b/pkg/chunked/filesystem_linux_test.go
@@ -173,7 +173,8 @@ func TestSafeLink(t *testing.T) {
 	err = syscall.Fstat(int(newFile.Fd()), &st)
 	assert.NoError(t, err)
 
-	assert.Equal(t, st.Nlink, uint64(2))
+	// We need this conversion on ARM64
+	assert.Equal(t, uint64(st.Nlink), uint64(2))
 
 	err = newFile.Close()
 	assert.NoError(t, err)


### PR DESCRIPTION
This PR fixes the `TestSafeLink` test which fails on ARM64. 

The failing test: 
```
--- FAIL: TestSafeLink (0.00s)
    filesystem_linux_test.go:176: 
        	Error Trace:	/root/projects/containers/storage/pkg/chunked/filesystem_linux_test.go:176
        	Error:      	Not equal: 
        	            	expected: uint32(0x2)
        	            	actual  : uint64(0x2)
        	Test:       	TestSafeLink 
```
This is because the [Stat_t](https://pkg.go.dev/syscall#Stat_t) structure has different data types, see [arm version](https://fuchsia.googlesource.com/third_party/go/+/main/src/syscall/ztypes_linux_arm64.go#105). The same problem is solved in the function [`getNlink()`](https://github.com/containers/storage/blob/main/pkg/archive/archive_unix_test.go#L156).