### PR TITLE
Enable `staticcheck` linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -8,4 +8,3 @@ linters:
     - gofumpt
   disable:
     - errcheck
-    - staticcheck

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,8 +1,7 @@
 ---
 run:
   concurrency: 6
-  deadline: 5m
-  skip-dirs-use-default: true
+  timeout: 5m
 linters:
   enable:
     - gofumpt


### PR DESCRIPTION
This PR enables `staticcheck` linter and fixes not-allowed properties of the `Golangci-lint` config. 

Partially fixes:
- #1579