### PR TITLE
Solve `errcheck` warnings (part 0)

### DIFF
--- a/pkg/fileutils/exists_test.go
+++ b/pkg/fileutils/exists_test.go
@@ -73,15 +73,15 @@ func TestExist(t *testing.T) {
 func BenchmarkExists(b *testing.B) {
 	tempDir := b.TempDir()
 	for i := 0; i < b.N; i++ {
-		Exists(tempDir)
-		Lexists(tempDir)
+		_ = Exists(tempDir)
+		_ = Lexists(tempDir)
 	}
 }
 
 func BenchmarkStat(b *testing.B) {
 	tempDir := b.TempDir()
 	for i := 0; i < b.N; i++ {
-		os.Stat(tempDir)
-		os.Lstat(tempDir)
+		_, _ = os.Stat(tempDir)
+		_, _ = os.Lstat(tempDir)
 	}
 }

--- a/pkg/idmap/idmapped_utils.go
+++ b/pkg/idmap/idmapped_utils.go
@@ -10,6 +10,7 @@ import (
 	"syscall"
 
 	"github.com/containers/storage/pkg/idtools"
+	"github.com/sirupsen/logrus"
 	"golang.org/x/sys/unix"
 )
 
@@ -65,8 +66,16 @@ func CreateUsernsProcess(uidMaps []idtools.IDMap, gidMaps []idtools.IDMap) (int,
 		}
 	}
 	cleanupFunc := func() {
-		unix.Kill(int(pid), unix.SIGKILL)
-		_, _ = unix.Wait4(int(pid), nil, 0, nil)
+		err1 := unix.Kill(int(pid), unix.SIGKILL)
+		if err1 != nil && err1 != syscall.ESRCH {
+			logrus.Warnf("kill process pid: %d with SIGKILL ended with error: %v", int(pid), err1)
+		}
+		if err1 != nil {
+			return
+		}
+		if _, err := unix.Wait4(int(pid), nil, 0, nil); err != nil {
+			logrus.Warnf("wait4 pid: %d ended with error: %v", int(pid), err)
+		}
 	}
 	writeMappings := func(fname string, idmap []idtools.IDMap) error {
 		mappings := ""

--- a/pkg/idmap/idmapped_utils.go
+++ b/pkg/idmap/idmapped_utils.go
@@ -61,7 +61,7 @@ func CreateUsernsProcess(uidMaps []idtools.IDMap, gidMaps []idtools.IDMap) (int,
 		_ = unix.Prctl(unix.PR_SET_PDEATHSIG, uintptr(unix.SIGKILL), 0, 0, 0)
 		// just wait for the SIGKILL
 		for {
-			syscall.Pause()
+			_ = syscall.Pause()
 		}
 	}
 	cleanupFunc := func() {

--- a/pkg/unshare/unshare_linux.go
+++ b/pkg/unshare/unshare_linux.go
@@ -590,7 +590,12 @@ func MaybeReexecUsingUserNamespace(evenForRoot bool) {
 	cmd.Hook = func(int) error {
 		go func() {
 			for receivedSignal := range interrupted {
-				cmd.Cmd.Process.Signal(receivedSignal)
+				if err := cmd.Cmd.Process.Signal(receivedSignal); err != nil {
+					logrus.Warnf(
+						"Failed to send a signal '%d' to the Process (PID: %d): %v",
+						receivedSignal, cmd.Cmd.Process.Pid, err,
+					)
+				}
 			}
 		}()
 		return nil

--- a/types/utils.go
+++ b/types/utils.go
@@ -66,7 +66,10 @@ func reloadConfigurationFileIfNeeded(configFile string, storeOptions *StoreOptio
 		return
 	}
 
-	ReloadConfigurationFile(configFile, storeOptions)
+	if err := ReloadConfigurationFile(configFile, storeOptions); err != nil {
+		logrus.Warningf("Failed to reload %q %v\n", configFile, err)
+		return
+	}
 
 	prevReloadConfig.storeOptions = storeOptions
 	prevReloadConfig.mod = mtime


### PR DESCRIPTION
This PR is one of several fixes of warnings found by `golangci` when the `errcheck` linter is enabled. 

Partially fixes:
- #1579