### PR TITLE
Solve `errcheck` warnings (part 2)

### DIFF
--- a/drivers/aufs/aufs_test.go
+++ b/drivers/aufs/aufs_test.go
@@ -774,7 +774,9 @@ func BenchmarkConcurrentAccess(b *testing.B) {
 				}()
 			}
 			innerGroup.Wait()
-			d.Remove(id)
+			if err := d.Remove(id); err != nil {
+				b.Log(err)
+			}
 		}(id)
 	}
 

--- a/drivers/aufs/aufs_test.go
+++ b/drivers/aufs/aufs_test.go
@@ -764,7 +764,9 @@ func BenchmarkConcurrentAccess(b *testing.B) {
 			for i := 0; i < b.N; i++ {
 				innerGroup.Add(1)
 				go func() {
-					d.Get(id, graphdriver.MountOpts{})
+					if _, err := d.Get(id, graphdriver.MountOpts{}); err != nil {
+						b.Log(err)
+					}
 					if err := d.Put(id); err != nil {
 						b.Log(err)
 					}

--- a/drivers/aufs/aufs_test.go
+++ b/drivers/aufs/aufs_test.go
@@ -765,7 +765,9 @@ func BenchmarkConcurrentAccess(b *testing.B) {
 				innerGroup.Add(1)
 				go func() {
 					d.Get(id, graphdriver.MountOpts{})
-					d.Put(id)
+					if err := d.Put(id); err != nil {
+						b.Log(err)
+					}
 					innerGroup.Done()
 				}()
 			}

--- a/drivers/btrfs/btrfs_test.go
+++ b/drivers/btrfs/btrfs_test.go
@@ -45,7 +45,11 @@ func TestBtrfsSubvolDelete(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	defer d.Put("test")
+	defer func() {
+		if err := d.Put("test"); err != nil {
+			t.Fatal(err)
+		}
+	}()
 
 	if err := subvolCreate(dir, "subvoltest"); err != nil {
 		t.Fatal(err)

--- a/drivers/graphtest/graphbench_unix.go
+++ b/drivers/graphtest/graphbench_unix.go
@@ -240,7 +240,11 @@ func DriverBenchDeepLayerRead(b *testing.B, layerCount int, drivername string, d
 	if err != nil {
 		b.Fatal(err)
 	}
-	defer driver.Put(topLayer)
+	defer func() {
+		if err := driver.Put(topLayer); err != nil {
+			b.Fatal(err)
+		}
+	}()
 
 	b.ResetTimer()
 	for i := 0; i < b.N; i++ {

--- a/drivers/graphtest/graphtest_unix.go
+++ b/drivers/graphtest/graphtest_unix.go
@@ -131,7 +131,8 @@ func DriverTestCreateEmpty(t testing.TB, drivername string, driverOptions ...str
 	require.NoError(t, err)
 	assert.Len(t, fis, 0)
 
-	driver.Put("empty")
+	err = driver.Put("empty")
+	require.NoError(t, err)
 }
 
 // DriverTestCreateBase create a base driver and verify.
@@ -162,7 +163,8 @@ func DriverTestCreateSnap(t testing.TB, drivername string, driverOptions ...stri
 	assert.NoError(t, err)
 	err = os.Chmod(root, modifiedPerms)
 	require.NoError(t, err)
-	driver.Put("Snap2")
+	err = driver.Put("Snap2")
+	require.NoError(t, err)
 
 	err = driver.Create("SecondSnap", "Snap2", nil)
 	require.NoError(t, err)

--- a/drivers/graphtest/testutil.go
+++ b/drivers/graphtest/testutil.go
@@ -18,6 +18,7 @@ import (
 	graphdriver "github.com/containers/storage/drivers"
 	"github.com/containers/storage/pkg/archive"
 	"github.com/containers/storage/pkg/stringid"
+	"github.com/sirupsen/logrus"
 	"github.com/stretchr/testify/require"
 )
 
@@ -38,7 +39,11 @@ func addFiles(drv graphdriver.Driver, layer string, seed int64) error {
 	if err != nil {
 		return err
 	}
-	defer drv.Put(layer)
+	defer func() {
+		if err := drv.Put(layer); err != nil {
+			logrus.Warn(err)
+		}
+	}()
 
 	if err := os.WriteFile(path.Join(root, "file-a"), randomContent(64, seed), 0o755); err != nil {
 		return err
@@ -58,7 +63,11 @@ func checkFile(drv graphdriver.Driver, layer, filename string, content []byte) e
 	if err != nil {
 		return err
 	}
-	defer drv.Put(layer)
+	defer func() {
+		if err := drv.Put(layer); err != nil {
+			logrus.Warn(err)
+		}
+	}()
 
 	fileContent, err := os.ReadFile(path.Join(root, filename))
 	if err != nil {
@@ -77,7 +86,11 @@ func addFile(drv graphdriver.Driver, layer, filename string, content []byte) err
 	if err != nil {
 		return err
 	}
-	defer drv.Put(layer)
+	defer func() {
+		if err := drv.Put(layer); err != nil {
+			logrus.Warn(err)
+		}
+	}()
 
 	return os.WriteFile(path.Join(root, filename), content, 0o755)
 }
@@ -87,7 +100,11 @@ func addDirectory(drv graphdriver.Driver, layer, dir string) error {
 	if err != nil {
 		return err
 	}
-	defer drv.Put(layer)
+	defer func() {
+		if err := drv.Put(layer); err != nil {
+			logrus.Warn(err)
+		}
+	}()
 
 	return os.MkdirAll(path.Join(root, dir), 0o755)
 }
@@ -97,7 +114,11 @@ func removeAll(drv graphdriver.Driver, layer string, names ...string) error {
 	if err != nil {
 		return err
 	}
-	defer drv.Put(layer)
+	defer func() {
+		if err := drv.Put(layer); err != nil {
+			logrus.Warn(err)
+		}
+	}()
 
 	for _, filename := range names {
 		if err := os.RemoveAll(path.Join(root, filename)); err != nil {
@@ -112,7 +133,11 @@ func checkFileRemoved(drv graphdriver.Driver, layer, filename string) error {
 	if err != nil {
 		return err
 	}
-	defer drv.Put(layer)
+	defer func() {
+		if err := drv.Put(layer); err != nil {
+			logrus.Warn(err)
+		}
+	}()
 
 	if _, err := os.Stat(path.Join(root, filename)); err == nil {
 		return fmt.Errorf("file still exists: %s", path.Join(root, filename))
@@ -128,7 +153,11 @@ func addManyFiles(drv graphdriver.Driver, layer string, count int, seed int64) e
 	if err != nil {
 		return err
 	}
-	defer drv.Put(layer)
+	defer func() {
+		if err := drv.Put(layer); err != nil {
+			logrus.Warn(err)
+		}
+	}()
 
 	for i := 0; i < count; i += 100 {
 		dir := path.Join(root, fmt.Sprintf("directory-%d", i))
@@ -151,7 +180,11 @@ func changeManyFiles(drv graphdriver.Driver, layer string, count int, seed int64
 	if err != nil {
 		return nil, err
 	}
-	defer drv.Put(layer)
+	defer func() {
+		if err := drv.Put(layer); err != nil {
+			logrus.Warn(err)
+		}
+	}()
 
 	changes := []archive.Change{}
 	for i := 0; i < count; i += 100 {
@@ -211,7 +244,11 @@ func checkManyFiles(drv graphdriver.Driver, layer string, count int, seed int64)
 	if err != nil {
 		return err
 	}
-	defer drv.Put(layer)
+	defer func() {
+		if err := drv.Put(layer); err != nil {
+			logrus.Warn(err)
+		}
+	}()
 
 	for i := 0; i < count; i += 100 {
 		dir := path.Join(root, fmt.Sprintf("directory-%d", i))
@@ -265,7 +302,11 @@ func addLayerFiles(drv graphdriver.Driver, layer, parent string, i int) error {
 	if err != nil {
 		return err
 	}
-	defer drv.Put(layer)
+	defer func() {
+		if err := drv.Put(layer); err != nil {
+			logrus.Warn(err)
+		}
+	}()
 
 	if err := os.WriteFile(path.Join(root, "top-id"), []byte(layer), 0o755); err != nil {
 		return err
@@ -307,7 +348,11 @@ func checkManyLayers(drv graphdriver.Driver, layer string, count int) error {
 	if err != nil {
 		return err
 	}
-	defer drv.Put(layer)
+	defer func() {
+		if err := drv.Put(layer); err != nil {
+			logrus.Warn(err)
+		}
+	}()
 
 	layerIDBytes, err := os.ReadFile(path.Join(root, "top-id"))
 	if err != nil {

--- a/drivers/graphtest/testutil_unix.go
+++ b/drivers/graphtest/testutil_unix.go
@@ -43,7 +43,10 @@ func createBase(t testing.TB, driver graphdriver.Driver, name string) {
 
 	dir, err := driver.Get(name, graphdriver.MountOpts{})
 	require.NoError(t, err)
-	defer driver.Put(name)
+	defer func() {
+		err = driver.Put(name)
+		require.NoError(t, err)
+	}()
 
 	subdir := path.Join(dir, "a subdir")
 	require.NoError(t, os.Mkdir(subdir, defaultSubdirPerms|os.ModeSticky))
@@ -57,7 +60,10 @@ func createBase(t testing.TB, driver graphdriver.Driver, name string) {
 func verifyBase(t testing.TB, driver graphdriver.Driver, name string, defaultPerm os.FileMode) {
 	dir, err := driver.Get(name, graphdriver.MountOpts{})
 	require.NoError(t, err)
-	defer driver.Put(name)
+	defer func() {
+		err = driver.Put(name)
+		require.NoError(t, err)
+	}()
 
 	verifyFile(t, dir, defaultPerm|os.ModeDir, 0, 0)
 

--- a/pkg/chunked/cache_linux.go
+++ b/pkg/chunked/cache_linux.go
@@ -80,7 +80,9 @@ var (
 func (c *layer) release() {
 	runtime.SetFinalizer(c, nil)
 	if c.mmapBuffer != nil {
-		unix.Munmap(c.mmapBuffer)
+		if err := unix.Munmap(c.mmapBuffer); err != nil {
+			logrus.Warnf("Error Munmap: layer %q: %v", c.id, err)
+		}
 	}
 }
 
@@ -192,7 +194,9 @@ func (c *layersCache) loadLayerCache(layerID string) (_ *layer, errRet error) {
 	}
 	defer func() {
 		if errRet != nil && mmapBuffer != nil {
-			unix.Munmap(mmapBuffer)
+			if err := unix.Munmap(mmapBuffer); err != nil {
+				logrus.Warnf("Error Munmap: layer %q: %v", layerID, err)
+			}
 		}
 	}()
 	cacheFile, err := readCacheFileFromMemory(buffer)


### PR DESCRIPTION
This PR is one of several fixes of warnings found by `golangci` when the `errcheck` linter is enabled. 

Partially fixes:
- #1579