### PR TITLE
chunked: store compressed digest if validated

### DIFF
--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -193,6 +193,7 @@ type DriverWithDifferOutput struct {
 	UIDs               []uint32
 	GIDs               []uint32
 	UncompressedDigest digest.Digest
+	CompressedDigest   digest.Digest
 	Metadata           string
 	BigData            map[string][]byte
 	TarSplit           []byte

--- a/layers.go
+++ b/layers.go
@@ -2529,7 +2529,9 @@ func (r *layerStore) applyDiffFromStagingDirectory(id string, diffOutput *driver
 	layer.GIDs = diffOutput.GIDs
 	updateDigestMap(&r.byuncompressedsum, layer.UncompressedDigest, diffOutput.UncompressedDigest, layer.ID)
 	layer.UncompressedDigest = diffOutput.UncompressedDigest
-	updateDigestMap(&r.bytocsum, diffOutput.TOCDigest, diffOutput.TOCDigest, layer.ID)
+	updateDigestMap(&r.bycompressedsum, layer.CompressedDigest, diffOutput.CompressedDigest, layer.ID)
+	layer.CompressedDigest = diffOutput.CompressedDigest
+	updateDigestMap(&r.bytocsum, layer.TOCDigest, diffOutput.TOCDigest, layer.ID)
 	layer.TOCDigest = diffOutput.TOCDigest
 	layer.UncompressedSize = diffOutput.Size
 	layer.Metadata = diffOutput.Metadata

--- a/pkg/chunked/storage_linux.go
+++ b/pkg/chunked/storage_linux.go
@@ -1126,6 +1126,7 @@ func (c *chunkedDiffer) ApplyDiff(dest string, options *archive.TarOptions, diff
 	// stream to use for reading the zstd:chunked or Estargz file.
 	stream := c.stream
 
+	var compressedDigest digest.Digest
 	var uncompressedDigest digest.Digest
 	var convertedBlobSize int64
 
@@ -1142,7 +1143,7 @@ func (c *chunkedDiffer) ApplyDiff(dest string, options *archive.TarOptions, diff
 		}()
 
 		// calculate the checksum before accessing the file.
-		compressedDigest, err := c.copyAllBlobToFile(blobFile)
+		compressedDigest, err = c.copyAllBlobToFile(blobFile)
 		if err != nil {
 			return graphdriver.DriverWithDifferOutput{}, err
 		}
@@ -1228,6 +1229,7 @@ func (c *chunkedDiffer) ApplyDiff(dest string, options *archive.TarOptions, diff
 		},
 		TOCDigest:          c.tocDigest,
 		UncompressedDigest: uncompressedDigest,
+		CompressedDigest:   compressedDigest,
 	}
 
 	// When the hard links deduplication is used, file attributes are ignored because setting them


### PR DESCRIPTION
if the compressed digest was validated, as it happens when 'pull_options = {convert_images = "true"}' is set, then store it as well so that reusing the blob by its compressed digest works.

Previously, when an image converted to zstd:chunked was pulled a second time, it would not be recognized by its compressed digest, resulting in the need to re-pull the image again.