### PR TITLE
Solve `errcheck` warnings (part 3)

### DIFF
--- a/drivers/aufs/aufs.go
+++ b/drivers/aufs/aufs.go
@@ -349,7 +349,9 @@ func (a *Driver) createDirsFor(id, parent string) error {
 // Remove will unmount and remove the given id.
 func (a *Driver) Remove(id string) error {
 	a.locker.Lock(id)
-	defer a.locker.Unlock(id)
+	defer func() {
+		_ = a.locker.Unlock(id)
+	}()
 	a.pathCacheLock.Lock()
 	mountpoint, exists := a.pathCache[id]
 	a.pathCacheLock.Unlock()
@@ -440,7 +442,10 @@ func atomicRemove(source string) error {
 // This will mount the dir at its given path
 func (a *Driver) Get(id string, options graphdriver.MountOpts) (string, error) {
 	a.locker.Lock(id)
-	defer a.locker.Unlock(id)
+	defer func() {
+		_ = a.locker.Unlock(id)
+	}()
+
 	parents, err := a.getParentLayerPaths(id)
 	if err != nil && !os.IsNotExist(err) {
 		return "", err
@@ -477,7 +482,10 @@ func (a *Driver) Get(id string, options graphdriver.MountOpts) (string, error) {
 // Put unmounts and updates list of active mounts.
 func (a *Driver) Put(id string) error {
 	a.locker.Lock(id)
-	defer a.locker.Unlock(id)
+	defer func() {
+		_ = a.locker.Unlock(id)
+	}()
+
 	a.pathCacheLock.Lock()
 	m, exists := a.pathCache[id]
 	if !exists {
@@ -500,7 +508,9 @@ func (a *Driver) Put(id string) error {
 // For AUFS, it queries the mountpoint for this ID.
 func (a *Driver) ReadWriteDiskUsage(id string) (*directory.DiskUsage, error) {
 	a.locker.Lock(id)
-	defer a.locker.Unlock(id)
+	defer func() {
+		_ = a.locker.Unlock(id)
+	}()
 	a.pathCacheLock.Lock()
 	m, exists := a.pathCache[id]
 	if !exists {

--- a/drivers/aufs/aufs_test.go
+++ b/drivers/aufs/aufs_test.go
@@ -221,7 +221,11 @@ func TestMountedFalseResponse(t *testing.T) {
 func TestMountedTrueResponse(t *testing.T) {
 	d := newDriver(t)
 	defer os.RemoveAll(tmp)
-	defer d.Cleanup()
+	defer func() {
+		if err := d.Cleanup(); err != nil {
+			t.Fatal(err)
+		}
+	}()
 
 	err := d.Create("1", "", nil)
 	require.NoError(t, err)
@@ -488,7 +492,11 @@ func TestDiffSize(t *testing.T) {
 func TestChildDiffSize(t *testing.T) {
 	d := newDriver(t)
 	defer os.RemoveAll(tmp)
-	defer d.Cleanup()
+	defer func() {
+		if err := d.Cleanup(); err != nil {
+			t.Fatal(err)
+		}
+	}()
 
 	if err := d.CreateReadWrite("1", "", nil); err != nil {
 		t.Fatal(err)
@@ -543,7 +551,11 @@ func TestChildDiffSize(t *testing.T) {
 func TestExists(t *testing.T) {
 	d := newDriver(t)
 	defer os.RemoveAll(tmp)
-	defer d.Cleanup()
+	defer func() {
+		if err := d.Cleanup(); err != nil {
+			t.Fatal(err)
+		}
+	}()
 
 	if err := d.Create("1", "", nil); err != nil {
 		t.Fatal(err)
@@ -561,7 +573,11 @@ func TestExists(t *testing.T) {
 func TestStatus(t *testing.T) {
 	d := newDriver(t)
 	defer os.RemoveAll(tmp)
-	defer d.Cleanup()
+	defer func() {
+		if err := d.Cleanup(); err != nil {
+			t.Fatal(err)
+		}
+	}()
 
 	if err := d.Create("1", "", nil); err != nil {
 		t.Fatal(err)
@@ -589,7 +605,11 @@ func TestStatus(t *testing.T) {
 func TestApplyDiff(t *testing.T) {
 	d := newDriver(t)
 	defer os.RemoveAll(tmp)
-	defer d.Cleanup()
+	defer func() {
+		if err := d.Cleanup(); err != nil {
+			t.Fatal(err)
+		}
+	}()
 
 	if err := d.CreateReadWrite("1", "", nil); err != nil {
 		t.Fatal(err)
@@ -652,7 +672,11 @@ func testMountMoreThan42Layers(t *testing.T, mountPath string) {
 
 	defer os.RemoveAll(mountPath)
 	d := testInit(mountPath, t).(*Driver)
-	defer d.Cleanup()
+	defer func() {
+		if err := d.Cleanup(); err != nil {
+			t.Fatal(err)
+		}
+	}()
 	var last string
 	var expected int
 
@@ -726,7 +750,11 @@ func BenchmarkConcurrentAccess(b *testing.B) {
 
 	d := newDriver(b)
 	defer os.RemoveAll(tmp)
-	defer d.Cleanup()
+	defer func() {
+		if err := d.Cleanup(); err != nil {
+			b.Fatal(err)
+		}
+	}()
 
 	numConcurrent := 256
 	// create a bunch of ids


### PR DESCRIPTION
This PR is one of several fixes of warnings found by `golangci` when the `errcheck` linter is enabled. 

Partially fixes:
- #1579