### PR TITLE
Solve `errcheck` warnings (part 4)

### DIFF
--- a/drivers/aufs/aufs.go
+++ b/drivers/aufs/aufs.go
@@ -188,7 +188,9 @@ func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) 
 func supportsAufs() error {
 	// We can try to modprobe aufs first before looking at
 	// proc/filesystems for when aufs is supported
-	exec.Command("modprobe", "aufs").Run()
+	if err := exec.Command("modprobe", "aufs").Run(); err != nil {
+		logrus.Warnf("Execution of `modprobe aufs` ended with error: %v", err)
+	}
 
 	if unshare.IsRootless() {
 		return ErrAufsNested

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -692,7 +692,9 @@ func supportsOverlay(home string, homeMagic graphdriver.FsMagic, rootUID, rootGI
 
 	selinuxLabelTest := selinux.PrivContainerMountLabel()
 
-	exec.Command("modprobe", "overlay").Run()
+	if err := exec.Command("modprobe", "overlay").Run(); err != nil {
+		logrus.Warnf("Execution of `modprobe overlay` ended with error: %v", err)
+	}
 
 	logLevel := logrus.ErrorLevel
 	if unshare.IsRootless() {

--- a/pkg/chunked/bloom_filter_linux_test.go
+++ b/pkg/chunked/bloom_filter_linux_test.go
@@ -61,7 +61,10 @@ func initCache(sizeCache int) (*cacheFile, string, string, *bloomFilter) {
 	hash.Write([]byte("1"))
 	notPresentDigest = digester.Digest().String()
 
-	writeCacheFileToWriter(io.Discard, bloomFilter, tags, tagLen, digestLen, vdata, fnames, &tagsBuffer)
+	err := writeCacheFileToWriter(io.Discard, bloomFilter, tags, tagLen, digestLen, vdata, fnames, &tagsBuffer)
+	if err != nil {
+		panic(err)
+	}
 
 	cache := &cacheFile{
 		digestLen: digestLen,

--- a/pkg/chunked/filesystem_linux.go
+++ b/pkg/chunked/filesystem_linux.go
@@ -76,7 +76,9 @@ func doHardLink(dirfd, srcFd int, destFile string) error {
 
 	// if the destination exists, unlink it first and try again
 	if err != nil && os.IsExist(err) {
-		unix.Unlinkat(destDirFd, destBase, 0)
+		if err := unix.Unlinkat(destDirFd, destBase, 0); err != nil {
+			return err
+		}
 		return doLink()
 	}
 	return err

--- a/pkg/chunked/storage_linux.go
+++ b/pkg/chunked/storage_linux.go
@@ -1287,7 +1287,9 @@ func (c *chunkedDiffer) ApplyDiff(dest string, options *archive.TarOptions, diff
 		for _, e := range mergedEntries {
 			d := e.Name[0:2]
 			if _, found := createdDirs[d]; !found {
-				unix.Mkdirat(dirfd, d, 0o755)
+				if err := unix.Mkdirat(dirfd, d, 0o755); err != nil {
+					return output, &fs.PathError{Op: "mkdirat", Path: d, Err: err}
+				}
 				createdDirs[d] = struct{}{}
 			}
 		}


### PR DESCRIPTION
This PR is one of several fixes of warnings found by `golangci` when the `errcheck` linter is enabled. 

Partially fixes:
- #1579