### PR TITLE
Don't discard fields of `LayerOptions`

### DIFF
--- a/store.go
+++ b/store.go
@@ -1509,23 +1509,17 @@ func (s *store) putLayer(rlstore rwLayerStore, rlstores []roLayerStore, id, pare
 			gidMap = s.gidMap
 		}
 	}
-	layerOptions := LayerOptions{
-		OriginalDigest:     options.OriginalDigest,
-		OriginalSize:       options.OriginalSize,
-		UncompressedDigest: options.UncompressedDigest,
-		Flags:              options.Flags,
-	}
 	if s.canUseShifting(uidMap, gidMap) {
-		layerOptions.IDMappingOptions = types.IDMappingOptions{HostUIDMapping: true, HostGIDMapping: true, UIDMap: nil, GIDMap: nil}
+		options.IDMappingOptions = types.IDMappingOptions{HostUIDMapping: true, HostGIDMapping: true, UIDMap: nil, GIDMap: nil}
 	} else {
-		layerOptions.IDMappingOptions = types.IDMappingOptions{
+		options.IDMappingOptions = types.IDMappingOptions{
 			HostUIDMapping: options.HostUIDMapping,
 			HostGIDMapping: options.HostGIDMapping,
 			UIDMap:         copyIDMap(uidMap),
 			GIDMap:         copyIDMap(gidMap),
 		}
 	}
-	return rlstore.create(id, parentLayer, names, mountLabel, nil, &layerOptions, writeable, diff, slo)
+	return rlstore.create(id, parentLayer, names, mountLabel, nil, &options, writeable, diff, slo)
 }
 
 func (s *store) PutLayer(id, parent string, names []string, mountLabel string, writeable bool, lOptions *LayerOptions, diff io.Reader) (*Layer, int64, error) {


### PR DESCRIPTION
Instead of making a copy with some fields, pass the ~deep copy of options we are already using with all of them.

Originally motivated by a linter pointing out that the copy of `options.BigData` has no readers.

In some cases it's not entirely clear that we intended the fields to be a public API; at least I can't see any external caller of any of these fields. But now that they _are_ a public API, we can either implement it, or mark the fields as deprecated ... and then we would need to introduce an internal option structure to carry the fields for the call paths where we do want these fields. That's possible but more work, so I'm doing the lazy thing.


@giuseppe @nalind PTAL