### PR TITLE
Clean up some warnings

### DIFF
--- a/check.go
+++ b/check.go
@@ -962,6 +962,9 @@ func (c *checkDirectory) add(path string, typeflag byte, uid, gid int, size int6
 					mtime:    mtime,
 				}
 			}
+		case tar.TypeXGlobalHeader:
+			// ignore, since even though it looks like a valid pathname, it doesn't end
+			// up on the filesystem
 		default:
 			// treat these as TypeReg items
 			delete(c.directory, components[0])
@@ -973,9 +976,6 @@ func (c *checkDirectory) add(path string, typeflag byte, uid, gid int, size int6
 				mode:     mode,
 				mtime:    mtime,
 			}
-		case tar.TypeXGlobalHeader:
-			// ignore, since even though it looks like a valid pathname, it doesn't end
-			// up on the filesystem
 		}
 		return
 	}

--- a/pkg/chrootarchive/archive_darwin.go
+++ b/pkg/chrootarchive/archive_darwin.go
@@ -10,9 +10,11 @@ func invokeUnpack(decompressedArchive io.Reader,
 	dest string,
 	options *archive.TarOptions, root string,
 ) error {
+	_ = root // Restricting the operation to this root is not implemented on macOS
 	return archive.Unpack(decompressedArchive, dest, options)
 }
 
 func invokePack(srcPath string, options *archive.TarOptions, root string) (io.ReadCloser, error) {
+	_ = root // Restricting the operation to this root is not implemented on macOS
 	return archive.TarWithOptions(srcPath, options)
 }

--- a/pkg/chunked/filesystem_linux.go
+++ b/pkg/chunked/filesystem_linux.go
@@ -505,7 +505,7 @@ func safeLink(dirfd int, mode os.FileMode, metadata *fileMetadata, options *arch
 	return setFileAttrs(dirfd, newFile, mode, metadata, options, false)
 }
 
-func safeSymlink(dirfd int, mode os.FileMode, metadata *fileMetadata, options *archive.TarOptions) error {
+func safeSymlink(dirfd int, metadata *fileMetadata) error {
 	destDir, destBase := filepath.Split(metadata.Name)
 	destDirFd := dirfd
 	if destDir != "" && destDir != "." {

--- a/pkg/chunked/filesystem_linux_test.go
+++ b/pkg/chunked/filesystem_linux_test.go
@@ -210,12 +210,8 @@ func TestSafeSymlink(t *testing.T) {
 			Mode:     0o755,
 		},
 	}
-	options := &archive.TarOptions{
-		// Allow the test to run without privileges
-		IgnoreChownErrors: true,
-	}
 
-	err = safeSymlink(rootFd, 0o755, &metadata, options)
+	err = safeSymlink(rootFd, &metadata)
 	require.NoError(t, err)
 
 	// validate it was created

--- a/pkg/chunked/storage_linux.go
+++ b/pkg/chunked/storage_linux.go
@@ -162,14 +162,14 @@ func GetDiffer(ctx context.Context, store storage.Store, blobDigest digest.Diges
 		if err != nil {
 			return nil, fmt.Errorf("parsing zstd:chunked TOC digest %q: %w", zstdChunkedTOCDigestString, err)
 		}
-		return makeZstdChunkedDiffer(ctx, store, blobSize, zstdChunkedTOCDigest, annotations, iss, pullOptions)
+		return makeZstdChunkedDiffer(store, blobSize, zstdChunkedTOCDigest, annotations, iss, pullOptions)
 	}
 	if hasEstargzTOC {
 		estargzTOCDigest, err := digest.Parse(estargzTOCDigestString)
 		if err != nil {
 			return nil, fmt.Errorf("parsing estargz TOC digest %q: %w", estargzTOCDigestString, err)
 		}
-		return makeEstargzChunkedDiffer(ctx, store, blobSize, estargzTOCDigest, iss, pullOptions)
+		return makeEstargzChunkedDiffer(store, blobSize, estargzTOCDigest, iss, pullOptions)
 	}
 
 	return makeConvertFromRawDiffer(store, blobDigest, blobSize, iss, pullOptions)
@@ -197,7 +197,7 @@ func makeConvertFromRawDiffer(store storage.Store, blobDigest digest.Digest, blo
 	}, nil
 }
 
-func makeZstdChunkedDiffer(ctx context.Context, store storage.Store, blobSize int64, tocDigest digest.Digest, annotations map[string]string, iss ImageSourceSeekable, pullOptions map[string]string) (*chunkedDiffer, error) {
+func makeZstdChunkedDiffer(store storage.Store, blobSize int64, tocDigest digest.Digest, annotations map[string]string, iss ImageSourceSeekable, pullOptions map[string]string) (*chunkedDiffer, error) {
 	manifest, toc, tarSplit, tocOffset, err := readZstdChunkedManifest(iss, tocDigest, annotations)
 	if err != nil {
 		return nil, fmt.Errorf("read zstd:chunked manifest: %w", err)
@@ -223,7 +223,7 @@ func makeZstdChunkedDiffer(ctx context.Context, store storage.Store, blobSize in
 	}, nil
 }
 
-func makeEstargzChunkedDiffer(ctx context.Context, store storage.Store, blobSize int64, tocDigest digest.Digest, iss ImageSourceSeekable, pullOptions map[string]string) (*chunkedDiffer, error) {
+func makeEstargzChunkedDiffer(store storage.Store, blobSize int64, tocDigest digest.Digest, iss ImageSourceSeekable, pullOptions map[string]string) (*chunkedDiffer, error) {
 	manifest, tocOffset, err := readEstargzChunkedManifest(iss, blobSize, tocDigest)
 	if err != nil {
 		return nil, fmt.Errorf("read zstd:chunked manifest: %w", err)

--- a/pkg/fileutils/exists_test.go
+++ b/pkg/fileutils/exists_test.go
@@ -24,24 +24,24 @@ func TestExist(t *testing.T) {
 	require.NoError(t, err)
 
 	assertSameError := func(err1, err2 error, description string) {
-		assert.Equal(t, err1 == nil, err2 == nil, "only one error is set")
+		assert.Equal(t, err1 == nil, err2 == nil, description+": only one error is set")
 		if err1 == nil {
 			return
 		}
 
 		var pathErr1 *os.PathError
 		var pathErr2 *os.PathError
-		assert.ErrorAs(t, err1, &pathErr1, "wrong error type")
-		assert.ErrorAs(t, err2, &pathErr2, "wrong error type")
-		assert.Equal(t, pathErr1.Path, pathErr1.Path, "different file path")
+		assert.ErrorAs(t, err1, &pathErr1, description+": wrong error type")
+		assert.ErrorAs(t, err2, &pathErr2, description+": wrong error type")
+		assert.Equal(t, pathErr1.Path, pathErr1.Path, description+": different file path")
 
 		// on Linux validates that the syscall error is the same
 		if runtime.GOOS == "linux" {
 			var syscallErr1 syscall.Errno
 			var syscallErr2 syscall.Errno
-			assert.ErrorAs(t, err1, &syscallErr1, "wrong error type")
-			assert.ErrorAs(t, err2, &syscallErr2, "wrong error type")
-			assert.Equal(t, syscallErr1, syscallErr2, "same error for existing path (follow=false)")
+			assert.ErrorAs(t, err1, &syscallErr1, description+": wrong error type")
+			assert.ErrorAs(t, err2, &syscallErr2, description+": wrong error type")
+			assert.Equal(t, syscallErr1, syscallErr2, description+": same error for existing path (follow=false)")
 		}
 	}
 

--- a/types/options.go
+++ b/types/options.go
@@ -352,7 +352,7 @@ func getRootlessStorageOpts(systemOpts StoreOptions) (StoreOptions, error) {
 			}
 
 			if opts.GraphDriverName == "" {
-				if canUseRootlessOverlay(opts.GraphRoot, opts.RunRoot) {
+				if canUseRootlessOverlay() {
 					opts.GraphDriverName = overlayDriver
 				} else {
 					opts.GraphDriverName = "vfs"

--- a/types/options_bsd.go
+++ b/types/options_bsd.go
@@ -16,6 +16,6 @@ var (
 )
 
 // canUseRootlessOverlay returns true if the overlay driver can be used for rootless containers
-func canUseRootlessOverlay(home, runhome string) bool {
+func canUseRootlessOverlay() bool {
 	return false
 }

--- a/types/options_darwin.go
+++ b/types/options_darwin.go
@@ -11,6 +11,6 @@ const (
 var defaultOverrideConfigFile = "/etc/containers/storage.conf"
 
 // canUseRootlessOverlay returns true if the overlay driver can be used for rootless containers
-func canUseRootlessOverlay(home, runhome string) bool {
+func canUseRootlessOverlay() bool {
 	return false
 }

--- a/types/options_linux.go
+++ b/types/options_linux.go
@@ -22,7 +22,7 @@ var (
 )
 
 // canUseRootlessOverlay returns true if the overlay driver can be used for rootless containers
-func canUseRootlessOverlay(home, runhome string) bool {
+func canUseRootlessOverlay() bool {
 	// we check first for fuse-overlayfs since it is cheaper.
 	if path, _ := exec.LookPath("fuse-overlayfs"); path != "" {
 		return true

--- a/types/options_test.go
+++ b/types/options_test.go
@@ -35,7 +35,7 @@ func TestGetRootlessStorageOpts(t *testing.T) {
 
 		assert.NilError(t, err)
 		expectedDriver := vfsDriver
-		if canUseRootlessOverlay(home, runhome) {
+		if canUseRootlessOverlay() {
 			expectedDriver = overlayDriver
 		}
 		assert.Equal(t, storageOpts.GraphDriverName, expectedDriver)

--- a/types/options_windows.go
+++ b/types/options_windows.go
@@ -14,6 +14,6 @@ var (
 )
 
 // canUseRootlessOverlay returns true if the overlay driver can be used for rootless containers
-func canUseRootlessOverlay(home, runhome string) bool {
+func canUseRootlessOverlay() bool {
 	return false
 }


### PR DESCRIPTION
from what `golangci-lint` and `gopls check` show. This is not comprehensive, primarily to minimize distractions when working on pkg/chunked.

Cc: @giuseppe primarily for a review of the `context.Context` removals.