### PR TITLE
Enable `errcheck` linter

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -5,5 +5,3 @@ run:
 linters:
   enable:
     - gofumpt
-  disable:
-    - errcheck


### PR DESCRIPTION
This PR enables `errcheck` linter. 

Fixes:
- #1579