### PR TITLE
drivers: change verbosity to debug for modprobe failures

### DIFF
--- a/drivers/aufs/aufs.go
+++ b/drivers/aufs/aufs.go
@@ -189,7 +189,7 @@ func supportsAufs() error {
 	// We can try to modprobe aufs first before looking at
 	// proc/filesystems for when aufs is supported
 	if err := exec.Command("modprobe", "aufs").Run(); err != nil {
-		logrus.Warnf("Execution of `modprobe aufs` ended with error: %v", err)
+		logrus.Debugf("Execution of `modprobe aufs` ended with error: %v", err)
 	}
 
 	if unshare.IsRootless() {

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -693,7 +693,7 @@ func supportsOverlay(home string, homeMagic graphdriver.FsMagic, rootUID, rootGI
 	selinuxLabelTest := selinux.PrivContainerMountLabel()
 
 	if err := exec.Command("modprobe", "overlay").Run(); err != nil {
-		logrus.Warnf("Execution of `modprobe overlay` ended with error: %v", err)
+		logrus.Debugf("Execution of `modprobe overlay` ended with error: %v", err)
 	}
 
 	logLevel := logrus.ErrorLevel

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -692,8 +692,11 @@ func supportsOverlay(home string, homeMagic graphdriver.FsMagic, rootUID, rootGI
 
 	selinuxLabelTest := selinux.PrivContainerMountLabel()
 
-	if err := exec.Command("modprobe", "overlay").Run(); err != nil {
-		logrus.Debugf("Execution of `modprobe overlay` ended with error: %v", err)
+	// don't try to modprobe overlay if it's already loaded
+	if err := fileutils.Exists("/sys/module/overlay"); err != nil {
+		if err := exec.Command("modprobe", "overlay").Run(); err != nil {
+			logrus.Debugf("Execution of `modprobe overlay` ended with error: %v", err)
+		}
 	}
 
 	logLevel := logrus.ErrorLevel


### PR DESCRIPTION
commit 48e010f485ffe0dabc8a4e6092dfba2fc74f59c3 caused the regression with rootless since an unprivileged user cannot use `modprobe`.