### PR TITLE
drivers: drop modprobe calls

### DIFF
--- a/drivers/aufs/aufs.go
+++ b/drivers/aufs/aufs.go
@@ -30,7 +30,6 @@ import (
 	"io"
 	"io/fs"
 	"os"
-	"os/exec"
 	"path"
 	"path/filepath"
 	"strings"
@@ -183,15 +182,7 @@ func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) 
 }
 
 // Return a nil error if the kernel supports aufs
-// We cannot modprobe because inside dind modprobe fails
-// to run
 func supportsAufs() error {
-	// We can try to modprobe aufs first before looking at
-	// proc/filesystems for when aufs is supported
-	if err := exec.Command("modprobe", "aufs").Run(); err != nil {
-		logrus.Warnf("Execution of `modprobe aufs` ended with error: %v", err)
-	}
-
 	if unshare.IsRootless() {
 		return ErrAufsNested
 	}

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -688,13 +688,7 @@ func SupportsNativeOverlay(home, runhome string) (bool, error) {
 }
 
 func supportsOverlay(home string, homeMagic graphdriver.FsMagic, rootUID, rootGID int) (supportsDType bool, err error) {
-	// We can try to modprobe overlay first
-
 	selinuxLabelTest := selinux.PrivContainerMountLabel()
-
-	if err := exec.Command("modprobe", "overlay").Run(); err != nil {
-		logrus.Warnf("Execution of `modprobe overlay` ended with error: %v", err)
-	}
 
 	logLevel := logrus.ErrorLevel
 	if unshare.IsRootless() {


### PR DESCRIPTION
drop an expensive call to "modprobe" each time we initialize the storage.  The kernel already tries to automatically load the module if needed, and still the user has the possibility to load the module manually if required.

Alternative fix for: https://github.com/containers/storage/pull/2019