### PR TITLE
[WIP] chunked: fix reuse of the layers cache

### DIFF
--- a/pkg/chunked/cache_linux.go
+++ b/pkg/chunked/cache_linux.go
@@ -111,7 +111,7 @@ func getLayersCacheRef(store storage.Store) *layersCache {
 		cache.refs++
 		return cache
 	}
-	cache := &layersCache{
+	cache = &layersCache{
 		store:   store,
 		refs:    1,
 		created: time.Now(),
@@ -254,13 +254,13 @@ func (c *layersCache) createCacheFileFromTOC(layerID string) (*layer, error) {
 }
 
 func (c *layersCache) load() error {
-	c.mutex.Lock()
-	defer c.mutex.Unlock()
-
 	loadedLayers := make(map[string]*layer)
+	c.mutex.RLock()
 	for _, r := range c.layers {
 		loadedLayers[r.id] = r
 	}
+	c.mutex.RUnlock()
+
 	allLayers, err := c.store.Layers()
 	if err != nil {
 		return err
@@ -300,7 +300,9 @@ func (c *layersCache) load() error {
 	for _, l := range loadedLayers {
 		l.release()
 	}
+	c.mutex.Lock()
 	c.layers = newLayers
+	c.mutex.Unlock()
 	return nil
 }
 


### PR DESCRIPTION
the global singleton was never updated, causing the cache to be always recreated for each layer.

It is not possible to keep the layersCache mutex for the entire load() since it calls into some store APIs causing a deadlock since findDigestInternal() is already called while some store locks are held.

Closes: https://github.com/containers/storage/issues/2023