### PR TITLE
loopback: fix race condition opening loopback device

### DIFF
--- a/pkg/loopback/attach_test.go
+++ b/pkg/loopback/attach_test.go
@@ -1,0 +1,49 @@
+//go:build linux && cgo
+// +build linux,cgo
+
+package loopback
+
+import (
+	"os"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const (
+	maxDevicesPerGoroutine = 1000
+	maxGoroutines          = 10
+)
+
+func TestAttachLoopbackDeviceRace(t *testing.T) {
+	createLoopbackDevice := func() {
+		// Create a file to use as a backing file
+		f, err := os.CreateTemp(t.TempDir(), "loopback-test")
+		require.NoError(t, err)
+		defer f.Close()
+
+		defer os.Remove(f.Name())
+
+		lp, err := AttachLoopDevice(f.Name())
+		assert.NoError(t, err)
+		assert.NotNil(t, lp, "loopback device file should not be nil")
+		if lp != nil {
+			lp.Close()
+		}
+	}
+
+	wg := sync.WaitGroup{}
+
+	for i := 0; i < maxGoroutines; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for i := 0; i < maxDevicesPerGoroutine; i++ {
+				createLoopbackDevice()
+			}
+		}()
+	}
+	wg.Wait()
+}


### PR DESCRIPTION
the loopback device file could be already used/removed by another process.  Since the process is inherently racy, just grab the next available index and try again until it succeeds.

Closes: https://github.com/containers/storage/issues/2038
