### PR TITLE
chrootarchive: Disable on MacOS and Windows

### DIFF
--- a/pkg/chrootarchive/archive_darwin.go
+++ b/pkg/chrootarchive/archive_darwin.go
@@ -10,8 +10,7 @@ func invokeUnpack(decompressedArchive io.Reader,
 	dest string,
 	options *archive.TarOptions, root string,
 ) error {
-	_ = root // Restricting the operation to this root is not implemented on macOS
-	return archive.Unpack(decompressedArchive, dest, options)
+	return fmt.Errorf("cannot unpack via chroot on this platform")
 }
 
 func invokePack(srcPath string, options *archive.TarOptions, root string) (io.ReadCloser, error) {

--- a/pkg/chrootarchive/archive_windows.go
+++ b/pkg/chrootarchive/archive_windows.go
@@ -16,10 +16,7 @@ func invokeUnpack(decompressedArchive io.Reader,
 	dest string,
 	options *archive.TarOptions, root string,
 ) error {
-	// Windows is different to Linux here because Windows does not support
-	// chroot. Hence there is no point sandboxing a chrooted process to
-	// do the unpack. We call inline instead within the daemon process.
-	return archive.Unpack(decompressedArchive, longpath.AddPrefix(dest), options)
+	return fmt.Errorf("cannot unpack via chroot on this platform")
 }
 
 func invokePack(srcPath string, options *archive.TarOptions, root string) (io.ReadCloser, error) {


### PR DESCRIPTION
Since this is not secure, let's not pretend it is.

Prep for changing the API to be fd-relative for better support on Linux (and in theory FreeBSD).