### PR TITLE
Update golangci-lint

### DIFF
--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -496,7 +496,7 @@ func driverPut(driver ProtoDriver, id string, mainErr *error) {
 		if *mainErr == nil {
 			*mainErr = err
 		} else {
-			logrus.Errorf(err.Error())
+			logrus.Error(err)
 		}
 	}
 }

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -1492,7 +1492,7 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 				if err := unix.Uname(&uts); err == nil {
 					release = " " + string(uts.Release[:]) + " " + string(uts.Version[:])
 				}
-				logrus.StandardLogger().Logf(logLevel, "Ignoring global metacopy option, not supported with booted kernel"+release)
+				logrus.StandardLogger().Logf(logLevel, "Ignoring global metacopy option, not supported with booted kernel %s", release)
 			} else {
 				logrus.Debugf("Ignoring global metacopy option, the mount program doesn't support it")
 			}

--- a/tests/tools/Makefile
+++ b/tests/tools/Makefile
@@ -1,5 +1,6 @@
 GO := go
 BUILDDIR := build
+GOLANGCI_LINT_VERSION := 1.60.1
 
 all: $(BUILDDIR)
 
@@ -29,6 +30,5 @@ $(BUILDDIR)/git-validation:
 $(BUILDDIR)/go-md2man:
 	$(call go-build,./vendor/github.com/cpuguy83/go-md2man)
 
-$(BUILDDIR)/golangci-lint: VERSION=v1.55.2
 $(BUILDDIR)/golangci-lint:
-	curl -fsSL https://raw.githubusercontent.com/golangci/golangci-lint/$(VERSION)/install.sh | sh -s -- -b ./$(BUILDDIR) $(VERSION)
+	curl -fsSL https://raw.githubusercontent.com/golangci/golangci-lint/v$(GOLANGCI_LINT_VERSION)/install.sh | sh -s -- -b ./$(BUILDDIR) v$(GOLANGCI_LINT_VERSION)


### PR DESCRIPTION
This PR updates `golangci-lint` and fixes new warnings. 