### PR TITLE
Add doc comments around "string bool" usage

### DIFF
--- a/pkg/chunked/storage_linux.go
+++ b/pkg/chunked/storage_linux.go
@@ -973,6 +973,14 @@ type hardLinkToCreate struct {
 	metadata *fileMetadata
 }
 
+// parseBooleanPullOption coerces a string value we deserialized from toml into a bool value.
+// Any value which is not exactly the string "true" is treated as false, and no warning
+// is emitted.
+// Note that unlike e.g. use_composefs which is also a "string bool", this function
+// does not use https://pkg.go.dev/strconv#ParseBool
+// You can search the source code for the term "string bool" for other places to which behave similiarly.
+// Ideally of course we would parse booleans in a consistent
+// way - which would be most especially clear if we supported native TOML values.
 func parseBooleanPullOption(pullOptions map[string]string, name string, def bool) bool {
 	if value, ok := pullOptions[name]; ok {
 		return strings.ToLower(value) == "true"

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,6 +20,8 @@ type BtrfsOptionsConfig struct {
 type OverlayOptionsConfig struct {
 	// IgnoreChownErrors is a flag for whether chown errors should be
 	// ignored when building an image.
+	// This can take any value accepted by Go's https://pkg.go.dev/strconv#ParseBool
+	// Search the source code for the term "string bool" to find other places which behave similarly.
 	IgnoreChownErrors string `toml:"ignore_chown_errors,omitempty"`
 	// MountOpt specifies extra mount options used when mounting
 	MountOpt string `toml:"mountopt,omitempty"`
@@ -30,8 +32,12 @@ type OverlayOptionsConfig struct {
 	// Inodes is used to set a maximum inodes of the container image.
 	Inodes string `toml:"inodes,omitempty"`
 	// Do not create a bind mount on the storage home
+	// This can take any value accepted by Go's https://pkg.go.dev/strconv#ParseBool
+	// Search the source code for the term "string bool" to find other places which behave similarly.
 	SkipMountHome string `toml:"skip_mount_home,omitempty"`
-	// Specify whether composefs must be used to mount the data layers
+	// Specify whether composefs must be used to mount the data layers.
+	// This can take any value accepted by Go's https://pkg.go.dev/strconv#ParseBool
+	// Search the source code for the term "string bool" to find other places which behave similarly.
 	UseComposefs string `toml:"use_composefs,omitempty"`
 	// ForceMask indicates the permissions mask (e.g. "0755") to use for new
 	// files and directories


### PR DESCRIPTION
I've been poking at composefs related things here and stumbled across the very confusing fact that some values in the storage config are booleans - but must be
*strings* even though TOML supports native boolean values.

Further, digging in more we actually use two different parsers for boolean values; one silently accepts anything that is not the string `"true"` to mean `false`, but the other uses the Go strconv function and does return an error.

I'm not trying to fix any of this yet; the clear fix is to widen what we accept into a native TOML boolean type *in addition* which would require a bit of custom deserialization. Let's just document this to start.