### PR TITLE
storage.conf: Various cleanups

### DIFF
--- a/docs/containers-storage-composefs.md
+++ b/docs/containers-storage-composefs.md
@@ -3,7 +3,6 @@
 ## NAME
 containers-storage-composefs - Information about composefs and containers/storage
 
-
 ## DESCRIPTION
 
 To enable composefs at a baseline requires the following configuration in `containers-storage.conf`:
@@ -12,6 +11,8 @@ To enable composefs at a baseline requires the following configuration in `conta
 [storage.options.overlay]
 use_composefs = "true"
 ```
+
+This value must be a "string bool", it cannot be a native TOML boolean.
 
 However at the current time, composefs requires zstd:chunked images, so first
 you must be sure that zstd:chunked is enabled. For more, see [zstd:chunked](containers-storage-zstd-chunked.md).
@@ -23,8 +24,11 @@ latency to image pulls.
 Putting these things together, the following is required (in addition to the above config).
 
 ```
-pull_options = {enable_partial_images = "true", use_hard_links = "false", ostree_repos="", convert_images = "true"}
+[storage.options.pull_options]
+convert_images = "true"
 ```
+
+This value must be a "string bool", it cannot be a native TOML boolean.
 
 ## BUGS
 

--- a/docs/containers-storage-zstd-chunked.md
+++ b/docs/containers-storage-zstd-chunked.md
@@ -16,13 +16,16 @@ to include additional metadata (especially a "table of contents") that includes 
 Additionally chunks are compressed separately. This allows a client to dynamically fetch only content which
 it doesn't already have using HTTP range requests.
 
-To enable zstd:chunked requires the following changes to `containers-storage.conf`:
+At the time of this writing, support for this is enabled by default in the code.
+
+You can explicitly enable or disable zstd:chunked with following changes to `containers-storage.conf`:
 
 ```
-pull_options = {enable_partial_images = "true", use_hard_links = "false", ostree_repos=""}
+[storage.overlay.pull_options]
+enable_partial_images = "true" | "false"
 ```
 
-This option may or may not be enabled by default in your distribution/operating system.
+Note that the value of this field must be a "string bool", it cannot be a native TOML boolean.
 
 ## INTERNALS
 

--- a/storage.conf
+++ b/storage.conf
@@ -54,32 +54,31 @@ graphroot = "/var/lib/containers/storage"
 additionalimagestores = [
 ]
 
-# Allows specification of how storage is populated when pulling images. This
-# option can speed the pulling process of images compressed with format
-# zstd:chunked. Containers/storage looks for files within images that are being
-# pulled from a container registry that were previously pulled to the host.  It
-# can copy or create a hard link to the existing file when it finds them,
-# eliminating the need to pull them from the container registry. These options
-# can deduplicate pulling of content, disk storage of content and can allow the
-# kernel to use less memory when running containers.
+# Options controlling how storage is populated when pulling images. 
+[storage.options.pull_options]
+# Enable the "zstd:chunked" feature, which allows partial pulls, reusing
+# content that already exists on the system. This is enabled by default,
+# but can be explicitly disabled. For more on zstd:chunked, see
+# https://github.com/containers/storage/blob/main/docs/containers-storage-zstd-chunked.md
+# This is a "string bool": "false" | "true" (cannot be native TOML boolean)
+# enable_partial_images = "true"
 
-# containers/storage supports four keys
-#   * enable_partial_images="true" | "false"
-#     Tells containers/storage to look for files previously pulled in storage
-#     rather then always pulling them from the container registry.
-#   * use_hard_links = "false" | "true"
-#     Tells containers/storage to use hard links rather then create new files in
-#     the image, if an identical file already existed in storage.
-#   * ostree_repos = ""
-#     Tells containers/storage where an ostree repository exists that might have
-#     previously pulled content which can be used when attempting to avoid
-#     pulling content from the container registry
-#   * convert_images = "false" | "true"
-#     If set to true, containers/storage will convert images to a
-#     format compatible with partial pulls in order to take advantage
-#     of local deduplication and hard linking.  It is an expensive
-#     operation so it is not enabled by default.
-pull_options = {enable_partial_images = "true", use_hard_links = "false", ostree_repos=""}
+# Tells containers/storage to use hard links rather then create new files in
+# the image, if an identical file already existed in storage.
+# This is a "string bool": "false" | "true" (cannot be native TOML boolean)
+# use_hard_links = "false"
+
+# Path to an ostree repository that might have
+# previously pulled content which can be used when attempting to avoid
+# pulling content from the container registry
+# ostree_repos=""
+
+# If set to "true", containers/storage will convert images to a
+# format compatible with partial pulls in order to take advantage
+# of local deduplication and hard linking.  It is an expensive
+# operation so it is not enabled by default.
+# This is a "string bool": "false" | "true" (cannot be native TOML boolean)
+# convert_images = "false"
 
 # Root-auto-userns-user is a user name which can be used to look up one or more UID/GID
 # ranges in the /etc/subuid and /etc/subgid file.  These ranges will be partitioned
@@ -102,6 +101,7 @@ pull_options = {enable_partial_images = "true", use_hard_links = "false", ostree
 # squashed down to the default uid in the container.  These images will have no
 # separation between the users in the container. Only supported for the overlay
 # and vfs drivers.
+# This is a "string bool": "false" | "true" (cannot be native TOML boolean)
 #ignore_chown_errors = "false"
 
 # Inodes is used to set a maximum inodes of the container image.
@@ -115,9 +115,11 @@ pull_options = {enable_partial_images = "true", use_hard_links = "false", ostree
 mountopt = "nodev"
 
 # Set to skip a PRIVATE bind mount on the storage home directory.
+# This is a "string bool": "false" | "true" (cannot be native TOML boolean)
 # skip_mount_home = "false"
 
 # Set to use composefs to mount data layers with overlay.
+# This is a "string bool": "false" | "true" (cannot be native TOML boolean)
 # use_composefs = "false"
 
 # Size is used to set a maximum size of the container image.


### PR DESCRIPTION
The default storage.conf we ship is inconsistent in a few ways; there's a lot of fixes rolled up into this single commit.

First: we were using a toml "inline table" for the pull options, and then documenting each key in that table in one blob above. It simply looks much nicer to use a non-inline table - then we can move the docs next to each individual value. This is also more consistent with other sections of the config.

I also thinned out a bit the doc comments; I think instead of trying to have a longer explanation of zstd:chunked in the comments here we should refer to the man page, which is a better place to have details (and that we should fill out more).

Per another PR, I also stumbled across the fact that we have a lot of "string bool" values and cannot be native TOML booleans. Document that clearly next to each type.

We already have default values in the *code* for all of these, so comment them all out to be consistent with other values. (We're then getting closer to having the config file be entirely comments, but that's a distinct project)

Finally, update the recent man pages I added to match these changes.