### PR TITLE
pkg/fileutils: fix Lexists on FreeBSD

### DIFF
--- a/pkg/fileutils/exists_freebsd.go
+++ b/pkg/fileutils/exists_freebsd.go
@@ -1,10 +1,9 @@
-//go:build !windows && !freebsd
-// +build !windows,!freebsd
-
 package fileutils
 
 import (
+	"errors"
 	"os"
+	"syscall"
 
 	"golang.org/x/sys/unix"
 )
@@ -24,9 +23,13 @@ func Exists(path string) error {
 // Lexists checks whether a file or directory exists at the given path.
 // If the path is a symlink, the symlink itself is checked.
 func Lexists(path string) error {
-	// It uses unix.Faccessat which is a faster operation compared to os.Stat for
-	// simply checking the existence of a file.
+	// FreeBSD before 15.0 does not support the AT_SYMLINK_NOFOLLOW flag for
+	// faccessat. In this case, the call to faccessat will return EINVAL and
+	// we fall back to using Lstat.
 	err := unix.Faccessat(unix.AT_FDCWD, path, unix.F_OK, unix.AT_SYMLINK_NOFOLLOW)
+	if err != nil && errors.Is(err, syscall.EINVAL) {
+		_, err = os.Lstat(path)
+	}
 	if err != nil {
 		return &os.PathError{Op: "faccessat", Path: path, Err: err}
 	}


### PR DESCRIPTION
The faccessat system call does not support AT_SYMLINK_NOFOLLOW on FreeBSD versions before 15.0. This works around the limitation by falling back to os.Lstat if faccessat returns an EINVAL error.

I tested this on FreeBSD 14.x hosts using 'go test ./pkg/fileutils' as well as on a 15.0 prerelease host to verify that faccessat behaves as expected in 15.0.
