### PR TITLE
pkg/fileutils: fix Lexists on FreeBSD (second attempt)

### DIFF
--- a/pkg/fileutils/exists_freebsd.go
+++ b/pkg/fileutils/exists_freebsd.go
@@ -27,10 +27,11 @@ func Lexists(path string) error {
 	// faccessat. In this case, the call to faccessat will return EINVAL and
 	// we fall back to using Lstat.
 	err := unix.Faccessat(unix.AT_FDCWD, path, unix.F_OK, unix.AT_SYMLINK_NOFOLLOW)
-	if err != nil && errors.Is(err, syscall.EINVAL) {
-		_, err = os.Lstat(path)
-	}
 	if err != nil {
+		if errors.Is(err, syscall.EINVAL) {
+			_, err = os.Lstat(path)
+			return err
+		}
 		return &os.PathError{Op: "faccessat", Path: path, Err: err}
 	}
 	return nil


### PR DESCRIPTION
The previous attempt worked with 'podman image load' but not 'podman image save' since the error returned from Lexists for non-existent files was not recognized by os.IsNotExist. This version returns well-formed errors for non-existent files and works with both 'podman image load' and 'podman image save'.