### PR TITLE
Ignore rootless EPERM failures setting security xattrs

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -427,7 +427,7 @@ func readSecurityXattrToTarHeader(path string, hdr *tar.Header) error {
 	}
 	for _, xattr := range []string{"security.capability", "security.ima"} {
 		capability, err := system.Lgetxattr(path, xattr)
-		if err != nil && !errors.Is(err, system.EOPNOTSUPP) && err != system.ErrNotSupportedPlatform {
+		if err != nil && !errors.Is(err, system.EOPNOTSUPP) && err != system.ErrNotSupportedPlatform && !(unshare.IsRootless() && errors.Is(err, syscall.EPERM)) {
 			return fmt.Errorf("failed to read %q attribute from %q: %w", xattr, path, err)
 		}
 		if capability != nil {


### PR DESCRIPTION
This is specifically for the IMA xattrs, which cannot be set except as root; as rootless, they fail with EPERM. We never noticed this before (likely because IMA xattrs seem uncommon in the wild) but if there is a file in an image with an IMA xattr rootless Podman becomes completely unable to use the image. This is particularly relevant because the catatonit binary Podman uses for building its pause image has started to include an IMA xattr on Fedora Rawhide, which is breaking rootless Podman there rather badly.

Since this cannot work as rootless, it seems simplest to try to set the xattr, but tolerate failure iff the error is EPERM and we are not run as root.

Fixes: https://github.com/containers/podman/issues/18543