### PR TITLE
Treat XDG_CONFIG_HOME and $HOME/.config the same way

### DIFF
--- a/pkg/homedir/homedir.go
+++ b/pkg/homedir/homedir.go
@@ -6,11 +6,16 @@ import (
 	"path/filepath"
 )
 
-// GetDataHome returns XDG_DATA_HOME.
-// GetDataHome returns $HOME/.local/share and nil error if XDG_DATA_HOME is not set.
+// DataHome (deprecated)
+func GetDataHome() (string, error) {
+	return DataHome()
+}
+
+// DataHome returns XDG_DATA_HOME.
+// DataHome returns $HOME/.local/share and nil error if XDG_DATA_HOME is not set.
 //
 // See also https://standards.freedesktop.org/basedir-spec/latest/ar01s03.html
-func GetDataHome() (string, error) {
+func DataHome() (string, error) {
 	if xdgDataHome := os.Getenv("XDG_DATA_HOME"); xdgDataHome != "" {
 		return xdgDataHome, nil
 	}
@@ -21,11 +26,16 @@ func GetDataHome() (string, error) {
 	return filepath.Join(home, ".local", "share"), nil
 }
 
-// GetCacheHome returns XDG_CACHE_HOME.
-// GetCacheHome returns $HOME/.cache and nil error if XDG_CACHE_HOME is not set.
+// GetCacheHome (deprecated)
+func GetCacheHome() (string, error) {
+	return CacheHome()
+}
+
+// CacheHome returns XDG_CACHE_HOME.
+// CacheHome returns $HOME/.cache and nil error if XDG_CACHE_HOME is not set.
 //
 // See also https://standards.freedesktop.org/basedir-spec/latest/ar01s03.html
-func GetCacheHome() (string, error) {
+func CacheHome() (string, error) {
 	if xdgCacheHome := os.Getenv("XDG_CACHE_HOME"); xdgCacheHome != "" {
 		return xdgCacheHome, nil
 	}
@@ -34,4 +44,14 @@ func GetCacheHome() (string, error) {
 		return "", errors.New("could not get either XDG_CACHE_HOME or HOME")
 	}
 	return filepath.Join(home, ".cache"), nil
+}
+
+// GetRuntimeDir (deprecated)
+func GetRuntimeDir() (string, error) {
+	return RuntimeDir()
+}
+
+// GetShortcutString (deprecated)
+func GetShortcutString() string {
+	return ShortcutString()
 }

--- a/pkg/homedir/homedir_windows.go
+++ b/pkg/homedir/homedir_windows.go
@@ -26,16 +26,21 @@ func Get() string {
 	return home
 }
 
-// GetConfigHome returns the home directory of the current user with the help of
+// GetConfigHome (deprecated)
+func GetConfigHome() (string, error) {
+	return ConfigHome()
+}
+
+// ConfigHome returns the home directory of the current user with the help of
 // environment variables depending on the target operating system.
 // Returned path should be used with "path/filepath" to form new paths.
-func GetConfigHome() (string, error) {
+func ConfigHome() (string, error) {
 	return filepath.Join(Get(), ".config"), nil
 }
 
-// GetShortcutString returns the string that is shortcut to user's home directory
+// ShortcutString returns the string that is shortcut to user's home directory
 // in the native shell of the platform running on.
-func GetShortcutString() string {
+func ShortcutString() string {
 	return "%USERPROFILE%" // be careful while using in format functions
 }
 
@@ -44,15 +49,15 @@ func StickRuntimeDirContents(files []string) ([]string, error) {
 	return nil, nil
 }
 
-// GetRuntimeDir returns a directory suitable to store runtime files.
+// RuntimeDir returns a directory suitable to store runtime files.
 // The function will try to use the XDG_RUNTIME_DIR env variable if it is set.
 // XDG_RUNTIME_DIR is typically configured via pam_systemd.
-// If XDG_RUNTIME_DIR is not set, GetRuntimeDir will try to find a suitable
+// If XDG_RUNTIME_DIR is not set, RuntimeDir will try to find a suitable
 // directory for the current user.
 //
 // See also https://standards.freedesktop.org/basedir-spec/latest/ar01s03.html
-func GetRuntimeDir() (string, error) {
-	data, err := GetDataHome()
+func RuntimeDir() (string, error) {
+	data, err := DataHome()
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Currently we handle XDG_CONFIG_HOME and the fallback $HOME/.config differently. We create the later if it does not exist and verify that it is owned by the current user. This patch makes XDG_CONFIG_HOME follow the same pattern.