### PR TITLE
Dedup fs-verity-digests metadata key definition

### DIFF
--- a/drivers/overlay/composefs.go
+++ b/drivers/overlay/composefs.go
@@ -21,6 +21,9 @@ import (
 	"golang.org/x/sys/unix"
 )
 
+// Key used to find the lookaside digests in associated data with a layer
+const FsVerityDigestsKey = "fs-verity-digests"
+
 var (
 	composeFsHelperOnce sync.Once
 	composeFsHelperPath string

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -88,8 +88,7 @@ const (
 
 	stagingLockFile = "staging.lock"
 
-	tocArtifact             = "toc"
-	fsVerityDigestsArtifact = "fs-verity-digests"
+	tocArtifact = "toc"
 
 	// idLength represents the number of random characters
 	// which can be used to create the unique link identifier
@@ -2284,7 +2283,7 @@ func (d *Driver) ApplyDiffFromStagingDirectory(id, parent string, diffOutput *gr
 
 	if d.usingComposefs {
 		toc := diffOutput.Artifacts[tocArtifact]
-		verityDigests := diffOutput.Artifacts[fsVerityDigestsArtifact].(map[string]string)
+		verityDigests := diffOutput.Artifacts[FsVerityDigestsKey].(map[string]string)
 		if err := generateComposeFsBlob(verityDigests, toc, d.getComposefsData(id)); err != nil {
 			return err
 		}

--- a/pkg/chunked/storage_linux.go
+++ b/pkg/chunked/storage_linux.go
@@ -20,6 +20,7 @@ import (
 	"github.com/containerd/stargz-snapshotter/estargz"
 	storage "github.com/containers/storage"
 	graphdriver "github.com/containers/storage/drivers"
+	"github.com/containers/storage/drivers/overlay"
 	"github.com/containers/storage/pkg/archive"
 	"github.com/containers/storage/pkg/chunked/compressor"
 	"github.com/containers/storage/pkg/chunked/internal"
@@ -44,7 +45,6 @@ const (
 	chunkedData             = "zstd-chunked-data"
 	chunkedLayerDataKey     = "zstd-chunked-layer-data"
 	tocKey                  = "toc"
-	fsVerityDigestsKey      = "fs-verity-digests"
 
 	fileTypeZstdChunked = iota
 	fileTypeEstargz
@@ -1554,7 +1554,7 @@ func (c *chunkedDiffer) ApplyDiff(dest string, options *archive.TarOptions, diff
 		logrus.Debugf("Missing %d bytes out of %d (%.2f %%)", missingPartsSize, totalChunksSize, float32(missingPartsSize*100.0)/float32(totalChunksSize))
 	}
 
-	output.Artifacts[fsVerityDigestsKey] = c.fsVerityDigests
+	output.Artifacts[overlay.FsVerityDigestsKey] = c.fsVerityDigests
 
 	return output, nil
 }


### PR DESCRIPTION
I was just reading this code and found it odd that we had two definitions. This just makes it a public constant in the overlay code.