### PR TITLE
pkg/directory: correctly ignore ENOENT while walking

### DIFF
--- a/pkg/directory/directory_unix.go
+++ b/pkg/directory/directory_unix.go
@@ -4,8 +4,8 @@
 package directory
 
 import (
+	"errors"
 	"io/fs"
-	"os"
 	"path/filepath"
 	"syscall"
 )
@@ -27,7 +27,7 @@ func Usage(dir string) (usage *DiskUsage, err error) {
 		if err != nil {
 			// if dir does not exist, Usage() returns the error.
 			// if dir/x disappeared while walking, Usage() ignores dir/x.
-			if os.IsNotExist(err) && d != dir {
+			if errors.Is(err, fs.ErrNotExist) && d != dir {
 				return nil
 			}
 			return err
@@ -35,6 +35,9 @@ func Usage(dir string) (usage *DiskUsage, err error) {
 
 		fileInfo, err := entry.Info()
 		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return nil
+			}
 			return err
 		}
 

--- a/pkg/directory/directory_windows.go
+++ b/pkg/directory/directory_windows.go
@@ -4,8 +4,8 @@
 package directory
 
 import (
+	"errors"
 	"io/fs"
-	"os"
 	"path/filepath"
 )
 
@@ -25,7 +25,7 @@ func Usage(dir string) (usage *DiskUsage, err error) {
 		if err != nil {
 			// if dir does not exist, Size() returns the error.
 			// if dir/x disappeared while walking, Size() ignores dir/x.
-			if os.IsNotExist(err) && path != dir {
+			if errors.Is(err, fs.ErrNotExist) && path != dir {
 				return nil
 			}
 			return err
@@ -40,6 +40,9 @@ func Usage(dir string) (usage *DiskUsage, err error) {
 
 		fileInfo, err := d.Info()
 		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return nil
+			}
 			return err
 		}
 		usage.Size += fileInfo.Size()


### PR DESCRIPTION
As documented in (fs.DirEntry) Info() it can return ENOENT so we must ignore it there as well. Reported in
https://github.com/containers/podman/issues/23909

Given this is a race I don't think I can add a test here.