### PR TITLE
userns: skip "nogroup"

### DIFF
--- a/userns.go
+++ b/userns.go
@@ -99,7 +99,7 @@ func parseMountedFiles(containerMount, passwdFile, groupFile string) uint32 {
 		for _, u := range users {
 			// Skip the "nobody" user otherwise we end up with 65536
 			// ids with most images
-			if u.Name == "nobody" {
+			if u.Name == "nobody" || u.Name == "nogroup" {
 				continue
 			}
 			if u.Uid > size && u.Uid != nobodyUser {
@@ -114,7 +114,7 @@ func parseMountedFiles(containerMount, passwdFile, groupFile string) uint32 {
 	groups, err := libcontainerUser.ParseGroupFile(groupFile)
 	if err == nil {
 		for _, g := range groups {
-			if g.Name == "nobody" {
+			if g.Name == "nobody" || g.Name == "nogroup" {
 				continue
 			}
 			if g.Gid > size && g.Gid != nobodyUser {

--- a/userns_test.go
+++ b/userns_test.go
@@ -228,6 +228,15 @@ nobody:x:65534:`,
 			groupContent:  "FOOBAR",
 			expectedMax:   0,
 		},
+		{
+			name:          "nogroup ignored",
+			passwdContent: "",
+			groupContent: `
+root:x:0:
+admin:x:4000:
+nogroup:x:65533:`,
+			expectedMax: 4001,
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
the alpine image defines a "nogroup":

$ podman run --rm alpine grep nogroup /etc/group
nogroup:x:65533:

ignore it as we are already doing for the "nobody" user.