### PR TITLE
CI: Fix `git-validation.sh`

### DIFF
--- a/hack/git-validation.sh
+++ b/hack/git-validation.sh
@@ -5,5 +5,9 @@ if [ ! -x "$GIT_VALIDATION" ]; then
 	echo Try installing it with \"make install.tools\"
 	exit 1
 fi
-EPOCH_TEST_COMMIT=$(git merge-base ${DEST_BRANCH:-main} HEAD)
+
+EPOCH_TEST_COMMIT=$CIRRUS_BASE_SHA
+if [ -z "${EPOCH_TEST_COMMIT}" ]; then
+	EPOCH_TEST_COMMIT=$(git merge-base ${DEST_BRANCH:-main} HEAD)
+fi
 exec "$GIT_VALIDATION" -q -run DCO,short-subject -range "${EPOCH_TEST_COMMIT}..HEAD"


### PR DESCRIPTION
This PR fixes `git-validation.sh`, failing in Cirrus CI. The problem was caused by the missing `main` branch. Cirrus CI performs a clone of a single branch with full Git history and no tags. 


Fixes: #2067