### PR TITLE
Fix assignment of quota project IDs

### DIFF
--- a/drivers/quota/projectquota_supported.go
+++ b/drivers/quota/projectquota_supported.go
@@ -18,6 +18,16 @@ package quota
 #include <linux/quota.h>
 #include <linux/dqblk_xfs.h>
 
+#ifndef FS_XFLAG_PROJINHERIT
+struct fsxattr {
+	__u32		fsx_xflags;
+	__u32		fsx_extsize;
+	__u32		fsx_nextents;
+	__u32		fsx_projid;
+	unsigned char	fsx_pad[12];
+};
+#define FS_XFLAG_PROJINHERIT	0x00000200
+#endif
 #ifndef FS_IOC_FSGETXATTR
 #define FS_IOC_FSGETXATTR		_IOR ('X', 31, struct fsxattr)
 #endif
@@ -346,6 +356,7 @@ func setProjectID(targetPath string, projectID uint32) error {
 		return fmt.Errorf("failed to get projid for %s: %w", targetPath, errno)
 	}
 	fsx.fsx_projid = C.__u32(projectID)
+	fsx.fsx_xflags |= C.FS_XFLAG_PROJINHERIT
 	_, _, errno = unix.Syscall(unix.SYS_IOCTL, getDirFd(dir), C.FS_IOC_FSSETXATTR,
 		uintptr(unsafe.Pointer(&fsx)))
 	if errno != 0 {

--- a/drivers/quota/projectquota_supported.go
+++ b/drivers/quota/projectquota_supported.go
@@ -172,6 +172,11 @@ func NewControl(basePath string) (*Control, error) {
 		return nil, err
 	}
 
+	// Clear inherit flag from top-level directory if necessary.
+	if err := stripProjectInherit(basePath); err != nil {
+		return nil, err
+	}
+
 	//
 	// get first project id to be used for next container
 	//
@@ -349,6 +354,8 @@ func setProjectID(targetPath string, projectID uint32) error {
 	}
 	defer closeDir(dir)
 
+	logrus.Debugf("Setting quota project ID %d on %s", projectID, targetPath)
+
 	var fsx C.struct_fsxattr
 	_, _, errno := unix.Syscall(unix.SYS_IOCTL, getDirFd(dir), C.FS_IOC_FSGETXATTR,
 		uintptr(unsafe.Pointer(&fsx)))
@@ -363,6 +370,36 @@ func setProjectID(targetPath string, projectID uint32) error {
 		return fmt.Errorf("failed to set projid for %s: %w", targetPath, errno)
 	}
 
+	return nil
+}
+
+// stripProjectInherit strips the project inherit flag from a directory.
+// Used on the top-level directory to ensure project IDs are only inherited for
+// files in directories we set quotas on - not the directories we want to set
+// the quotas on, as that would make everything use the same project ID.
+func stripProjectInherit(targetPath string) error {
+	dir, err := openDir(targetPath)
+	if err != nil {
+		return err
+	}
+	defer closeDir(dir)
+
+	var fsx C.struct_fsxattr
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, getDirFd(dir), C.FS_IOC_FSGETXATTR,
+		uintptr(unsafe.Pointer(&fsx)))
+	if errno != 0 {
+		return fmt.Errorf("failed to get xfs attrs for %s: %w", targetPath, errno)
+	}
+	if fsx.fsx_xflags&C.FS_XFLAG_PROJINHERIT != 0 {
+		// Flag is set, need to clear it.
+		logrus.Debugf("Clearing PROJINHERIT flag from directory %s", targetPath)
+		fsx.fsx_xflags = fsx.fsx_xflags &^ C.FS_XFLAG_PROJINHERIT
+		_, _, errno = unix.Syscall(unix.SYS_IOCTL, getDirFd(dir), C.FS_IOC_FSSETXATTR,
+			uintptr(unsafe.Pointer(&fsx)))
+		if errno != 0 {
+			return fmt.Errorf("failed to clear PROJINHERIT for %s: %w", targetPath, errno)
+		}
+	}
 	return nil
 }
 


### PR DESCRIPTION
This PR reverts #1921 which completely removed the PROJINHERIT flag from our quota support. That did not actually fix the problem, it just papered over a few of the cracks. The actual problem is that configuring quota support on the system using our recommended commands sets the PROJINHERIT flag on the top-level directory in some (but not all, for unclear reasons?) cases. We set a project ID on the base directory to give us a base value for subsequent ID assignments, but if the base directory has PROJINHERIT that base ID prevents us from setting new IDs on any subdirectories. Strip the flag from the top-level directory if present to resolve.

There is a second problem, in that Podman is choosing the wrong directory to assign quotas to, but that must be fixed in Podman after this merges.

Fixes https://issues.redhat.com/browse/RHEL-18038