### PR TITLE
ci: add codespell

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -180,6 +180,13 @@ gofix_task:
     build_script: go fix ./...
     test_script: git diff --exit-code
 
+codespell_task:
+    alias: codespell
+    container:
+        image: python
+    build_script: pip install codespell
+    test_script: codespell
+
 
 # Status aggregator for all tests.  This task simply ensures a defined
 # set of tasks all passed, and allows confirming that based on the status
@@ -197,6 +204,7 @@ success_task:
         - vendor
         - cross
         - gofix
+        - codespell
     container:
         image: golang:1.21
     clone_script: 'mkdir -p "$CIRRUS_WORKING_DIR"'  # Source code not needed

--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,3 @@
+[codespell]
+skip = ./.git,./vendor,./tests/tools/vendor,AUTHORS
+ignore-words-list = afile,flate,prevend,Plack,worl

--- a/Makefile
+++ b/Makefile
@@ -46,7 +46,7 @@ containers-storage: ## build using gc on the host
 	$(GO) build -compiler gc $(BUILDFLAGS) ./cmd/containers-storage
 
 codespell:
-	codespell -S Makefile,build,buildah,buildah.spec,imgtype,copy,AUTHORS,bin,vendor,.git,go.sum,CHANGELOG.md,changelog.txt,seccomp.json,.cirrus.yml,"*.xz,*.gz,*.tar,*.tgz,*ico,*.png,*.1,*.5,*.orig,*.rej" -L plack,worl,flate,uint,iff,od,ERRO -w
+	codespell
 
 binary local-binary: containers-storage
 

--- a/pkg/chunked/cache_linux.go
+++ b/pkg/chunked/cache_linux.go
@@ -274,7 +274,7 @@ func (c *layersCache) load() error {
 	var newLayers []*layer
 	for _, r := range allLayers {
 		// The layer is present in the store and it is already loaded.  Attempt to
-		// re-use it if mmap'ed.
+		// reuse it if mmap'ed.
 		if l, found := loadedLayers[r.ID]; found {
 			// If the layer is not marked for re-load, move it to newLayers.
 			if !l.reloadWithMmap {

--- a/pkg/idtools/idtools.go
+++ b/pkg/idtools/idtools.go
@@ -367,7 +367,7 @@ func checkChownErr(err error, name string, uid, gid int) error {
 	return err
 }
 
-// Stat contains file states that can be overriden with ContainersOverrideXattr.
+// Stat contains file states that can be overridden with ContainersOverrideXattr.
 type Stat struct {
 	IDs  IDPair
 	Mode os.FileMode


### PR DESCRIPTION
1. Move codespell config out of Makefile, simplify (remove unused stuff).

2. Fix found issues (using `codespell -w`).

3. Add a codespell CI job.