### PR TITLE
composefs: use mount from file where supported

### DIFF
--- a/drivers/overlay/composefs.go
+++ b/drivers/overlay/composefs.go
@@ -172,7 +172,7 @@ func openComposefsMount(dataDir string) (int, error) {
 	if err := unix.FsconfigCreate(fsfd); err != nil {
 		buffer := make([]byte, 4096)
 		if n, _ := unix.Read(fsfd, buffer); n > 0 {
-			return -1, fmt.Errorf("failed to create erofs filesystem: %s: %w", string(buffer[:n]), err)
+			return -1, fmt.Errorf("failed to create erofs filesystem: %s: %w", strings.TrimSuffix(string(buffer[:n]), "\n"), err)
 		}
 		return -1, fmt.Errorf("failed to create erofs filesystem: %w", err)
 	}

--- a/drivers/overlay/composefs.go
+++ b/drivers/overlay/composefs.go
@@ -12,6 +12,7 @@ import (
 	"path/filepath"
 	"strings"
 	"sync"
+	"sync/atomic"
 
 	"github.com/containers/storage/pkg/chunked/dump"
 	"github.com/containers/storage/pkg/fsverity"
@@ -24,6 +25,10 @@ var (
 	composeFsHelperOnce sync.Once
 	composeFsHelperPath string
 	composeFsHelperErr  error
+
+	// skipMountViaFile is used to avoid trying to mount EROFS directly via the file if we already know the current kernel
+	// does not support it.  Mounting directly via a file will be supported in kernel 6.12.
+	skipMountViaFile atomic.Bool
 )
 
 func getComposeFsHelper() (string, error) {
@@ -136,12 +141,16 @@ func hasACL(path string) (bool, error) {
 	return binary.LittleEndian.Uint32(flags)&LCFS_EROFS_FLAGS_HAS_ACL != 0, nil
 }
 
-func openBlobFile(blobFile string, hasACL bool) (int, error) {
-	loop, err := loopback.AttachLoopDeviceRO(blobFile)
-	if err != nil {
-		return -1, err
+func openBlobFile(blobFile string, hasACL, useLoopDevice bool) (int, error) {
+	if useLoopDevice {
+		loop, err := loopback.AttachLoopDeviceRO(blobFile)
+		if err != nil {
+			return -1, err
+		}
+		defer loop.Close()
+
+		blobFile = loop.Name()
 	}
-	defer loop.Close()
 
 	fsfd, err := unix.Fsopen("erofs", 0)
 	if err != nil {
@@ -149,7 +158,7 @@ func openBlobFile(blobFile string, hasACL bool) (int, error) {
 	}
 	defer unix.Close(fsfd)
 
-	if err := unix.FsconfigSetString(fsfd, "source", loop.Name()); err != nil {
+	if err := unix.FsconfigSetString(fsfd, "source", blobFile); err != nil {
 		return -1, fmt.Errorf("failed to set source for erofs filesystem: %w", err)
 	}
 
@@ -190,7 +199,16 @@ func openComposefsMount(dataDir string) (int, error) {
 		return -1, err
 	}
 
-	return openBlobFile(blobFile, hasACL)
+	if !skipMountViaFile.Load() {
+		fd, err := openBlobFile(blobFile, hasACL, false)
+		if err == nil || !errors.Is(err, unix.ENOTBLK) {
+			return fd, err
+		}
+		logrus.Debugf("The current kernel doesn't support mounting EROFS directly from a file, fallback to a loopback device")
+		skipMountViaFile.Store(true)
+	}
+
+	return openBlobFile(blobFile, hasACL, true)
 }
 
 func mountComposefsBlob(dataDir, mountPoint string) error {


### PR DESCRIPTION
https://git.kernel.org/pub/scm/linux/kernel/git/torvalds/linux.git/commit/?id=fb176750266a3d7f42ebdcf28e8ba40350b27847 adds the possibility to mount a EROFS file system directly from its backing file instead of using a loopback device.
