### PR TITLE
fsdiff: mount both layers are read-only

### DIFF
--- a/drivers/fsdiff.go
+++ b/drivers/fsdiff.go
@@ -128,6 +128,7 @@ func (gdw *NaiveDiffDriver) Changes(id string, idMappings *idtools.IDMappings, p
 
 	options := MountOpts{
 		MountLabel: mountLabel,
+		Options:    []string{"ro"},
 	}
 	layerFs, err := driver.Get(id, options)
 	if err != nil {
@@ -138,10 +139,6 @@ func (gdw *NaiveDiffDriver) Changes(id string, idMappings *idtools.IDMappings, p
 	parentFs := ""
 
 	if parent != "" {
-		options := MountOpts{
-			MountLabel: mountLabel,
-			Options:    []string{"ro"},
-		}
 		parentFs, err = driver.Get(parent, options)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
there is no reason to mount the first layer as writeable.  If fixes mounting layers that are in a read-only location like an additional image store, or are backed by composefs.