### PR TITLE
Compute an uncompressed digest for chunked layers

### DIFF
--- a/docs/containers-storage.conf.5.md
+++ b/docs/containers-storage.conf.5.md
@@ -124,6 +124,27 @@ The `storage.options.pull_options` table supports the following keys:
   It is an expensive operation so it is not enabled by default.
   This is a "string bool": "false"|"true" (cannot be native TOML boolean)
 
+**insecure_allow_unpredictable_image_contents="false"|"true"**
+  This should _almost never_ be set.
+  It allows partial pulls of images without guaranteeing that "partial
+  pulls" and non-partial pulls both result in consistent image contents.
+  This allows pulling estargz images and early versions of zstd:chunked images;
+  otherwise, these layers always use the traditional non-partial pull path.
+
+  This option should be enabled _extremely_ rarely, only if _all_ images that could
+  EVER be conceivably pulled on this system are _guaranteed_ (e.g. using a signature policy)
+  to come from a build system trusted to never attack image integrity.
+
+  If this consistency enforcement were disabled, malicious images could be built
+  in a way designed to evade other audit mechanisms, so presence of most other audit
+  mechanisms is not a replacement for the above-mentioned need for all images to come
+  from a trusted build system.
+
+  As a side effect, enabling this option will also make image IDs unpredictable
+  (usually not equal to the traditional value matching the config digest).
+
+  This is a "string bool": "false"|"true" (cannot be native TOML boolean)
+
 ### STORAGE OPTIONS FOR AUFS TABLE
 
 The `storage.options.aufs` table supports the following options:

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -231,8 +231,8 @@ const (
 	// DifferOutputFormatDir means the output is a directory and it will
 	// keep the original layout.
 	DifferOutputFormatDir = iota
-	// DifferOutputFormatFlat will store the files by their checksum, in the form
-	// checksum[0:2]/checksum[2:]
+	// DifferOutputFormatFlat will store the files by their checksum, per
+	// pkg/chunked/internal/composefs.RegularFilePathForValidatedDigest.
 	DifferOutputFormatFlat
 )
 

--- a/pkg/chunked/cache_linux.go
+++ b/pkg/chunked/cache_linux.go
@@ -710,7 +710,7 @@ func prepareCacheFile(manifest []byte, format graphdriver.DifferOutputFormat) ([
 	switch format {
 	case graphdriver.DifferOutputFormatDir:
 	case graphdriver.DifferOutputFormatFlat:
-		entries, err = makeEntriesFlat(entries)
+		entries, err = makeEntriesFlat(entries, nil)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/chunked/dump/dump_test.go
+++ b/pkg/chunked/dump/dump_test.go
@@ -59,7 +59,7 @@ func TestDumpNode(t *testing.T) {
 		Devminor: 0,
 		ModTime:  &modTime,
 		Linkname: "",
-		Digest:   "sha256:abcdef1234567890",
+		Digest:   "sha256:0123456789abcdef1123456789abcdef2123456789abcdef3123456789abcdef",
 		Xattrs: map[string]string{
 			"user.key1": base64.StdEncoding.EncodeToString([]byte("value1")),
 		},
@@ -150,7 +150,7 @@ func TestDumpNode(t *testing.T) {
 			entries: []*minimal.FileMetadata{
 				regularFileEntry,
 			},
-			expected: "/example.txt 100 100000 1 1000 1000 0 1672531200.0 ab/cdef1234567890 - - user.key1=value1\n",
+			expected: "/example.txt 100 100000 1 1000 1000 0 1672531200.0 01/23456789abcdef1123456789abcdef2123456789abcdef3123456789abcdef - - user.key1=value1\n",
 		},
 		{
 			name: "root entry with file",
@@ -158,7 +158,7 @@ func TestDumpNode(t *testing.T) {
 				rootEntry,
 				regularFileEntry,
 			},
-			expected:            "/ 0 40000 1 0 0 0 1672531200.0 - - -\n/example.txt 100 100000 1 1000 1000 0 1672531200.0 ab/cdef1234567890 - - user.key1=value1\n",
+			expected:            "/ 0 40000 1 0 0 0 1672531200.0 - - -\n/example.txt 100 100000 1 1000 1000 0 1672531200.0 01/23456789abcdef1123456789abcdef2123456789abcdef3123456789abcdef - - user.key1=value1\n",
 			skipAddingRootEntry: true,
 		},
 		{
@@ -196,7 +196,7 @@ func TestDumpNode(t *testing.T) {
 				regularFileEntry,
 				directoryEntry,
 			},
-			expected:            "/ 0 40000 1 0 0 0 1672531200.0 - - -\n/example.txt 100 100000 1 1000 1000 0 1672531200.0 ab/cdef1234567890 - - user.key1=value1\n/mydir 0 40000 1 1000 1000 0 1672531200.0 - - - user.key2=value2\n",
+			expected:            "/ 0 40000 1 0 0 0 1672531200.0 - - -\n/example.txt 100 100000 1 1000 1000 0 1672531200.0 01/23456789abcdef1123456789abcdef2123456789abcdef3123456789abcdef - - user.key1=value1\n/mydir 0 40000 1 1000 1000 0 1672531200.0 - - - user.key2=value2\n",
 			skipAddingRootEntry: true,
 		},
 	}

--- a/pkg/chunked/internal/path/path.go
+++ b/pkg/chunked/internal/path/path.go
@@ -1,7 +1,10 @@
 package path
 
 import (
+	"fmt"
 	"path/filepath"
+
+	"github.com/opencontainers/go-digest"
 )
 
 // CleanAbsPath removes any ".." and "." from the path
@@ -9,4 +12,16 @@ import (
 // directory, it returns "/".
 func CleanAbsPath(path string) string {
 	return filepath.Clean("/" + path)
+}
+
+// RegularFilePath returns the path used in the composefs backing store for a
+// regular file with the provided content digest.
+//
+// The caller MUST ensure d is a valid digest (in particular, that it contains no path separators or .. entries)
+func RegularFilePathForValidatedDigest(d digest.Digest) (string, error) {
+	if algo := d.Algorithm(); algo != digest.SHA256 {
+		return "", fmt.Errorf("unexpected digest algorithm %q", algo)
+	}
+	e := d.Encoded()
+	return e[0:2] + "/" + e[2:], nil
 }

--- a/pkg/chunked/internal/path/path_test.go
+++ b/pkg/chunked/internal/path/path_test.go
@@ -4,7 +4,9 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/opencontainers/go-digest"
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestCleanAbsPath(t *testing.T) {
@@ -45,4 +47,17 @@ func TestCleanAbsPath(t *testing.T) {
 	for _, test := range tests {
 		assert.Equal(t, test.expected, CleanAbsPath(test.path), fmt.Sprintf("path %q failed", test.path))
 	}
+}
+
+func TestRegularFilePathForValidatedDigest(t *testing.T) {
+	d, err := digest.Parse("sha256:0123456789abcdef1123456789abcdef2123456789abcdef3123456789abcdef")
+	require.NoError(t, err)
+	res, err := RegularFilePathForValidatedDigest(d)
+	require.NoError(t, err)
+	assert.Equal(t, "01/23456789abcdef1123456789abcdef2123456789abcdef3123456789abcdef", res)
+
+	d, err = digest.Parse("sha512:0123456789abcdef1123456789abcdef2123456789abcdef3123456789abcdef0123456789abcdef1123456789abcdef2123456789abcdef3123456789abcdef")
+	require.NoError(t, err)
+	_, err = RegularFilePathForValidatedDigest(d)
+	assert.Error(t, err)
 }

--- a/pkg/chunked/storage_linux.go
+++ b/pkg/chunked/storage_linux.go
@@ -132,7 +132,11 @@ func parsePullOptions(store storage.Store) pullOptions {
 		{&res.convertImages, "convert_images", false},
 		{&res.useHardLinks, "use_hard_links", false},
 	} {
-		*e.dest = parseBooleanPullOption(options, e.name, e.defaultValue)
+		if value, ok := options[e.name]; ok {
+			*e.dest = strings.ToLower(value) == "true"
+		} else {
+			*e.dest = e.defaultValue
+		}
 	}
 	res.ostreeRepos = strings.Split(options["ostree_repos"], ":")
 
@@ -1070,13 +1074,6 @@ type hardLinkToCreate struct {
 	dirfd    int
 	mode     os.FileMode
 	metadata *fileMetadata
-}
-
-func parseBooleanPullOption(pullOptions map[string]string, name string, def bool) bool {
-	if value, ok := pullOptions[name]; ok {
-		return strings.ToLower(value) == "true"
-	}
-	return def
 }
 
 type findAndCopyFileOptions struct {

--- a/pkg/chunked/storage_linux.go
+++ b/pkg/chunked/storage_linux.go
@@ -1120,7 +1120,7 @@ func (c *chunkedDiffer) findAndCopyFile(dirfd int, r *fileMetadata, copyOptions 
 func makeEntriesFlat(mergedEntries []fileMetadata) ([]fileMetadata, error) {
 	var new []fileMetadata
 
-	hashes := make(map[string]string)
+	knownFlatPaths := make(map[string]struct{})
 	for i := range mergedEntries {
 		if mergedEntries[i].Type != TypeReg {
 			continue
@@ -1133,13 +1133,14 @@ func makeEntriesFlat(mergedEntries []fileMetadata) ([]fileMetadata, error) {
 			return nil, err
 		}
 		d := digest.Encoded()
+		path := fmt.Sprintf("%s/%s", d[0:2], d[2:])
 
-		if hashes[d] != "" {
+		if _, known := knownFlatPaths[path]; known {
 			continue
 		}
-		hashes[d] = d
+		knownFlatPaths[path] = struct{}{}
 
-		mergedEntries[i].Name = fmt.Sprintf("%s/%s", d[0:2], d[2:])
+		mergedEntries[i].Name = path
 		mergedEntries[i].skipSetAttrs = true
 
 		new = append(new, mergedEntries[i])

--- a/storage.conf
+++ b/storage.conf
@@ -80,6 +80,25 @@ additionalimagestores = [
 # This is a "string bool": "false" | "true" (cannot be native TOML boolean)
 # convert_images = "false"
 
+# This should ALMOST NEVER be set.
+# It allows partial pulls of images without guaranteeing that "partial
+# pulls" and non-partial pulls both result in consistent image contents.
+# This allows pulling estargz images and early versions of zstd:chunked images;
+# otherwise, these layers always use the traditional non-partial pull path.
+#
+# This option should be enabled EXTREMELY rarely, only if ALL images that could
+# EVER be conceivably pulled on this system are GUARANTEED (e.g. using a signature policy)
+# to come from a build system trusted to never attack image integrity.
+#
+# If this consistency enforcement were disabled, malicious images could be built
+# in a way designed to evade other audit mechanisms, so presence of most other audit
+# mechanisms is not a replacement for the above-mentioned need for all images to come
+# from a trusted build system.
+#
+# As a side effect, enabling this option will also make image IDs unpredictable
+# (usually not equal to the traditional value matching the config digest).
+# insecure_allow_unpredictable_image_contents = "false"
+
 # Root-auto-userns-user is a user name which can be used to look up one or more UID/GID
 # ranges in the /etc/subuid and /etc/subgid file.  These ranges will be partitioned
 # to containers configured to create automatically a user namespace.  Containers


### PR DESCRIPTION
… to ensure we can always use traditional layer IDs and image IDs, and use the uncompressed digests to avoid zstd:chunked view ambiguity, in c/image.

<s>Absolutely untested.</s>