### PR TITLE
Backport pull request #2117 to release-1.55

### DIFF
--- a/drivers/copy/copy_linux.go
+++ b/drivers/copy/copy_linux.go
@@ -17,7 +17,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"net"
 	"os"
 	"path/filepath"
 	"strings"
@@ -200,11 +199,9 @@ func DirCopy(srcDir, dstDir string, copyMode Mode, copyXattrs bool) error {
 			}
 
 		case mode&os.ModeSocket != 0:
-			s, err := net.Listen("unix", dstPath)
-			if err != nil {
+			if err := unix.Mknod(dstPath, stat.Mode, int(stat.Rdev)); err != nil {
 				return err
 			}
-			s.Close()
 
 		case mode&os.ModeDevice != 0:
 			if unshare.IsRootless() {

--- a/drivers/copy/copy_test.go
+++ b/drivers/copy/copy_test.go
@@ -6,6 +6,7 @@ package copy
 import (
 	"fmt"
 	"math/rand"
+	"net"
 	"os"
 	"path/filepath"
 	"syscall"
@@ -84,6 +85,11 @@ func randomMode(baseMode int) os.FileMode {
 
 func populateSrcDir(t *testing.T, srcDir string, remainingDepth int) {
 	if remainingDepth == 0 {
+		socketPath := filepath.Join(srcDir, "srcsocket")
+		s, err := net.ListenUnix("unix", &net.UnixAddr{Name: socketPath, Net: "unix"})
+		assert.NilError(t, err)
+		s.SetUnlinkOnClose(false)
+		s.Close()
 		return
 	}
 	aTime := time.Unix(rand.Int63(), 0)


### PR DESCRIPTION
Backport pull request #2117 to release-1.55.

Update copy.DirCopy to leave sockets in the file system

(cherry picked from commit 960e8dd66ac7f5e1a5f8c3511ecd237128785a40)