### PR TITLE
chunked: rework GetBlobAt usage

### DIFF
--- a/pkg/chunked/compression_linux.go
+++ b/pkg/chunked/compression_linux.go
@@ -44,25 +44,21 @@ func readEstargzChunkedManifest(blobStream ImageSourceSeekable, blobSize int64, 
 	if blobSize <= footerSize {
 		return nil, 0, errors.New("blob too small")
 	}
-	chunk := ImageSourceChunk{
-		Offset: uint64(blobSize - footerSize),
-		Length: uint64(footerSize),
-	}
-	parts, errs, err := blobStream.GetBlobAt([]ImageSourceChunk{chunk})
+
+	footer := make([]byte, footerSize)
+	streamsOrErrors, err := getBlobAt(blobStream, ImageSourceChunk{Offset: uint64(blobSize - footerSize), Length: uint64(footerSize)})
 	if err != nil {
 		return nil, 0, err
 	}
-	var reader io.ReadCloser
-	select {
-	case r := <-parts:
-		reader = r
-	case err := <-errs:
-		return nil, 0, err
-	}
-	defer reader.Close()
-	footer := make([]byte, footerSize)
-	if _, err := io.ReadFull(reader, footer); err != nil {
-		return nil, 0, err
+
+	for soe := range streamsOrErrors {
+		if soe.stream != nil {
+			_, err = io.ReadFull(soe.stream, footer)
+			_ = soe.stream.Close()
+		}
+		if soe.err != nil && err == nil {
+			err = soe.err
+		}
 	}
 
 	/* Read the ToC offset:
@@ -85,44 +81,50 @@ func readEstargzChunkedManifest(blobStream ImageSourceSeekable, blobSize int64, 
 		return nil, 0, errors.New("manifest too big")
 	}
 
-	chunk = ImageSourceChunk{
-		Offset: uint64(tocOffset),
-		Length: uint64(size),
-	}
-	parts, errs, err = blobStream.GetBlobAt([]ImageSourceChunk{chunk})
+	streamsOrErrors, err = getBlobAt(blobStream, ImageSourceChunk{Offset: uint64(tocOffset), Length: uint64(size)})
 	if err != nil {
 		return nil, 0, err
 	}
 
-	var tocReader io.ReadCloser
-	select {
-	case r := <-parts:
-		tocReader = r
-	case err := <-errs:
-		return nil, 0, err
-	}
-	defer tocReader.Close()
+	var manifestUncompressed []byte
 
-	r, err := pgzip.NewReader(tocReader)
-	if err != nil {
-		return nil, 0, err
-	}
-	defer r.Close()
+	for soe := range streamsOrErrors {
+		if soe.stream != nil {
+			err1 := func() error {
+				defer soe.stream.Close()
 
-	aTar := archivetar.NewReader(r)
+				r, err := pgzip.NewReader(soe.stream)
+				if err != nil {
+					return err
+				}
+				defer r.Close()
 
-	header, err := aTar.Next()
-	if err != nil {
-		return nil, 0, err
-	}
-	// set a reasonable limit
-	if header.Size > (1<<20)*50 {
-		return nil, 0, errors.New("manifest too big")
-	}
+				aTar := archivetar.NewReader(r)
 
-	manifestUncompressed := make([]byte, header.Size)
-	if _, err := io.ReadFull(aTar, manifestUncompressed); err != nil {
-		return nil, 0, err
+				header, err := aTar.Next()
+				if err != nil {
+					return err
+				}
+				// set a reasonable limit
+				if header.Size > (1<<20)*50 {
+					return errors.New("manifest too big")
+				}
+
+				manifestUncompressed = make([]byte, header.Size)
+				if _, err := io.ReadFull(aTar, manifestUncompressed); err != nil {
+					return err
+				}
+				return nil
+			}()
+			if err == nil {
+				err = err1
+			}
+		} else if err == nil {
+			err = soe.err
+		}
+	}
+	if manifestUncompressed == nil {
+		return nil, 0, errors.New("manifest not found")
 	}
 
 	manifestDigester := digest.Canonical.Digester()
@@ -140,7 +142,7 @@ func readEstargzChunkedManifest(blobStream ImageSourceSeekable, blobSize int64, 
 
 // readZstdChunkedManifest reads the zstd:chunked manifest from the seekable stream blobStream.
 // Returns (manifest blob, parsed manifest, tar-split blob or nil, manifest offset).
-func readZstdChunkedManifest(blobStream ImageSourceSeekable, tocDigest digest.Digest, annotations map[string]string) ([]byte, *internal.TOC, []byte, int64, error) {
+func readZstdChunkedManifest(blobStream ImageSourceSeekable, tocDigest digest.Digest, annotations map[string]string) (_ []byte, _ *internal.TOC, _ []byte, _ int64, retErr error) {
 	offsetMetadata := annotations[internal.ManifestInfoKey]
 	if offsetMetadata == "" {
 		return nil, nil, nil, 0, fmt.Errorf("%q annotation missing", internal.ManifestInfoKey)
@@ -175,26 +177,31 @@ func readZstdChunkedManifest(blobStream ImageSourceSeekable, tocDigest digest.Di
 	if tarSplitChunk.Offset > 0 {
 		chunks = append(chunks, tarSplitChunk)
 	}
-	parts, errs, err := blobStream.GetBlobAt(chunks)
+
+	streamsOrErrors, err := getBlobAt(blobStream, chunks...)
 	if err != nil {
 		return nil, nil, nil, 0, err
 	}
 
-	readBlob := func(len uint64) ([]byte, error) {
-		var reader io.ReadCloser
-		select {
-		case r := <-parts:
-			reader = r
-		case err := <-errs:
-			return nil, err
+	defer func() {
+		err := ensureAllBlobsDone(streamsOrErrors)
+		if retErr == nil {
+			retErr = err
 		}
+	}()
+
+	readBlob := func(len uint64) ([]byte, error) {
+		soe, ok := <-streamsOrErrors
+		if !ok {
+			return nil, errors.New("stream closed")
+		}
+		if soe.err != nil {
+			return nil, soe.err
+		}
+		defer soe.stream.Close()
 
 		blob := make([]byte, len)
-		if _, err := io.ReadFull(reader, blob); err != nil {
-			reader.Close()
-			return nil, err
-		}
-		if err := reader.Close(); err != nil {
+		if _, err := io.ReadFull(soe.stream, blob); err != nil {
 			return nil, err
 		}
 		return blob, nil

--- a/pkg/chunked/storage_linux_test.go
+++ b/pkg/chunked/storage_linux_test.go
@@ -1,0 +1,172 @@
+package chunked
+
+import (
+	"bytes"
+	"errors"
+	"fmt"
+	"io"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Mock for ImageSourceSeekable
+type mockImageSource struct {
+	streams chan io.ReadCloser
+	errors  chan error
+}
+
+func (m *mockImageSource) GetBlobAt(chunks []ImageSourceChunk) (chan io.ReadCloser, chan error, error) {
+	return m.streams, m.errors, nil
+}
+
+type mockReadCloser struct {
+	io.Reader
+	closed bool
+}
+
+func (m *mockReadCloser) Close() error {
+	m.closed = true
+	return nil
+}
+
+func mockReadCloserFromContent(content string) *mockReadCloser {
+	return &mockReadCloser{Reader: bytes.NewBufferString(content), closed: false}
+}
+
+func TestGetBlobAtNormalOperation(t *testing.T) {
+	errors := make(chan error, 1)
+	expectedStreams := []string{"stream1", "stream2"}
+	streamsObjs := []*mockReadCloser{
+		mockReadCloserFromContent(expectedStreams[0]),
+		mockReadCloserFromContent(expectedStreams[1]),
+	}
+	streams := make(chan io.ReadCloser, len(streamsObjs))
+
+	for _, s := range streamsObjs {
+		streams <- s
+	}
+	close(streams)
+	close(errors)
+
+	is := &mockImageSource{streams: streams, errors: errors}
+
+	chunks := []ImageSourceChunk{
+		{Offset: 0, Length: 1},
+		{Offset: 1, Length: 1},
+	}
+
+	resultChan, err := getBlobAt(is, chunks...)
+	require.NoError(t, err)
+
+	i := 0
+	for result := range resultChan {
+		assert.NoError(t, result.err)
+		buf := new(bytes.Buffer)
+		_, _ = buf.ReadFrom(result.stream)
+		result.stream.Close()
+		assert.Equal(t, expectedStreams[i], buf.String())
+		i++
+	}
+	assert.Len(t, expectedStreams, i)
+	for _, s := range streamsObjs {
+		assert.True(t, s.closed)
+	}
+}
+
+func TestGetBlobAtMaxStreams(t *testing.T) {
+	streams := make(chan io.ReadCloser, 5)
+	errors := make(chan error)
+
+	streamsObjs := []*mockReadCloser{}
+
+	for i := 1; i <= 5; i++ {
+		s := mockReadCloserFromContent(fmt.Sprintf("stream%d", i))
+		streamsObjs = append(streamsObjs, s)
+		streams <- s
+	}
+	close(streams)
+	close(errors)
+
+	is := &mockImageSource{streams: streams, errors: errors}
+
+	chunks := []ImageSourceChunk{
+		{Offset: 0, Length: 1},
+		{Offset: 1, Length: 1},
+		{Offset: 2, Length: 1},
+	}
+
+	resultChan, err := getBlobAt(is, chunks...)
+	require.NoError(t, err)
+
+	count := 0
+	receivedErr := false
+	for result := range resultChan {
+		if result.err != nil {
+			receivedErr = true
+		} else {
+			result.stream.Close()
+			count++
+		}
+	}
+	assert.True(t, receivedErr)
+	assert.Equal(t, 3, count)
+	for _, s := range streamsObjs {
+		assert.True(t, s.closed)
+	}
+}
+
+func TestGetBlobAtWithErrors(t *testing.T) {
+	streams := make(chan io.ReadCloser)
+	errorsC := make(chan error, 2)
+
+	errorsC <- errors.New("error1")
+	errorsC <- errors.New("error2")
+	close(streams)
+	close(errorsC)
+
+	is := &mockImageSource{streams: streams, errors: errorsC}
+
+	resultChan, err := getBlobAt(is)
+	require.NoError(t, err)
+
+	expectedErrors := []string{"error1", "error2"}
+	i := 0
+	for result := range resultChan {
+		assert.Nil(t, result.stream)
+		assert.NotNil(t, result.err)
+		if result.err != nil {
+			assert.Equal(t, expectedErrors[i], result.err.Error())
+		}
+		i++
+	}
+	assert.Equal(t, len(expectedErrors), i)
+}
+
+func TestGetBlobAtMixedStreamsAndErrors(t *testing.T) {
+	streams := make(chan io.ReadCloser, 2)
+	errorsC := make(chan error, 1)
+
+	streams <- mockReadCloserFromContent("stream1")
+	errorsC <- errors.New("error1")
+	close(streams)
+	close(errorsC)
+
+	is := &mockImageSource{streams: streams, errors: errorsC}
+
+	resultChan, err := getBlobAt(is)
+	require.NoError(t, err)
+
+	var receivedStreams int
+	var receivedErrors int
+	for result := range resultChan {
+		if result.err != nil {
+			receivedErrors++
+		} else {
+			receivedStreams++
+		}
+	}
+	assert.Equal(t, 0, receivedStreams)
+	assert.Equal(t, 2, receivedErrors)
+}


### PR DESCRIPTION
rewrite how the result from GetBlobAt is used, to make sure 1) that the streams are always closed, and 2) that any error is processed.

Closes: https://issues.redhat.com/browse/OCPBUGS-43968