### PR TITLE
add support for unpacking layers with xattrs set on FreeBSD

### DIFF
--- a/pkg/archive/xattr_freebsd.go
+++ b/pkg/archive/xattr_freebsd.go
@@ -1,0 +1,38 @@
+//go:build freebsd
+
+package archive
+
+import (
+	"strings"
+	"syscall"
+
+	"github.com/containers/storage/pkg/system"
+)
+
+// setExtendedAttribute sets an extended attribute on a file. On FreeBSD, extended attributes are
+// supported via the extattr system calls.
+func setExtendedAttribute(path string, xattrKey string, value []byte) error {
+	namespace, attrname, err := xattrToExtattr(xattrKey)
+	if err != nil {
+		return err
+	}
+	return system.ExtattrSetLink(path, namespace, attrname, value)
+}
+
+func xattrToExtattr(xattrname string) (namespace int, attrname string, err error) {
+	namespaceMap := map[string]int{
+		"user":   system.EXTATTR_NAMESPACE_USER,
+		"system": system.EXTATTR_NAMESPACE_SYSTEM,
+	}
+
+	namespaceName, attrname, found := strings.Cut(xattrname, ".")
+	if !found {
+		return -1, "", syscall.ENOTSUP
+	}
+
+	namespace, ok := namespaceMap[namespaceName]
+	if !ok {
+		return -1, "", syscall.ENOTSUP
+	}
+	return namespace, attrname, nil
+}

--- a/pkg/archive/xattr_unix.go
+++ b/pkg/archive/xattr_unix.go
@@ -1,0 +1,13 @@
+//go:build darwin || linux
+
+package archive
+
+import (
+	"github.com/containers/storage/pkg/system"
+)
+
+// setExtendedAttribute sets an extended attribute on a file. On Linux and Darwin,
+// extended attributes are supported via the xattr system calls.
+func setExtendedAttribute(path string, xattrKey string, value []byte) error {
+	return system.Lsetxattr(path, xattrKey, value, 0)
+}

--- a/pkg/archive/xattr_unsupported.go
+++ b/pkg/archive/xattr_unsupported.go
@@ -1,0 +1,12 @@
+//go:build !darwin && !linux && !freebsd
+
+package archive
+
+import (
+	"github.com/containers/storage/pkg/system"
+)
+
+// setExtendedAttribute is not supported on this platform.
+func setExtendedAttribute(path string, xattrKey string, value []byte) error {
+	return system.ErrNotSupportedPlatform
+}

--- a/pkg/system/extattr_freebsd.go
+++ b/pkg/system/extattr_freebsd.go
@@ -1,0 +1,96 @@
+//go:build freebsd
+
+package system
+
+import (
+	"os"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+const (
+	EXTATTR_NAMESPACE_EMPTY  = unix.EXTATTR_NAMESPACE_EMPTY
+	EXTATTR_NAMESPACE_USER   = unix.EXTATTR_NAMESPACE_USER
+	EXTATTR_NAMESPACE_SYSTEM = unix.EXTATTR_NAMESPACE_SYSTEM
+)
+
+// ExtattrGetLink retrieves the value of the extended attribute identified by attrname
+// in the given namespace and associated with the given path in the file system.
+// If the path is a symbolic link, the extended attribute is retrieved from the link itself.
+// Returns a []byte slice if the extattr is set and nil otherwise.
+func ExtattrGetLink(path string, attrnamespace int, attrname string) ([]byte, error) {
+	size, errno := unix.ExtattrGetLink(path, attrnamespace, attrname,
+		uintptr(unsafe.Pointer(nil)), 0)
+	if errno != nil {
+		if errno == unix.ENOATTR {
+			return nil, nil
+		}
+		return nil, &os.PathError{Op: "extattr_get_link", Path: path, Err: errno}
+	}
+	if size == 0 {
+		return []byte{}, nil
+	}
+
+	dest := make([]byte, size)
+	size, errno = unix.ExtattrGetLink(path, attrnamespace, attrname,
+		uintptr(unsafe.Pointer(&dest[0])), size)
+	if errno != nil {
+		return nil, &os.PathError{Op: "extattr_get_link", Path: path, Err: errno}
+	}
+
+	return dest[:size], nil
+}
+
+// ExtattrSetLink sets the value of extended attribute identified by attrname
+// in the given namespace and associated with the given path in the file system.
+// If the path is a symbolic link, the extended attribute is set on the link itself.
+func ExtattrSetLink(path string, attrnamespace int, attrname string, data []byte) error {
+	if len(data) == 0 {
+		data = []byte{} // ensure non-nil for empty data
+	}
+	if _, errno := unix.ExtattrSetLink(path, attrnamespace, attrname,
+		uintptr(unsafe.Pointer(&data[0])), len(data)); errno != nil {
+		return &os.PathError{Op: "extattr_set_link", Path: path, Err: errno}
+	}
+
+	return nil
+}
+
+// ExtattrListLink lists extended attributes associated with the given path
+// in the specified namespace. If the path is a symbolic link, the attributes
+// are listed from the link itself.
+func ExtattrListLink(path string, attrnamespace int) ([]string, error) {
+	size, errno := unix.ExtattrListLink(path, attrnamespace,
+		uintptr(unsafe.Pointer(nil)), 0)
+	if errno != nil {
+		if errno == unix.ENOATTR {
+			return nil, nil
+		}
+		return nil, &os.PathError{Op: "extattr_list_link", Path: path, Err: errno}
+	}
+	if size == 0 {
+		return []string{}, nil
+	}
+
+	dest := make([]byte, size)
+	size, errno = unix.ExtattrListLink(path, attrnamespace,
+		uintptr(unsafe.Pointer(&dest[0])), size)
+	if errno != nil {
+		return nil, &os.PathError{Op: "extattr_list_link", Path: path, Err: errno}
+	}
+
+	var attrs []string
+	for i := 0; i < size; {
+		// Each attribute is preceded by a single byte length
+		length := int(dest[i])
+		i++
+		if i+length > size {
+			break
+		}
+		attrs = append(attrs, string(dest[i:i+length]))
+		i += length
+	}
+
+	return attrs, nil
+}

--- a/pkg/system/extattr_unsupported.go
+++ b/pkg/system/extattr_unsupported.go
@@ -1,0 +1,24 @@
+//go:build !freebsd
+
+package system
+
+const (
+	EXTATTR_NAMESPACE_EMPTY  = 0
+	EXTATTR_NAMESPACE_USER   = 0
+	EXTATTR_NAMESPACE_SYSTEM = 0
+)
+
+// ExtattrGetLink is not supported on platforms other than FreeBSD.
+func ExtattrGetLink(path string, attrnamespace int, attrname string) ([]byte, error) {
+	return nil, ErrNotSupportedPlatform
+}
+
+// ExtattrSetLink is not supported on platforms other than FreeBSD.
+func ExtattrSetLink(path string, attrnamespace int, attrname string, data []byte) error {
+	return ErrNotSupportedPlatform
+}
+
+// ExtattrListLink is not supported on platforms other than FreeBSD.
+func ExtattrListLink(path string, attrnamespace int) ([]string, error) {
+	return nil, ErrNotSupportedPlatform
+}


### PR DESCRIPTION
Closes #2168

This PR implements system call wrappers for `extattr` on FreeBSD, and adds support for unpacking layers with external attributes(`xattr`). The implementation mimics how FreeBSD's linux compatibility layer and BSD tar handles xattr using extattr system calls, while both has some limitations that only two of the namespaces `user` and `system` are supported among the four – the rest, `trusted` and `security` remain unsupported.