### PR TITLE
cirrus: update CI image to f41

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -17,13 +17,13 @@ env:
     ####
     #### Cache-image names to test with (double-quotes around names are critical)
     ###
-    FEDORA_NAME: "fedora-39"
+    FEDORA_NAME: "fedora-41"
     DEBIAN_NAME: "debian-13"
 
     # GCE project where images live
     IMAGE_PROJECT: "libpod-218412"
     # VM Image built in containers/automation_images
-    IMAGE_SUFFIX: "c20241010t105554z-f40f39d13"
+    IMAGE_SUFFIX: "c20241107t210000z-f41f40d13"
     FEDORA_CACHE_IMAGE_NAME: "fedora-${IMAGE_SUFFIX}"
     DEBIAN_CACHE_IMAGE_NAME: "debian-${IMAGE_SUFFIX}"
 

--- a/contrib/cirrus/setup.sh
+++ b/contrib/cirrus/setup.sh
@@ -13,7 +13,7 @@ msg "Setting up $OS_RELEASE_ID $OS_RELEASE_VER"
 case "$OS_RELEASE_ID" in
     fedora)
         [[ -z "$RPMS_CONFLICTING" ]] || \
-            $SHORT_DNFY erase $RPMS_CONFLICTING
+            $SHORT_DNFY remove $RPMS_CONFLICTING
         ;;
     debian)
         [[ -z "$DEBS_CONFLICTING" ]] || \


### PR DESCRIPTION
replaces https://github.com/containers/storage/pull/2169 as manual changes are needed 