### PR TITLE
archive: honor ignoreChownErrors with ForceMode

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -734,7 +734,10 @@ func createTarFile(path, extractDir string, hdr *tar.Header, reader io.Reader, L
 			Mode: hdrInfo.Mode() & 0o7777,
 		}
 		if err := idtools.SetContainersOverrideXattr(path, value); err != nil {
-			return err
+			if !ignoreChownErrors {
+				return err
+			}
+			logrus.Warnf("Setting override extended attribute failed for %q. Ignoring due to ignoreChownErrors flag: %v", path, err)
 		}
 	}
 

--- a/pkg/archive/archive_test.go
+++ b/pkg/archive/archive_test.go
@@ -1247,3 +1247,20 @@ func readFileFromArchive(t *testing.T, archive io.ReadCloser, name string, expec
 	assert.NoError(t, err)
 	return string(content)
 }
+
+func TestCreateFifo(t *testing.T) {
+	hdr := tar.Header{Typeflag: tar.TypeFifo}
+	tmpDir := t.TempDir()
+	buffer := make([]byte, 1<<20)
+	err := createTarFile(filepath.Join(tmpDir, "fifo1"), tmpDir, &hdr, nil, true, nil, false, false, nil, buffer)
+	assert.NoError(t, err)
+
+	forceMask := os.FileMode(0o755)
+	err = createTarFile(filepath.Join(tmpDir, "fifo2"), tmpDir, &hdr, nil, true, nil, false, false, &forceMask, buffer)
+	// expect an error to chown a fifo
+	assert.Error(t, err)
+
+	err = createTarFile(filepath.Join(tmpDir, "fifo3"), tmpDir, &hdr, nil, true, nil, false, true, &forceMask, buffer)
+	// expect no error as honors ignoreChownErrors
+	assert.NoError(t, err)
+}


### PR DESCRIPTION
when ignore_chown_errors is set, ignore also failures from setting the override mode xattr.

Closes: https://github.com/containers/storage/issues/2174