### PR TITLE
pkg/system: add fromStatT for NetBSD

### DIFF
--- a/pkg/system/stat_netbsd.go
+++ b/pkg/system/stat_netbsd.go
@@ -1,0 +1,13 @@
+package system
+
+import "syscall"
+
+// fromStatT converts a syscall.Stat_t type to a system.Stat_t type
+func fromStatT(s *syscall.Stat_t) (*StatT, error) {
+	return &StatT{size: s.Size,
+		mode: uint32(s.Mode),
+		uid:  s.Uid,
+		gid:  s.Gid,
+		rdev: uint64(s.Rdev),
+		mtim: s.Mtimespec}, nil
+}


### PR DESCRIPTION
Identical to openbsd's implementation, but is not included when compiling on netbsd due to using named files rather than build arguments.

This adds a file which is part of the patches (to the `vendor` directory) for the pkgsrc build.