### PR TITLE
Move pkg/chunked/internal to pkg/chunked/internal/minimal

### DIFF
--- a/pkg/chunked/cache_linux.go
+++ b/pkg/chunked/cache_linux.go
@@ -16,7 +16,7 @@ import (
 
 	storage "github.com/containers/storage"
 	graphdriver "github.com/containers/storage/drivers"
-	"github.com/containers/storage/pkg/chunked/internal"
+	"github.com/containers/storage/pkg/chunked/internal/minimal"
 	"github.com/containers/storage/pkg/ioutils"
 	"github.com/docker/go-units"
 	jsoniter "github.com/json-iterator/go"
@@ -848,12 +848,12 @@ func (c *layersCache) findFileInOtherLayers(file *fileMetadata, useHardLinks boo
 	return "", "", nil
 }
 
-func (c *layersCache) findChunkInOtherLayers(chunk *internal.FileMetadata) (string, string, int64, error) {
+func (c *layersCache) findChunkInOtherLayers(chunk *minimal.FileMetadata) (string, string, int64, error) {
 	return c.findDigestInternal(chunk.ChunkDigest)
 }
 
-func unmarshalToc(manifest []byte) (*internal.TOC, error) {
-	var toc internal.TOC
+func unmarshalToc(manifest []byte) (*minimal.TOC, error) {
+	var toc minimal.TOC
 
 	iter := jsoniter.ParseBytes(jsoniter.ConfigFastest, manifest)
 
@@ -864,7 +864,7 @@ func unmarshalToc(manifest []byte) (*internal.TOC, error) {
 
 		case "entries":
 			for iter.ReadArray() {
-				var m internal.FileMetadata
+				var m minimal.FileMetadata
 				for field := iter.ReadObject(); field != ""; field = iter.ReadObject() {
 					switch strings.ToLower(field) {
 					case "type":

--- a/pkg/chunked/compression.go
+++ b/pkg/chunked/compression.go
@@ -4,18 +4,18 @@ import (
 	"io"
 
 	"github.com/containers/storage/pkg/chunked/compressor"
-	"github.com/containers/storage/pkg/chunked/internal"
+	"github.com/containers/storage/pkg/chunked/internal/minimal"
 )
 
 const (
-	TypeReg     = internal.TypeReg
-	TypeChunk   = internal.TypeChunk
-	TypeLink    = internal.TypeLink
-	TypeChar    = internal.TypeChar
-	TypeBlock   = internal.TypeBlock
-	TypeDir     = internal.TypeDir
-	TypeFifo    = internal.TypeFifo
-	TypeSymlink = internal.TypeSymlink
+	TypeReg     = minimal.TypeReg
+	TypeChunk   = minimal.TypeChunk
+	TypeLink    = minimal.TypeLink
+	TypeChar    = minimal.TypeChar
+	TypeBlock   = minimal.TypeBlock
+	TypeDir     = minimal.TypeDir
+	TypeFifo    = minimal.TypeFifo
+	TypeSymlink = minimal.TypeSymlink
 )
 
 // ZstdCompressor is a CompressorFunc for the zstd compression algorithm.

--- a/pkg/chunked/filesystem_linux.go
+++ b/pkg/chunked/filesystem_linux.go
@@ -15,7 +15,7 @@ import (
 
 	driversCopy "github.com/containers/storage/drivers/copy"
 	"github.com/containers/storage/pkg/archive"
-	"github.com/containers/storage/pkg/chunked/internal"
+	"github.com/containers/storage/pkg/chunked/internal/minimal"
 	storagePath "github.com/containers/storage/pkg/chunked/internal/path"
 	securejoin "github.com/cyphar/filepath-securejoin"
 	"github.com/vbatts/tar-split/archive/tar"
@@ -35,14 +35,14 @@ func procPathForFd(fd int) string {
 	return fmt.Sprintf("/proc/self/fd/%d", fd)
 }
 
-// fileMetadata is a wrapper around internal.FileMetadata with additional private fields that
+// fileMetadata is a wrapper around minimal.FileMetadata with additional private fields that
 // are not part of the TOC document.
 // Type: TypeChunk entries are stored in Chunks, the primary [fileMetadata] entries never use TypeChunk.
 type fileMetadata struct {
-	internal.FileMetadata
+	minimal.FileMetadata
 
 	// chunks stores the TypeChunk entries relevant to this entry when FileMetadata.Type == TypeReg.
-	chunks []*internal.FileMetadata
+	chunks []*minimal.FileMetadata
 
 	// skipSetAttrs is set when the file attributes must not be
 	// modified, e.g. it is a hard link from a different source,

--- a/pkg/chunked/filesystem_linux_test.go
+++ b/pkg/chunked/filesystem_linux_test.go
@@ -10,7 +10,7 @@ import (
 	"testing"
 
 	"github.com/containers/storage/pkg/archive"
-	"github.com/containers/storage/pkg/chunked/internal"
+	"github.com/containers/storage/pkg/chunked/internal/minimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -114,8 +114,8 @@ func TestSafeMkdir(t *testing.T) {
 	rootFd := int(rootFile.Fd())
 
 	metadata := fileMetadata{
-		FileMetadata: internal.FileMetadata{
-			Type: internal.TypeDir,
+		FileMetadata: minimal.FileMetadata{
+			Type: minimal.TypeDir,
 			Mode: 0o755,
 		},
 	}
@@ -153,11 +153,11 @@ func TestSafeLink(t *testing.T) {
 	assert.NoError(t, err)
 
 	metadata := fileMetadata{
-		FileMetadata: internal.FileMetadata{
+		FileMetadata: minimal.FileMetadata{
 			Name: linkName,
 			// try to create outside the root
 			Linkname: "../../" + existingFile,
-			Type:     internal.TypeReg,
+			Type:     minimal.TypeReg,
 			Mode:     0o755,
 		},
 	}
@@ -206,11 +206,11 @@ func TestSafeSymlink(t *testing.T) {
 	existingFile := path.Base(file.Name())
 
 	metadata := fileMetadata{
-		FileMetadata: internal.FileMetadata{
+		FileMetadata: minimal.FileMetadata{
 			Name: linkName,
 			// try to create outside the root
 			Linkname: "../../" + existingFile,
-			Type:     internal.TypeReg,
+			Type:     minimal.TypeReg,
 			Mode:     0o755,
 		},
 	}
@@ -280,9 +280,9 @@ func TestCopyFileContent(t *testing.T) {
 	require.NoError(t, err)
 
 	metadata := fileMetadata{
-		FileMetadata: internal.FileMetadata{
+		FileMetadata: minimal.FileMetadata{
 			Name: "new-file",
-			Type: internal.TypeDir,
+			Type: minimal.TypeDir,
 			Mode: 0o755,
 		},
 	}
@@ -304,9 +304,9 @@ func TestCopyFileContent(t *testing.T) {
 	assert.NotEqual(t, st.Ino, st2.Ino)
 
 	metadataCopyHardLinks := fileMetadata{
-		FileMetadata: internal.FileMetadata{
+		FileMetadata: minimal.FileMetadata{
 			Name: "new-file2",
-			Type: internal.TypeDir,
+			Type: minimal.TypeDir,
 			Mode: 0o755,
 		},
 	}

--- a/pkg/chunked/internal/minimal/compression.go
+++ b/pkg/chunked/internal/minimal/compression.go
@@ -1,4 +1,4 @@
-package internal
+package minimal
 
 // NOTE: This is used from github.com/containers/image by callers that
 // don't otherwise use containers/storage, so don't make this depend on any

--- a/pkg/chunked/internal/minimal/compression_test.go
+++ b/pkg/chunked/internal/minimal/compression_test.go
@@ -1,6 +1,6 @@
 //go:build linux
 
-package internal
+package minimal
 
 import (
 	"bytes"

--- a/pkg/chunked/toc/toc.go
+++ b/pkg/chunked/toc/toc.go
@@ -3,7 +3,7 @@ package toc
 import (
 	"errors"
 
-	"github.com/containers/storage/pkg/chunked/internal"
+	"github.com/containers/storage/pkg/chunked/internal/minimal"
 	digest "github.com/opencontainers/go-digest"
 )
 
@@ -19,7 +19,7 @@ const tocJSONDigestAnnotation = "containerd.io/snapshot/stargz/toc.digest"
 // This is an experimental feature and may be changed/removed in the future.
 func GetTOCDigest(annotations map[string]string) (*digest.Digest, error) {
 	d1, ok1 := annotations[tocJSONDigestAnnotation]
-	d2, ok2 := annotations[internal.ManifestChecksumKey]
+	d2, ok2 := annotations[minimal.ManifestChecksumKey]
 	switch {
 	case ok1 && ok2:
 		return nil, errors.New("both zstd:chunked and eStargz TOC found")


### PR DESCRIPTION
We now have several `internal` subpackages of `pkg/chunked`, so delineate more explicitly the parts that should be kept as small as possible because the c/image compression package depends on them.

Should not change behavior.

---

Previously discussed in https://github.com/containers/storage/pull/2194#discussion_r1881081145 .

I don’t like the `internal/minimal` subpackage name much; I don’t know how to choose a name that both expresses “be careful not to add dependencies here” and that looks good at the call sites (which don’t all care about the minimizing dependencies). Suggestions for an alternative are very welcome.