### PR TITLE
archive: detect symlink target changes

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -78,6 +78,7 @@ const (
 	windows = "windows"
 	darwin  = "darwin"
 	freebsd = "freebsd"
+	linux   = "linux"
 )
 
 var xattrsToIgnore = map[string]interface{}{

--- a/pkg/archive/changes.go
+++ b/pkg/archive/changes.go
@@ -270,6 +270,7 @@ type FileInfo struct {
 	capability []byte
 	added      bool
 	xattrs     map[string]string
+	target     string
 }
 
 // LookUp looks up the file information of a file.
@@ -336,6 +337,7 @@ func (info *FileInfo) addChanges(oldInfo *FileInfo, changes *[]Change) {
 			// back mtime
 			if statDifferent(oldStat, oldInfo, newStat, info) ||
 				!bytes.Equal(oldChild.capability, newChild.capability) ||
+				oldChild.target != newChild.target ||
 				!reflect.DeepEqual(oldChild.xattrs, newChild.xattrs) {
 				change := Change{
 					Path: newChild.path(),
@@ -390,6 +392,7 @@ func newRootFileInfo(idMappings *idtools.IDMappings) *FileInfo {
 		name:       string(os.PathSeparator),
 		idMappings: idMappings,
 		children:   make(map[string]*FileInfo),
+		target:     "",
 	}
 	return root
 }

--- a/pkg/archive/changes_linux.go
+++ b/pkg/archive/changes_linux.go
@@ -79,6 +79,7 @@ func walkchunk(path string, fi os.FileInfo, dir string, root *FileInfo) error {
 		children:   make(map[string]*FileInfo),
 		parent:     parent,
 		idMappings: root.idMappings,
+		target:     "",
 	}
 	cpath := filepath.Join(dir, path)
 	stat, err := system.FromStatT(fi.Sys().(*syscall.Stat_t))
@@ -108,6 +109,12 @@ func walkchunk(path string, fi os.FileInfo, dir string, root *FileInfo) error {
 				info.xattrs = make(map[string]string)
 			}
 			info.xattrs[key] = string(value)
+		}
+	}
+	if fi.Mode()&os.ModeSymlink != 0 {
+		info.target, err = os.Readlink(cpath)
+		if err != nil {
+			return err
 		}
 	}
 	parent.children[info.name] = info


### PR DESCRIPTION
improve detection of changes in symlinks when both the size and the mtime were changed.

Previously, the detection relied on a difference in either size or atime/mtime to identify changes in a symlink.  This is not enough, as the atime/mtime and it size could be left unaltered while only its target changes.

Fixes: https://github.com/containers/buildah/issues/5861