### PR TITLE
Fix compilation of pkg/archive tests on non-Linux

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -78,7 +78,6 @@ const (
 	windows = "windows"
 	darwin  = "darwin"
 	freebsd = "freebsd"
-	linux   = "linux"
 )
 
 var xattrsToIgnore = map[string]interface{}{

--- a/pkg/archive/changes_test.go
+++ b/pkg/archive/changes_test.go
@@ -12,7 +12,6 @@ import (
 	"github.com/containers/storage/pkg/idtools"
 	"github.com/containers/storage/pkg/system"
 	"github.com/stretchr/testify/require"
-	"golang.org/x/sys/unix"
 )
 
 func copyDir(src, dst string) error {
@@ -40,16 +39,6 @@ type FileData struct {
 	path        string
 	contents    string
 	permissions os.FileMode
-}
-
-// resetSymlinkTimesLinux sets the atime and mtime of a symlink to a known value, to test
-// whether changes to the symlink target are detected correctly.
-func resetSymlinkTimesLinux(path string) error {
-	if runtime.GOOS != linux {
-		return nil
-	}
-	ts := []unix.Timespec{unix.NsecToTimespec(0), unix.NsecToTimespec(0)}
-	return unix.UtimesNanoAt(unix.AT_FDCWD, path, ts, unix.AT_SYMLINK_NOFOLLOW)
 }
 
 func createSampleDir(t *testing.T, root string) {
@@ -93,7 +82,7 @@ func createSampleDir(t *testing.T, root string) {
 			err := os.Symlink(info.contents, p)
 			require.NoError(t, err)
 
-			err = resetSymlinkTimesLinux(p)
+			err = resetSymlinkTimes(p)
 			require.NoError(t, err)
 		}
 
@@ -317,7 +306,7 @@ func mutateSampleDir(t *testing.T, root string) {
 	require.NoError(t, err)
 	err = os.Symlink("target3", symlink2)
 	require.NoError(t, err)
-	err = resetSymlinkTimesLinux(symlink2)
+	err = resetSymlinkTimes(symlink2)
 	require.NoError(t, err)
 
 	// Replace dir with file

--- a/pkg/archive/changes_unix_test.go
+++ b/pkg/archive/changes_unix_test.go
@@ -1,0 +1,12 @@
+package archive
+
+import (
+	"golang.org/x/sys/unix"
+)
+
+// resetSymlinkTimes sets the atime and mtime of a symlink to a known value, to test
+// whether changes to the symlink target are detected correctly.
+func resetSymlinkTimes(path string) error {
+	ts := []unix.Timeval{unix.NsecToTimeval(0), unix.NsecToTimeval(0)}
+	return unix.Lutimes(path, ts)
+}

--- a/pkg/archive/changes_windows_test.go
+++ b/pkg/archive/changes_windows_test.go
@@ -1,0 +1,5 @@
+package archive
+
+func resetSymlinkTimes(path string) error {
+	return nil
+}


### PR DESCRIPTION
Unixy systems have Lutimes(), and we should have stubbed it out for non-Unixy systems.