### PR TITLE
overlay: Add error prefixing for mount.MakePrivate

### DIFF
--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -418,7 +418,7 @@ func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) 
 
 	if !opts.skipMountHome {
 		if err := mount.MakePrivate(home); err != nil {
-			return nil, err
+			return nil, fmt.Errorf("overlay: failed to make mount private: %w", err)
 		}
 	}
 


### PR DESCRIPTION
I'm hitting this error path in
https://github.com/containers/buildah/issues/5976
and it was not obvious to me which bit of code was failing. Add an error prefix so it's easy to find.