### PR TITLE
layers: write read only layers to imagestore

### DIFF
--- a/layers_test.go
+++ b/layers_test.go
@@ -1,0 +1,35 @@
+package storage
+
+import (
+	"testing"
+	"unsafe"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestLayerLocationFromIndex(t *testing.T) {
+	tests := []struct {
+		index    int
+		expected layerLocations
+	}{
+		{0, 1},
+		{1, 2},
+		{2, 4},
+		{3, 8},
+		{4, 16},
+	}
+	for _, test := range tests {
+		result := layerLocationFromIndex(test.index)
+		assert.Equal(t, test.expected, result)
+	}
+}
+
+func TestLayerLocationFromIndexAndToIndex(t *testing.T) {
+	var l layerLocations
+	for i := 0; i < int(unsafe.Sizeof(l)*8); i++ {
+		location := layerLocationFromIndex(i)
+		index := indexFromLayerLocation(location)
+		require.Equal(t, i, index)
+	}
+}

--- a/tests/split-store.bats
+++ b/tests/split-store.bats
@@ -100,6 +100,17 @@ load helpers
 	# shutdown store
 	run storage --graph ${TESTDIR}/graph --image-store ${TESTDIR}/imagestore/ --run ${TESTDIR}/runroot/ shutdown
 
+	# A RO layer must be created in the image store and must be usable from there as a regular store.
+	run storage --graph ${TESTDIR}/graph --image-store ${TESTDIR}/imagestore/ --debug=false create-layer --readonly
+	[ "$status" -eq 0 ]
+	rolayer=$output
+	run storage --graph ${TESTDIR}/imagestore --debug=false mount $rolayer
+	[ "$status" -eq 0 ]
+	run storage --graph ${TESTDIR}/imagestore --debug=false unmount $rolayer
+	[ "$status" -eq 0 ]
+	run storage --graph ${TESTDIR}/imagestore shutdown
+	[ "$status" -eq 0 ]
+
 	# Now since image was deleted from graphRoot, we should
 	# get false output while checking if image still exists
 	run storage --graph ${TESTDIR}/graph exists -i $image


### PR DESCRIPTION
when an imagestore is used, a R/O layer must be written to the layers.json under the imagestore, not graphroot.

The lock on the imagestore is already taken through the multipleLockFile{} mechanism in place.

Closes: https://github.com/containers/storage/issues/2257