### PR TITLE
feat: add Timestamp to TarOptions

### DIFF
--- a/pkg/archive/changes.go
+++ b/pkg/archive/changes.go
@@ -452,7 +452,7 @@ func ChangesSize(newDir string, changes []Change) int64 {
 func ExportChanges(dir string, changes []Change, uidMaps, gidMaps []idtools.IDMap) (io.ReadCloser, error) {
 	reader, writer := io.Pipe()
 	go func() {
-		ta := newTarWriter(idtools.NewIDMappingsFromMaps(uidMaps, gidMaps), writer, nil)
+		ta := newTarWriter(idtools.NewIDMappingsFromMaps(uidMaps, gidMaps), writer, nil, nil)
 
 		// this buffer is needed for the duration of this piped stream
 		defer pools.BufioWriter32KPool.Put(ta.Buffer)


### PR DESCRIPTION
Allows overriding of timestamps for entries within an archive.

TarOptions already includes a number of other overrides, it seemed like a good place to add this one as well.

(am keen to look at getting `buildah` to have the ability to emit identical tarballs for `oci-archive`, and this is the first step)
