### PR TITLE
idmap: force PRIVATE propagation

### DIFF
--- a/pkg/idmap/idmapped_utils.go
+++ b/pkg/idmap/idmapped_utils.go
@@ -33,8 +33,9 @@ func CreateIDMappedMount(source, target string, pid int) error {
 
 	if err := unix.MountSetattr(targetDirFd, "", unix.AT_EMPTY_PATH|unix.AT_RECURSIVE,
 		&unix.MountAttr{
-			Attr_set:  unix.MOUNT_ATTR_IDMAP,
-			Userns_fd: uint64(userNsFile.Fd()),
+			Attr_set:    unix.MOUNT_ATTR_IDMAP,
+			Userns_fd:   uint64(userNsFile.Fd()),
+			Propagation: unix.MS_PRIVATE,
 		}); err != nil {
 		return &os.PathError{Op: "mount_setattr", Path: source, Err: err}
 	}


### PR DESCRIPTION
do not leak idmapped mounts to other namespaces, since they are meant to be used privately by overlay.

This is already done with the default configuration, since we have a private mount on top of the graphdriver directory, but it is not the case when `skip_home_mount` is used.

Closes: https://issues.redhat.com/browse/OCPBUGS-49927