### PR TITLE
subid: drop support for old version

### DIFF
--- a/hack/libsubid_tag.sh
+++ b/hack/libsubid_tag.sh
@@ -10,14 +10,12 @@ cc -o "$tmpdir"/libsubid_tag -l subid -x c - > /dev/null 2> /dev/null << EOF
 #include <stdio.h>
 #include <stdlib.h>
 
-const char *Prog = "test";
-FILE *shadow_logfd = NULL;
-
 int main() {
 	struct subid_range *ranges = NULL;
 #if SUBID_ABI_MAJOR >= 4
 	subid_get_uid_ranges("root", &ranges);
 #else
+	libsubid_init("root", stderr);
 	get_subuid_ranges("root", &ranges);
 #endif
 	free(ranges);


### PR DESCRIPTION
the new ABI has been around for more than 3 years now (shadow-utils v4.11).

Closes: https://github.com/containers/storage/issues/2260