### PR TITLE
Update to Go 1.23

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -170,13 +170,13 @@ vendor_task:
 cross_task:
     alias: cross
     container:
-        image: golang:1.22
+        image: golang:1.23
     build_script: make cross
 
 gofix_task:
     alias: gofix
     container:
-        image: golang:1.22
+        image: golang:1.23
     build_script: go fix ./...
     test_script: git diff --exit-code
 

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-go 1.22.0
+go 1.23.0
 
 // Warning: Ensure the "go" and "toolchain" versions match exactly to prevent unwanted auto-updates.
 // That generally means there should be no toolchain directive present.


### PR DESCRIPTION
This is a very minimal change, just to handle the version bump.

I intend to let Renovate do the dependency updates.