### PR TITLE
RFC: Use Go 1.23 iterators for locking+traversing stores.

### DIFF
--- a/check_test.go
+++ b/check_test.go
@@ -76,16 +76,14 @@ func TestCheckDetectWriteable(t *testing.T) {
 	require.NoError(t, err, "unexpected error initializing test store")
 	s, ok := stoar.(*store)
 	require.True(t, ok, "unexpected error making type assertion")
-	_, done, err := readAllLayerStores(s, func(store roLayerStore) (struct{}, bool, error) {
+	for store, err := range s.readAllLayerStores() {
+		require.NoError(t, err)
 		if roLayerStoreIsReallyReadWrite(store) { // implicitly checking that the type assertion in this function doesn't panic
 			sawRWlayers = true
 		}
-		return struct{}{}, false, nil
-	})
-	assert.False(t, done, "unexpected error from readAllLayerStores")
-	assert.NoError(t, err, "unexpected error from readAllLayerStores")
+	}
 	assert.True(t, sawRWlayers, "unexpected error detecting which layer store is writeable")
-	_, done, err = readAllImageStores(s, func(store roImageStore) (struct{}, bool, error) {
+	_, done, err := readAllImageStores(s, func(store roImageStore) (struct{}, bool, error) {
 		if roImageStoreIsReallyReadWrite(store) { // implicitly checking that the type assertion in this function doesn't panic
 			sawRWimages = true
 		}


### PR DESCRIPTION
RFC: this is a ~demo, only migrating one function out of several.

This replaces one kind of boilerplate with another, but overall seems a bit less repetitive. The primary benefit is that the code working within the locked stores can `return` directly, without boilerplate, and there is no need to manually declare a `func(…)` for the loop body.

The `for store, err := range` syntax is a bit weird, admittedly, but maybe worth it.

The primary downside is that this really doesn’t work for the exactly-one-closure-call helpers (`writeTo…Store`):
- Using `for store, err := range writeToSingleStore` is very unintuitive, but maybe acceptable with good helper names
- But Go doesn’t recognize that the loop body executes exactly once, and that if the loop body always `return`s, there is no need for the code afterwards to `return` as well. So every caller would need to add an unreachable invented `return` there… and that seems a bit much for me.

So, we would end up with two rather different helper patterns instead of ~one. I’m really unsure whether it is worth it. It might well make sense to leave the code as is, and to wait another 1/5/10 years for Go to gain type inference and a convenient closure syntax.