### PR TITLE
Fix: Overlay fails with a permission error when trying to create and access layers

### DIFF
--- a/pkg/fileutils/exists_unix.go
+++ b/pkg/fileutils/exists_unix.go
@@ -13,7 +13,7 @@ import (
 func Exists(path string) error {
 	// It uses unix.Faccessat which is a faster operation compared to os.Stat for
 	// simply checking the existence of a file.
-	err := unix.Faccessat(unix.AT_FDCWD, path, unix.F_OK, 0)
+	err := unix.Faccessat(unix.AT_FDCWD, path, unix.F_OK, unix.AT_EACCESS)
 	if err != nil {
 		return &os.PathError{Op: "faccessat", Path: path, Err: err}
 	}
@@ -25,7 +25,7 @@ func Exists(path string) error {
 func Lexists(path string) error {
 	// It uses unix.Faccessat which is a faster operation compared to os.Stat for
 	// simply checking the existence of a file.
-	err := unix.Faccessat(unix.AT_FDCWD, path, unix.F_OK, unix.AT_SYMLINK_NOFOLLOW)
+	err := unix.Faccessat(unix.AT_FDCWD, path, unix.F_OK, unix.AT_SYMLINK_NOFOLLOW|unix.AT_EACCESS)
 	if err != nil {
 		return &os.PathError{Op: "faccessat", Path: path, Err: err}
 	}


### PR DESCRIPTION
When the overlay driver (and some others) tries to access the directories for the relevant layers it uses faccessat syscall (in fileutils.Exists() fileutils.Lexists()).
The syscall is missing the AT_EACCESS flag and so permissions to access the files are determined solely on the uid.
This error happens when we run with a user that has the correct capabilities to access the file (e.g cap_dac_override) but the file permissions don't allow the specific user.

This PR adds the AT_EACCESS flag to the faccessat syscall in Exists() and Lexists() functions to ensure that they will be able to verify file existence based on the effective user.

**How to reproduce** (adding a binary to help demonstrate the issue)

Compile this `faccessast_test` program
```
#include <stdio.h>
#include <fcntl.h>
#include <unistd.h>
#include <errno.h>
#include <sys/stat.h>
int main(int argc, char *argv[]) {
    if (argc != 2) {
        fprintf(stderr, "Usage: %s <path>\n", argv[0]);
        return 1;
    }
    const char *path = argv[1];
    
    if (faccessat(AT_FDCWD, path, F_OK, AT_SYMLINK_NOFOLLOW) == 0) {
        printf("[faccessat][without AT_EACCESS]\tFile exists: %s\n", path);
    } else {
        perror("[faccessat][without AT_EACCESS]");
    }
    
    if (faccessat(AT_FDCWD, path, F_OK, AT_SYMLINK_NOFOLLOW|AT_EACCESS) == 0) {
        printf("[faccessat][with AT_EACCESS]\tFile exists: %s\n", path);
    } else {
        perror("[faccessat][with AT_EACCESS]");
    }
    return 0;
}
```

Then use the following commands:
```
sudo mkdir -p /foo/a
sudo chmod -R 700 /foo/
sudo chown -R root:root /foo/
sudo setcap "cap_dac_override=eip" faccessat_test
./faccessat_test /foo/a
```