### PR TITLE
[crio-1.31] chore(deps): update dependency golangci/golangci-lint to v1.64.8

### DIFF
--- a/tests/tools/Makefile
+++ b/tests/tools/Makefile
@@ -29,6 +29,6 @@ $(BUILDDIR)/git-validation:
 $(BUILDDIR)/go-md2man:
 	$(call go-build,./vendor/github.com/cpuguy83/go-md2man)
 
-$(BUILDDIR)/golangci-lint: VERSION=v1.55.2
+$(BUILDDIR)/golangci-lint: VERSION=v1.64.8
 $(BUILDDIR)/golangci-lint:
 	curl -fsSL https://raw.githubusercontent.com/golangci/golangci-lint/$(VERSION)/install.sh | sh -s -- -b ./$(BUILDDIR) $(VERSION)


### PR DESCRIPTION
…v1.64.8