### PR TITLE
Switch to golangci-lint v2, fix new warnings

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,7 +1,17 @@
----
-run:
-  concurrency: 6
-  timeout: 5m
-linters:
+version: "2"
+
+formatters:
   enable:
     - gofumpt
+
+linters:
+  exclusions:
+    presets:
+      - comments
+      - std-error-handling
+  settings:
+    staticcheck:
+      checks:
+        - all
+        - -ST1003 # https://staticcheck.dev/docs/checks/#ST1003 Poorly chosen identifier.
+        - -QF1008 # https://staticcheck.dev/docs/checks/#QF1008 Omit embedded fields from selector expression.

--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ TESTFLAGS := $(shell $(GO) test -race $(BUILDFLAGS) ./pkg/stringutils 2>&1 > /de
 # N/B: This value is managed by Renovate, manual changes are
 # possible, as long as they don't disturb the formatting
 # (i.e. DO NOT ADD A 'v' prefix!)
-GOLANGCI_LINT_VERSION := 1.64.8
+GOLANGCI_LINT_VERSION := 2.0.2
 
 default all: local-binary docs local-validate local-cross ## validate all checks, build and cross-build\nbinaries and docs
 

--- a/drivers/aufs/aufs.go
+++ b/drivers/aufs/aufs.go
@@ -517,7 +517,7 @@ func (a *Driver) isParent(id, parent string) bool {
 	if parent == "" && len(parents) > 0 {
 		return false
 	}
-	return !(len(parents) > 0 && parent != parents[0])
+	return len(parents) == 0 || parent == parents[0]
 }
 
 // Diff produces an archive of the changes between the specified

--- a/drivers/aufs/aufs.go
+++ b/drivers/aufs/aufs.go
@@ -778,6 +778,6 @@ func (a *Driver) SupportsShifting() bool {
 }
 
 // Dedup performs deduplication of the driver's storage.
-func (d *Driver) Dedup(req graphdriver.DedupArgs) (graphdriver.DedupResult, error) {
+func (a *Driver) Dedup(req graphdriver.DedupArgs) (graphdriver.DedupResult, error) {
 	return graphdriver.DedupResult{}, nil
 }

--- a/drivers/copy/copy_linux.go
+++ b/drivers/copy/copy_linux.go
@@ -40,7 +40,7 @@ const (
 )
 
 // CopyRegularToFile copies the content of a file to another
-func CopyRegularToFile(srcPath string, dstFile *os.File, fileinfo os.FileInfo, copyWithFileRange, copyWithFileClone *bool) error { // nolint: revive,golint
+func CopyRegularToFile(srcPath string, dstFile *os.File, fileinfo os.FileInfo, copyWithFileRange, copyWithFileClone *bool) error { //nolint: revive
 	srcFile, err := os.Open(srcPath)
 	if err != nil {
 		return err
@@ -72,7 +72,7 @@ func CopyRegularToFile(srcPath string, dstFile *os.File, fileinfo os.FileInfo, c
 }
 
 // CopyRegular copies the content of a file to another
-func CopyRegular(srcPath, dstPath string, fileinfo os.FileInfo, copyWithFileRange, copyWithFileClone *bool) error { // nolint: revive,golint
+func CopyRegular(srcPath, dstPath string, fileinfo os.FileInfo, copyWithFileRange, copyWithFileClone *bool) error { //nolint: revive
 	// If the destination file already exists, we shouldn't blow it away
 	dstFile, err := os.OpenFile(dstPath, os.O_WRONLY|os.O_CREATE|os.O_EXCL, fileinfo.Mode())
 	if err != nil {

--- a/drivers/copy/copy_unsupported.go
+++ b/drivers/copy/copy_unsupported.go
@@ -24,7 +24,7 @@ func DirCopy(srcDir, dstDir string, _ Mode, _ bool) error {
 }
 
 // CopyRegularToFile copies the content of a file to another
-func CopyRegularToFile(srcPath string, dstFile *os.File, fileinfo os.FileInfo, copyWithFileRange, copyWithFileClone *bool) error { //nolint: revive,golint // "func name will be used as copy.CopyRegularToFile by other packages, and that stutters"
+func CopyRegularToFile(srcPath string, dstFile *os.File, fileinfo os.FileInfo, copyWithFileRange, copyWithFileClone *bool) error { //nolint: revive // "func name will be used as copy.CopyRegularToFile by other packages, and that stutters"
 	f, err := os.Open(srcPath)
 	if err != nil {
 		return err
@@ -35,6 +35,6 @@ func CopyRegularToFile(srcPath string, dstFile *os.File, fileinfo os.FileInfo, c
 }
 
 // CopyRegular copies the content of a file to another
-func CopyRegular(srcPath, dstPath string, fileinfo os.FileInfo, copyWithFileRange, copyWithFileClone *bool) error { //nolint:revive,golint // "func name will be used as copy.CopyRegular by other packages, and that stutters"
+func CopyRegular(srcPath, dstPath string, fileinfo os.FileInfo, copyWithFileRange, copyWithFileClone *bool) error { //nolint:revive // "func name will be used as copy.CopyRegular by other packages, and that stutters"
 	return chrootarchive.NewArchiver(nil).CopyWithTar(srcPath, dstPath)
 }

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -54,8 +54,8 @@ type MountOpts struct {
 	// Mount label is the MAC Labels to assign to mount point (SELINUX)
 	MountLabel string
 	// UidMaps & GidMaps are the User Namespace mappings to be assigned to content in the mount point
-	UidMaps []idtools.IDMap //nolint: revive,golint
-	GidMaps []idtools.IDMap //nolint: revive,golint
+	UidMaps []idtools.IDMap //nolint: revive
+	GidMaps []idtools.IDMap //nolint: revive
 	Options []string
 
 	// Volatile specifies whether the container storage can be optimized

--- a/drivers/overlay/composefs.go
+++ b/drivers/overlay/composefs.go
@@ -53,7 +53,7 @@ func generateComposeFsBlob(verityDigests map[string]string, toc interface{}, com
 	}
 
 	destFile := getComposefsBlob(composefsDir)
-	writerJson, err := getComposeFsHelper()
+	writerJSON, err := getComposeFsHelper()
 	if err != nil {
 		return fmt.Errorf("failed to find mkcomposefs: %w", err)
 	}
@@ -74,7 +74,7 @@ func generateComposeFsBlob(verityDigests map[string]string, toc interface{}, com
 		defer outFile.Close()
 
 		errBuf := &bytes.Buffer{}
-		cmd := exec.Command(writerJson, "--from-file", "-", "-")
+		cmd := exec.Command(writerJSON, "--from-file", "-", "-")
 		cmd.Stderr = errBuf
 		cmd.Stdin = dumpReader
 		cmd.Stdout = outFile

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -639,6 +639,8 @@ func SupportsNativeOverlay(home, runhome string) (bool, error) {
 	case "true":
 		logrus.Debugf("overlay: storage already configured with a mount-program")
 		return false, nil
+	case "false":
+		// Do nothing.
 	default:
 		needsMountProgram, err := scanForMountProgramIndicators(home)
 		if err != nil && !os.IsNotExist(err) {
@@ -652,7 +654,6 @@ func SupportsNativeOverlay(home, runhome string) (bool, error) {
 		}
 		// fall through to check if we find ourselves needing to use a
 		// mount program now
-	case "false":
 	}
 
 	for _, dir := range []string{home, runhome} {

--- a/internal/dedup/dedup.go
+++ b/internal/dedup/dedup.go
@@ -13,7 +13,7 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-var notSupported = errors.New("reflinks are not supported on this platform")
+var errNotSupported = errors.New("reflinks are not supported on this platform")
 
 const (
 	DedupHashInvalid DedupHashMethod = iota
@@ -134,7 +134,7 @@ func DedupDirs(dirs []string, options DedupOptions) (DedupResult, error) {
 						break
 					}
 					logrus.Debugf("Failed to deduplicate: %v", err)
-					if errors.Is(err, notSupported) {
+					if errors.Is(err, errNotSupported) {
 						return dedupBytes, err
 					}
 				}
@@ -153,7 +153,7 @@ func DedupDirs(dirs []string, options DedupOptions) (DedupResult, error) {
 			return nil
 		}); err != nil {
 			// if reflinks are not supported, return immediately without errors
-			if errors.Is(err, notSupported) {
+			if errors.Is(err, errNotSupported) {
 				return res, nil
 			}
 			return res, err

--- a/internal/dedup/dedup_linux.go
+++ b/internal/dedup/dedup_linux.go
@@ -98,7 +98,7 @@ func (d *dedupFiles) dedup(src, dst string, fiDst fs.FileInfo) (uint64, error) {
 	}
 
 	if errors.Is(err, unix.ENOTSUP) {
-		return 0, notSupported
+		return 0, errNotSupported
 	}
 	return 0, fmt.Errorf("failed to clone file %q: %w", src, err)
 }

--- a/internal/dedup/dedup_linux_test.go
+++ b/internal/dedup/dedup_linux_test.go
@@ -22,7 +22,7 @@ func wasVisited(d *dedupFiles, dev, ino uint64) bool {
 
 func TestRecordAndCheckInode(t *testing.T) {
 	d, err := newDedupFiles()
-	if err == notSupported {
+	if err == errNotSupported {
 		t.Skip("dedupFiles is not supported on this platform")
 	}
 

--- a/internal/dedup/dedup_unsupported.go
+++ b/internal/dedup/dedup_unsupported.go
@@ -9,19 +9,19 @@ import (
 type dedupFiles struct{}
 
 func newDedupFiles() (*dedupFiles, error) {
-	return nil, notSupported
+	return nil, errNotSupported
 }
 
 // isFirstVisitOf records that the file is being processed.  Returns true if the file was already visited.
 func (d *dedupFiles) isFirstVisitOf(fi fs.FileInfo) (bool, error) {
-	return false, notSupported
+	return false, errNotSupported
 }
 
 // dedup deduplicates the file at src path to dst path
 func (d *dedupFiles) dedup(src, dst string, fiDst fs.FileInfo) (uint64, error) {
-	return 0, notSupported
+	return 0, errNotSupported
 }
 
 func readAllFile(path string, info fs.FileInfo, fn func([]byte) (string, error)) (string, error) {
-	return "", notSupported
+	return "", errNotSupported
 }

--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -687,7 +687,7 @@ func extractTarFileEntry(path, extractDir string, hdr *tar.Header, reader io.Rea
 	case tar.TypeDir:
 		// Create directory unless it exists as a directory already.
 		// In that case we just want to merge the two
-		if fi, err := os.Lstat(path); !(err == nil && fi.IsDir()) {
+		if fi, err := os.Lstat(path); err != nil || !fi.IsDir() {
 			if err := os.Mkdir(path, mask); err != nil {
 				return err
 			}
@@ -1130,7 +1130,7 @@ loop:
 				continue
 			}
 
-			if !(fi.IsDir() && hdr.Typeflag == tar.TypeDir) {
+			if !fi.IsDir() || hdr.Typeflag != tar.TypeDir {
 				if err := os.RemoveAll(path); err != nil {
 					return err
 				}

--- a/pkg/archive/changes.go
+++ b/pkg/archive/changes.go
@@ -70,7 +70,7 @@ func (c changesByPath) Swap(i, j int)      { c[j], c[i] = c[i], c[j] }
 // files, we handle this by comparing for exact times, *or* same
 // second count and either a or b having exactly 0 nanoseconds
 func sameFsTime(a, b time.Time) bool {
-	return a == b ||
+	return a.Equal(b) ||
 		(a.Unix() == b.Unix() &&
 			(a.Nanosecond() == 0 || b.Nanosecond() == 0))
 }

--- a/pkg/archive/changes_linux.go
+++ b/pkg/archive/changes_linux.go
@@ -174,14 +174,7 @@ func (w *walker) walk(path string, i1, i2 os.FileInfo) (err error) {
 	ix1 := 0
 	ix2 := 0
 
-	for {
-		if ix1 >= len(names1) {
-			break
-		}
-		if ix2 >= len(names2) {
-			break
-		}
-
+	for ix1 < len(names1) && ix2 < len(names2) {
 		ni1 := names1[ix1]
 		ni2 := names2[ix2]
 

--- a/pkg/archive/changes_test.go
+++ b/pkg/archive/changes_test.go
@@ -72,13 +72,14 @@ func createSampleDir(t *testing.T, root string) {
 	now := time.Now()
 	for _, info := range files {
 		p := path.Join(root, info.path)
-		if info.filetype == Dir {
+		switch info.filetype {
+		case Dir:
 			err := os.MkdirAll(p, info.permissions)
 			require.NoError(t, err)
-		} else if info.filetype == Regular {
+		case Regular:
 			err := os.WriteFile(p, []byte(info.contents), info.permissions)
 			require.NoError(t, err)
-		} else if info.filetype == Symlink {
+		case Symlink:
 			err := os.Symlink(info.contents, p)
 			require.NoError(t, err)
 

--- a/pkg/archive/diff.go
+++ b/pkg/archive/diff.go
@@ -178,7 +178,7 @@ func UnpackLayer(dest string, layer io.Reader, options *TarOptions) (size int64,
 				if err := resetImmutable(path, &fi); err != nil {
 					return 0, err
 				}
-				if !(fi.IsDir() && hdr.Typeflag == tar.TypeDir) {
+				if !fi.IsDir() || hdr.Typeflag != tar.TypeDir {
 					if err := os.RemoveAll(path); err != nil {
 						return 0, err
 					}

--- a/pkg/chunked/storage_linux.go
+++ b/pkg/chunked/storage_linux.go
@@ -1271,7 +1271,7 @@ func getBlobAtConverterGoroutine(stream chan streamOrErr, streams chan io.ReadCl
 	tooManyStreams := false
 	streamsSoFar := 0
 
-	err := errors.New("Unexpected error in getBlobAtGoroutine")
+	err := errors.New("unexpected error in getBlobAtGoroutine")
 
 	defer func() {
 		if err != nil {

--- a/pkg/idtools/idtools.go
+++ b/pkg/idtools/idtools.go
@@ -429,25 +429,25 @@ func parseOverrideXattr(xstat []byte) (Stat, error) {
 	var stat Stat
 	attrs := strings.Split(string(xstat), ":")
 	if len(attrs) < 3 {
-		return stat, fmt.Errorf("The number of parts in %s is less than 3",
+		return stat, fmt.Errorf("the number of parts in %s is less than 3",
 			ContainersOverrideXattr)
 	}
 
 	value, err := strconv.ParseUint(attrs[0], 10, 32)
 	if err != nil {
-		return stat, fmt.Errorf("Failed to parse UID: %w", err)
+		return stat, fmt.Errorf("failed to parse UID: %w", err)
 	}
 	stat.IDs.UID = int(value)
 
 	value, err = strconv.ParseUint(attrs[1], 10, 32)
 	if err != nil {
-		return stat, fmt.Errorf("Failed to parse GID: %w", err)
+		return stat, fmt.Errorf("failed to parse GID: %w", err)
 	}
 	stat.IDs.GID = int(value)
 
 	value, err = strconv.ParseUint(attrs[2], 8, 32)
 	if err != nil {
-		return stat, fmt.Errorf("Failed to parse mode: %w", err)
+		return stat, fmt.Errorf("failed to parse mode: %w", err)
 	}
 	stat.Mode = os.FileMode(value) & os.ModePerm
 	if value&0o1000 != 0 {
@@ -484,7 +484,7 @@ func parseOverrideXattr(xstat []byte) (Stat, error) {
 				return stat, err
 			}
 		} else {
-			return stat, fmt.Errorf("Invalid file type %s", typ)
+			return stat, fmt.Errorf("invalid file type %s", typ)
 		}
 	}
 	return stat, nil
@@ -494,18 +494,18 @@ func parseDevice(typ string) (int, int, error) {
 	parts := strings.Split(typ, "-")
 	// If there are more than 3 parts, just ignore them to be forward compatible
 	if len(parts) < 3 {
-		return 0, 0, fmt.Errorf("Invalid device type %s", typ)
+		return 0, 0, fmt.Errorf("invalid device type %s", typ)
 	}
 	if parts[0] != "block" && parts[0] != "char" {
-		return 0, 0, fmt.Errorf("Invalid device type %s", typ)
+		return 0, 0, fmt.Errorf("invalid device type %s", typ)
 	}
 	major, err := strconv.Atoi(parts[1])
 	if err != nil {
-		return 0, 0, fmt.Errorf("Failed to parse major number: %w", err)
+		return 0, 0, fmt.Errorf("failed to parse major number: %w", err)
 	}
 	minor, err := strconv.Atoi(parts[2])
 	if err != nil {
-		return 0, 0, fmt.Errorf("Failed to parse minor number: %w", err)
+		return 0, 0, fmt.Errorf("failed to parse minor number: %w", err)
 	}
 	return major, minor, nil
 }

--- a/pkg/loopback/attach_loopback.go
+++ b/pkg/loopback/attach_loopback.go
@@ -16,8 +16,8 @@ import (
 // Loopback related errors
 var (
 	ErrAttachLoopbackDevice   = errors.New("loopback attach failed")
-	ErrGetLoopbackBackingFile = errors.New("Unable to get loopback backing file")
-	ErrSetCapacity            = errors.New("Unable set loopback capacity")
+	ErrGetLoopbackBackingFile = errors.New("unable to get loopback backing file")
+	ErrSetCapacity            = errors.New("unable set loopback capacity")
 )
 
 func stringToLoopName(src string) [LoNameSize]uint8 {

--- a/pkg/unshare/unshare_linux.go
+++ b/pkg/unshare/unshare_linux.go
@@ -249,7 +249,7 @@ func (c *Cmd) Start() (retErr error) {
 				if err != nil {
 					return fmt.Errorf("finding newgidmap: %w", err)
 				}
-				cmd := exec.Command(path, append([]string{pidString}, strings.Fields(strings.Replace(g.String(), "\n", " ", -1))...)...)
+				cmd := exec.Command(path, append([]string{pidString}, strings.Fields(g.String())...)...)
 				g.Reset()
 				cmd.Stdout = g
 				cmd.Stderr = g
@@ -309,7 +309,7 @@ func (c *Cmd) Start() (retErr error) {
 				if err != nil {
 					return fmt.Errorf("finding newuidmap: %w", err)
 				}
-				cmd := exec.Command(path, append([]string{pidString}, strings.Fields(strings.Replace(u.String(), "\n", " ", -1))...)...)
+				cmd := exec.Command(path, append([]string{pidString}, strings.Fields(u.String())...)...)
 				u.Reset()
 				cmd.Stdout = u
 				cmd.Stderr = u

--- a/pkg/unshare/unshare_linux.go
+++ b/pkg/unshare/unshare_linux.go
@@ -32,9 +32,9 @@ type Cmd struct {
 	*exec.Cmd
 	UnshareFlags               int
 	UseNewuidmap               bool
-	UidMappings                []specs.LinuxIDMapping // nolint: revive,golint
+	UidMappings                []specs.LinuxIDMapping //nolint: revive
 	UseNewgidmap               bool
-	GidMappings                []specs.LinuxIDMapping // nolint: revive,golint
+	GidMappings                []specs.LinuxIDMapping //nolint: revive
 	GidMappingsEnableSetgroups bool
 	Setsid                     bool
 	Setpgrp                    bool

--- a/pkg/unshare/unshare_linux.go
+++ b/pkg/unshare/unshare_linux.go
@@ -267,7 +267,7 @@ func (c *Cmd) Start() (retErr error) {
 					}
 					logrus.Warnf("Falling back to single mapping")
 					g.Reset()
-					g.Write([]byte(fmt.Sprintf("0 %d 1\n", os.Getegid())))
+					fmt.Fprintf(g, "0 %d 1\n", os.Getegid())
 				}
 			}
 			if !gidmapSet {
@@ -328,7 +328,7 @@ func (c *Cmd) Start() (retErr error) {
 
 					logrus.Warnf("Falling back to single mapping")
 					u.Reset()
-					u.Write([]byte(fmt.Sprintf("0 %d 1\n", os.Geteuid())))
+					fmt.Fprintf(u, "0 %d 1\n", os.Geteuid())
 				}
 			}
 			if !uidmapSet {

--- a/store.go
+++ b/store.go
@@ -3723,7 +3723,7 @@ func makeBigDataBaseName(key string) string {
 		if err != nil || size != 1 {
 			break
 		}
-		if ch != '.' && !(ch >= '0' && ch <= '9') && !(ch >= 'a' && ch <= 'z') {
+		if ch != '.' && (ch < '0' || ch > '9') && (ch < 'a' || ch > 'z') {
 			break
 		}
 	}

--- a/types/options.go
+++ b/types/options.go
@@ -394,7 +394,7 @@ func ReloadConfigurationFileIfNeeded(configFile string, storeOptions *StoreOptio
 	}
 
 	mtime := fi.ModTime()
-	if prevReloadConfig.storeOptions != nil && prevReloadConfig.mod == mtime && prevReloadConfig.configFile == configFile {
+	if prevReloadConfig.storeOptions != nil && mtime.Equal(prevReloadConfig.mod) && prevReloadConfig.configFile == configFile {
 		*storeOptions = *prevReloadConfig.storeOptions
 		return nil
 	}

--- a/types/utils.go
+++ b/types/utils.go
@@ -61,7 +61,7 @@ func reloadConfigurationFileIfNeeded(configFile string, storeOptions *StoreOptio
 	}
 
 	mtime := fi.ModTime()
-	if prevReloadConfig.storeOptions != nil && prevReloadConfig.mod == mtime && prevReloadConfig.configFile == configFile {
+	if prevReloadConfig.storeOptions != nil && mtime.Equal(prevReloadConfig.mod) && prevReloadConfig.configFile == configFile {
 		*storeOptions = *prevReloadConfig.storeOptions
 		return
 	}

--- a/types/utils.go
+++ b/types/utils.go
@@ -14,7 +14,7 @@ import (
 
 func expandEnvPath(path string, rootlessUID int) (string, error) {
 	var err error
-	path = strings.Replace(path, "$UID", strconv.Itoa(rootlessUID), -1)
+	path = strings.ReplaceAll(path, "$UID", strconv.Itoa(rootlessUID))
 	path = os.ExpandEnv(path)
 	newpath, err := filepath.EvalSymlinks(path)
 	if err != nil {


### PR DESCRIPTION
The new configuration file was initially generated by golangci-lint
migrate, when tweaked to minimize and simplify.
   
golangci-lint v2 switches to a new version of staticcheck which shows
much more warnings. Many of them are fixed here, and the rest
are suppressed. The suppressed ones are:
 - -ST1003 # https://staticcheck.dev/docs/checks/#ST1003 Poorly chosen identifier (impractical to change public API)
 - -QF1008 # https://staticcheck.dev/docs/checks/#QF1008 Omit embedded fields from selector expression (doesn't really improve code readability)
