### PR TITLE
idmap: fix first argument to open_tree

### DIFF
--- a/pkg/idmap/idmapped_utils.go
+++ b/pkg/idmap/idmapped_utils.go
@@ -25,7 +25,7 @@ func CreateIDMappedMount(source, target string, pid int) error {
 	}
 	defer userNsFile.Close()
 
-	targetDirFd, err := unix.OpenTree(0, source, unix.OPEN_TREE_CLONE)
+	targetDirFd, err := unix.OpenTree(unix.AT_FDCWD, source, unix.OPEN_TREE_CLONE)
 	if err != nil {
 		return &os.PathError{Op: "open_tree", Path: source, Err: err}
 	}


### PR DESCRIPTION
0 is a valid file descriptor, to ignore the argument we need to use AT_FDCWD.