### PR TITLE
fix minor review comment about the driver mutex and a minor lint issue

### DIFF
--- a/.cirrus.yml
+++ b/.cirrus.yml
@@ -126,7 +126,7 @@ lint_task:
         folder: $GOPATH/pkg/mod
     build_script: |
       apt-get update
-      apt-get install -y libbtrfs-dev
+      apt-get install -y libbtrfs-dev libsubid-dev
     test_script: |
       make TAGS=regex_precompile local-validate
       make lint

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -130,7 +130,7 @@ type Driver struct {
 	usingMetacopy    bool
 	usingComposefs   bool
 
-	stagingDirsLocksMutex *sync.Mutex
+	stagingDirsLocksMutex sync.Mutex
 	// stagingDirsLocks access is not thread safe, it is required that callers take
 	// stagingDirsLocksMutex on each access to guard against concurrent map writes.
 	stagingDirsLocks map[string]*lockfile.LockFile
@@ -441,7 +441,7 @@ func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) 
 		supportsVolatile:      supportsVolatile,
 		usingComposefs:        opts.useComposefs,
 		options:               *opts,
-		stagingDirsLocksMutex: &sync.Mutex{},
+		stagingDirsLocksMutex: sync.Mutex{},
 		stagingDirsLocks:      make(map[string]*lockfile.LockFile),
 	}
 

--- a/hack/libsubid_tag.sh
+++ b/hack/libsubid_tag.sh
@@ -5,7 +5,7 @@ fi
 tmpdir="$PWD/tmp.$RANDOM"
 mkdir -p "$tmpdir"
 trap 'rm -fr "$tmpdir"' EXIT
-cc -o "$tmpdir"/libsubid_tag -l subid -x c - > /dev/null 2> /dev/null << EOF
+cc -o "$tmpdir"/libsubid_tag -x c - -l subid > /dev/null 2> /dev/null << EOF
 #include <shadow/subid.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/pkg/idtools/idtools_supported.go
+++ b/pkg/idtools/idtools_supported.go
@@ -29,9 +29,7 @@ struct subid_range get_range(struct subid_range *ranges, int i)
 */
 import "C"
 
-var (
-	onceInit sync.Once
-)
+var onceInit sync.Once
 
 func readSubid(username string, isUser bool) (ranges, error) {
 	var ret ranges


### PR DESCRIPTION
driver/overlay: inline the mutex in driver

There is no need for the extra pointer indirection. With this Driver can
no longer be copied but that was never supported and now lint should
even catch a copy and warn as copying a Mutex is not allowed.

---

pkg/idtools: fix lint gofumpt error

CI doesn't seem to cover the libsubid build tag.

---

CI: add libsubid to lint task

This should ensure we run lint with the libsubid build tag.
Now this is not perfect either, as we do not cover the !libsubid but
that is only one single simple file.
