### PR TITLE
types: Always apply rootless path defaults

### DIFF
--- a/types/options.go
+++ b/types/options.go
@@ -160,19 +160,17 @@ func loadStoreOptionsFromConfFile(storageConf string) (StoreOptions, error) {
 		defaultRootlessGraphRoot = storageOpts.GraphRoot
 		storageOpts = StoreOptions{}
 		reloadConfigurationFileIfNeeded(storageConf, &storageOpts)
-		if usePerUserStorage() {
-			// If the file did not specify a graphroot or runroot,
-			// set sane defaults so we don't try and use root-owned
-			// directories
-			if storageOpts.RunRoot == "" {
-				storageOpts.RunRoot = defaultRootlessRunRoot
-			}
-			if storageOpts.GraphRoot == "" {
-				if storageOpts.RootlessStoragePath != "" {
-					storageOpts.GraphRoot = storageOpts.RootlessStoragePath
-				} else {
-					storageOpts.GraphRoot = defaultRootlessGraphRoot
-				}
+		// If the file did not specify a graphroot or runroot,
+		// set sane defaults so we don't try and use root-owned
+		// directories
+		if storageOpts.RunRoot == "" {
+			storageOpts.RunRoot = defaultRootlessRunRoot
+		}
+		if storageOpts.GraphRoot == "" {
+			if storageOpts.RootlessStoragePath != "" {
+				storageOpts.GraphRoot = storageOpts.RootlessStoragePath
+			} else {
+				storageOpts.GraphRoot = defaultRootlessGraphRoot
 			}
 		}
 	}


### PR DESCRIPTION
When running as non-root, the code previously checked if usePerUserStorage() before applying default paths for RunRoot and GraphRoot if they were missing from the configuration file. This check prevented defaults from being applied if the STORAGE_DRIVER environment variable was set.

Do not merge before https://github.com/containers/common/pull/2420