### PR TITLE
scope contiguity checks for idmap to mountProgram presence

### DIFF
--- a/drivers/aufs/aufs.go
+++ b/drivers/aufs/aufs.go
@@ -772,8 +772,8 @@ func (a *Driver) UpdateLayerIDMap(id string, toContainer, toHost *idtools.IDMapp
 	return fmt.Errorf("aufs doesn't support changing ID mappings")
 }
 
-// SupportsShifting tells whether the driver support shifting of the UIDs/GIDs in an userNS
-func (a *Driver) SupportsShifting() bool {
+// SupportsShifting tells whether the driver support shifting of the UIDs/GIDs to the provided mapping in an userNS
+func (a *Driver) SupportsShifting(uidmap, gidmap []idtools.IDMap) bool {
 	return false
 }
 

--- a/drivers/chown.go
+++ b/drivers/chown.go
@@ -131,7 +131,7 @@ func (n *naiveLayerIDMapUpdater) UpdateLayerIDMap(id string, toContainer, toHost
 	return ChownPathByMaps(layerFs, toContainer, toHost)
 }
 
-// SupportsShifting tells whether the driver support shifting of the UIDs/GIDs in an userNS
-func (n *naiveLayerIDMapUpdater) SupportsShifting() bool {
+// SupportsShifting tells whether the driver support shifting of the UIDs/GIDs to the provided mapping in an userNS
+func (n *naiveLayerIDMapUpdater) SupportsShifting(uidmap, gidmap []idtools.IDMap) bool {
 	return false
 }

--- a/drivers/driver.go
+++ b/drivers/driver.go
@@ -193,8 +193,9 @@ type LayerIDMapUpdater interface {
 	UpdateLayerIDMap(id string, toContainer, toHost *idtools.IDMappings, mountLabel string) error
 
 	// SupportsShifting tells whether the driver support shifting of the UIDs/GIDs in a
-	// image and it is not required to Chown the files when running in an user namespace.
-	SupportsShifting() bool
+	// image to the provided mapping and it is not required to Chown the files when running in
+	// an user namespace.
+	SupportsShifting(uidmap, gidmap []idtools.IDMap) bool
 }
 
 // Driver is the interface for layered/snapshot file system drivers.

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -2555,6 +2555,12 @@ func (d *Driver) supportsIDmappedMounts() bool {
 
 // SupportsShifting tells whether the driver support shifting of the UIDs/GIDs to the provided mapping in an userNS
 func (d *Driver) SupportsShifting(uidmap, gidmap []idtools.IDMap) bool {
+	if !idtools.IsContiguous(uidmap) {
+		return false
+	}
+	if !idtools.IsContiguous(gidmap) {
+		return false
+	}
 	if os.Getenv("_CONTAINERS_OVERLAY_DISABLE_IDMAP") == "yes" {
 		return false
 	}

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -2555,16 +2555,18 @@ func (d *Driver) supportsIDmappedMounts() bool {
 
 // SupportsShifting tells whether the driver support shifting of the UIDs/GIDs to the provided mapping in an userNS
 func (d *Driver) SupportsShifting(uidmap, gidmap []idtools.IDMap) bool {
-	if !idtools.IsContiguous(uidmap) {
-		return false
-	}
-	if !idtools.IsContiguous(gidmap) {
-		return false
-	}
 	if os.Getenv("_CONTAINERS_OVERLAY_DISABLE_IDMAP") == "yes" {
 		return false
 	}
 	if d.options.mountProgram != "" {
+		// fuse-overlayfs supports only contiguous mappings, since it performs the mapping on the
+		// upper layer too, to avoid https://github.com/containers/podman/issues/10272
+		if !idtools.IsContiguous(uidmap) {
+			return false
+		}
+		if !idtools.IsContiguous(gidmap) {
+			return false
+		}
 		return true
 	}
 	return d.supportsIDmappedMounts()

--- a/drivers/overlay/overlay.go
+++ b/drivers/overlay/overlay.go
@@ -828,7 +828,7 @@ func (d *Driver) Status() [][2]string {
 		{"Supports d_type", strconv.FormatBool(d.supportsDType)},
 		{"Native Overlay Diff", strconv.FormatBool(!d.useNaiveDiff())},
 		{"Using metacopy", strconv.FormatBool(d.usingMetacopy)},
-		{"Supports shifting", strconv.FormatBool(d.SupportsShifting())},
+		{"Supports shifting", strconv.FormatBool(d.SupportsShifting(nil, nil))},
 		{"Supports volatile", strconv.FormatBool(supportsVolatile)},
 	}
 }
@@ -1483,7 +1483,7 @@ func (d *Driver) get(id string, disableShifting bool, options graphdriver.MountO
 
 	readWrite := !inAdditionalStore
 
-	if !d.SupportsShifting() || options.DisableShifting {
+	if !d.SupportsShifting(options.UidMaps, options.GidMaps) || options.DisableShifting {
 		disableShifting = true
 	}
 
@@ -2553,8 +2553,8 @@ func (d *Driver) supportsIDmappedMounts() bool {
 	return false
 }
 
-// SupportsShifting tells whether the driver support shifting of the UIDs/GIDs in an userNS
-func (d *Driver) SupportsShifting() bool {
+// SupportsShifting tells whether the driver support shifting of the UIDs/GIDs to the provided mapping in an userNS
+func (d *Driver) SupportsShifting(uidmap, gidmap []idtools.IDMap) bool {
 	if os.Getenv("_CONTAINERS_OVERLAY_DISABLE_IDMAP") == "yes" {
 		return false
 	}

--- a/drivers/vfs/driver.go
+++ b/drivers/vfs/driver.go
@@ -312,9 +312,9 @@ func (d *Driver) AdditionalImageStores() []string {
 	return nil
 }
 
-// SupportsShifting tells whether the driver support shifting of the UIDs/GIDs in an userNS
-func (d *Driver) SupportsShifting() bool {
-	return d.updater.SupportsShifting()
+// SupportsShifting tells whether the driver support shifting of the UIDs/GIDs to the provided mapping in an userNS
+func (d *Driver) SupportsShifting(uidmap, gidmap []idtools.IDMap) bool {
+	return d.updater.SupportsShifting(uidmap, gidmap)
 }
 
 // UpdateLayerIDMap updates ID mappings in a from matching the ones specified

--- a/drivers/windows/windows.go
+++ b/drivers/windows/windows.go
@@ -986,8 +986,8 @@ func (d *Driver) UpdateLayerIDMap(id string, toContainer, toHost *idtools.IDMapp
 	return fmt.Errorf("windows doesn't support changing ID mappings")
 }
 
-// SupportsShifting tells whether the driver support shifting of the UIDs/GIDs in an userNS
-func (d *Driver) SupportsShifting() bool {
+// SupportsShifting tells whether the driver support shifting of the UIDs/GIDs to the provided mapping in an userNS
+func (d *Driver) SupportsShifting(uidmap, gidmap []idtools.IDMap) bool {
 	return false
 }
 

--- a/layers.go
+++ b/layers.go
@@ -1634,7 +1634,7 @@ func (r *layerStore) Mount(id string, options drivers.MountOpts) (string, error)
 		options.MountLabel = layer.MountLabel
 	}
 
-	if (options.UidMaps != nil || options.GidMaps != nil) && !r.driver.SupportsShifting() {
+	if (options.UidMaps != nil || options.GidMaps != nil) && !r.driver.SupportsShifting(options.UidMaps, options.GidMaps) {
 		if !reflect.DeepEqual(options.UidMaps, layer.UIDMap) || !reflect.DeepEqual(options.GidMaps, layer.GIDMap) {
 			return "", fmt.Errorf("cannot mount layer %v: shifting not enabled", layer.ID)
 		}

--- a/store.go
+++ b/store.go
@@ -1445,16 +1445,7 @@ func (s *store) writeToAllStores(fn func(rlstore rwLayerStore) error) error {
 // On entry:
 // - rlstore must be locked for writing
 func (s *store) canUseShifting(uidmap, gidmap []idtools.IDMap) bool {
-	if !s.graphDriver.SupportsShifting(uidmap, gidmap) {
-		return false
-	}
-	if uidmap != nil && !idtools.IsContiguous(uidmap) {
-		return false
-	}
-	if gidmap != nil && !idtools.IsContiguous(gidmap) {
-		return false
-	}
-	return true
+	return s.graphDriver.SupportsShifting(uidmap, gidmap)
 }
 
 // On entry:

--- a/store.go
+++ b/store.go
@@ -1445,7 +1445,7 @@ func (s *store) writeToAllStores(fn func(rlstore rwLayerStore) error) error {
 // On entry:
 // - rlstore must be locked for writing
 func (s *store) canUseShifting(uidmap, gidmap []idtools.IDMap) bool {
-	if !s.graphDriver.SupportsShifting() {
+	if !s.graphDriver.SupportsShifting(uidmap, gidmap) {
 		return false
 	}
 	if uidmap != nil && !idtools.IsContiguous(uidmap) {


### PR DESCRIPTION
move the check for a contiguous mapping to overlay when a mount program is specified, since this is required only for fuse-overlayfs, not native idmapped mounts.

Closes: https://issues.redhat.com/browse/RHEL-94967
Closes: https://github.com/containers/storage/issues/2345