### PR TITLE
fix: Ignore ENOENT error when calling unmount

### DIFF
--- a/pkg/mount/unmount_unix.go
+++ b/pkg/mount/unmount_unix.go
@@ -21,6 +21,9 @@ func unmount(target string, flags int) error {
 			// can be returned if flags are invalid, so this code
 			// assumes that the flags value is always correct.
 			return nil
+		case unix.ENOENT:
+			// Ignore "no such file or directory" error.
+			return nil
 		}
 		break
 	}


### PR DESCRIPTION
If the file or directoy doesn't exist then we can assume it is unmounted.

JIRA: https://issues.redhat.com/browse/RHEL-99488