### PR TITLE
pkg/archive.tarWriter.addFile(): don't change hardlink targets

### DIFF
--- a/pkg/archive/archive.go
+++ b/pkg/archive/archive.go
@@ -697,7 +697,10 @@ func (ta *tarWriter) addFile(headers *addFileData) error {
 	}
 
 	if !headers.fi.IsDir() && hasHardlinks(headers.fi) {
-		ta.SeenFiles[getInodeFromStat(headers.fi.Sys())] = headers.hdr.Name
+		ino := getInodeFromStat(headers.fi.Sys())
+		if _, seen := ta.SeenFiles[ino]; !seen {
+			ta.SeenFiles[ino] = headers.hdr.Name
+		}
 	}
 
 	return nil


### PR DESCRIPTION
When examining a file that we're adding to an archive to see if it's hard linked to another file that's already been written, or to one that might be written later, only set an entry in the inode->name map that points to the entry we're writing for the first file.  This keeps us from writing tar headers with Typeflag==TypeLink and a Linkname that points to another entry with Typeflag==TypeLink in cases where the inode has more than two names.

Fixes https://github.com/containers/buildah/issues/6297.