### PR TITLE
Move the repository to monorepo.

### DIFF
--- a/.github/workflows/auto-close-prs.yml
+++ b/.github/workflows/auto-close-prs.yml
@@ -1,0 +1,15 @@
+name: Close Pull Request
+
+on:
+  pull_request_target:
+    types: [opened]
+    branches:
+      - main
+
+jobs:
+  run:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: superbrothers/close-pull-request@9c18513d320d7b2c7185fb93396d0c664d5d8448
+      with:
+        comment: "This repository has been migrated to https://github.com/containers/container-libs. Please open your PR there."

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
+> [!WARNING]
+> This package was moved; please update your references to use `go.podman.io/storage` instead.
+> New development of this project happens on https://github.com/containers/container-libs.
+> For more information, check https://blog.podman.io/2025/08/upcoming-migration-of-three-containers-repositories-to-monorepo/.
+
 `storage` is a Go library which aims to provide methods for storing filesystem
 layers, container images, and containers.  A `containers-storage` CLI wrapper
 is also included for manual and scripting use.

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,4 @@
+// Deprecated: Use go.podman.io/storage instead.
 go 1.23.0
 
 // Warning: Ensure the "go" and "toolchain" versions match exactly to prevent unwanted auto-updates.


### PR DESCRIPTION
This commit:
- mentions the monorepo in the README.MD.
- deprecates the module in favor of go.podman.io/storage.
- adds github workflow to auto-close newly created PRs.