### PR TITLE
Add bcachefs storage driver with subvolume/snapshot support

### DIFF
--- a/drivers/bcachefs/bcachefs.go
+++ b/drivers/bcachefs/bcachefs.go
@@ -1,0 +1,394 @@
+//go:build linux
+
+package bcachefs
+
+import (
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"unsafe"
+
+	graphdriver "github.com/containers/storage/drivers"
+	"github.com/containers/storage/internal/tempdir"
+	"github.com/containers/storage/pkg/directory"
+	"github.com/containers/storage/pkg/fileutils"
+	"github.com/containers/storage/pkg/idtools"
+	"github.com/containers/storage/pkg/mount"
+	"github.com/containers/storage/pkg/system"
+	"github.com/opencontainers/selinux/go-selinux/label"
+	"golang.org/x/sys/unix"
+)
+
+const (
+	defaultPerms = os.FileMode(0o555)
+
+	// _IOW(0xbc, 16, struct bch_ioctl_subvolume) - struct size 32 bytes
+	bchIoctlSubvolumeCreate = 0x4020bc10
+	// _IOW(0xbc, 17, struct bch_ioctl_subvolume)
+	bchIoctlSubvolumeDestroy = 0x4020bc11
+
+	bchSubvolSnapshotCreate = 1 << 0
+
+	// subvolCreateMode is the initial mode for subvolume creation, masked by umask in kernel
+	subvolCreateMode = 0o777
+)
+
+// bchIoctlSubvolume matches struct bch_ioctl_subvolume from libbcachefs/bcachefs_ioctl.h.
+// The Dirfd field is int32 to accommodate AT_FDCWD (-100).
+type bchIoctlSubvolume struct {
+	Flags  uint32
+	Dirfd  int32
+	Mode   uint16
+	Pad    [3]uint16
+	DstPtr uint64
+	SrcPtr uint64
+}
+
+func init() {
+	graphdriver.MustRegister("bcachefs", Init)
+}
+
+// Driver implements the graphdriver.Driver interface for bcachefs filesystems.
+type Driver struct {
+	home string
+}
+
+// Init returns a new bcachefs driver.
+// An error is returned if the home directory is not on a bcachefs filesystem.
+func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) {
+	fsMagic, err := graphdriver.GetFSMagic(home)
+	if err != nil {
+		return nil, err
+	}
+
+	if fsMagic != graphdriver.FsMagicBcachefs {
+		return nil, fmt.Errorf("%q is not on a bcachefs filesystem: %w", home, graphdriver.ErrPrerequisites)
+	}
+
+	if err := os.MkdirAll(filepath.Join(home, "subvolumes"), 0o700); err != nil {
+		return nil, err
+	}
+
+	if err := mount.MakePrivate(home); err != nil {
+		return nil, err
+	}
+
+	driver := &Driver{
+		home: home,
+	}
+
+	return graphdriver.NewNaiveDiffDriver(driver, graphdriver.NewNaiveLayerIDMapUpdater(driver)), nil
+}
+
+// isSubvolume checks if the given path is a bcachefs subvolume by comparing
+// the subvolume ID with its parent's subvolume ID using statx(2).
+func isSubvolume(p string) (bool, error) {
+	var stat unix.Statx_t
+	if err := unix.Statx(unix.AT_FDCWD, p, unix.AT_SYMLINK_NOFOLLOW, unix.STATX_SUBVOL, &stat); err != nil {
+		return false, err
+	}
+
+	parentPath := filepath.Dir(p)
+	var parentStat unix.Statx_t
+	if err := unix.Statx(unix.AT_FDCWD, parentPath, unix.AT_SYMLINK_NOFOLLOW, unix.STATX_SUBVOL, &parentStat); err != nil {
+		return false, err
+	}
+
+	return stat.Subvol != parentStat.Subvol, nil
+}
+
+// subvolCreate creates a new bcachefs subvolume at the specified absolute path.
+func subvolCreate(dstPath string) error {
+	if dstPath == "" {
+		return fmt.Errorf("destination path cannot be empty")
+	}
+
+	parentDir := filepath.Dir(dstPath)
+
+	fd, err := unix.Open(parentDir, unix.O_RDONLY|unix.O_DIRECTORY, 0)
+	if err != nil {
+		return fmt.Errorf("failed to open parent directory %s: %w", parentDir, err)
+	}
+	defer unix.Close(fd)
+
+	dstBytes := append([]byte(dstPath), 0)
+
+	args := bchIoctlSubvolume{
+		Flags:  0,
+		Dirfd:  unix.AT_FDCWD,
+		Mode:   subvolCreateMode,
+		DstPtr: uint64(uintptr(unsafe.Pointer(&dstBytes[0]))),
+		SrcPtr: 0,
+	}
+
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), bchIoctlSubvolumeCreate,
+		uintptr(unsafe.Pointer(&args)))
+	if errno != 0 {
+		return fmt.Errorf("failed to create bcachefs subvolume %s: %w", dstPath, errno)
+	}
+	return nil
+}
+
+// subvolSnapshot creates a read-write snapshot of srcPath at dstPath.
+// Both paths must be absolute paths on the same bcachefs filesystem.
+func subvolSnapshot(srcPath, dstPath string) error {
+	if srcPath == "" {
+		return fmt.Errorf("source path cannot be empty")
+	}
+	if dstPath == "" {
+		return fmt.Errorf("destination path cannot be empty")
+	}
+
+	parentDir := filepath.Dir(dstPath)
+
+	fd, err := unix.Open(parentDir, unix.O_RDONLY|unix.O_DIRECTORY, 0)
+	if err != nil {
+		return fmt.Errorf("failed to open parent directory %s: %w", parentDir, err)
+	}
+	defer unix.Close(fd)
+
+	dstBytes := append([]byte(dstPath), 0)
+	srcBytes := append([]byte(srcPath), 0)
+
+	args := bchIoctlSubvolume{
+		Flags:  bchSubvolSnapshotCreate,
+		Dirfd:  unix.AT_FDCWD,
+		Mode:   subvolCreateMode,
+		DstPtr: uint64(uintptr(unsafe.Pointer(&dstBytes[0]))),
+		SrcPtr: uint64(uintptr(unsafe.Pointer(&srcBytes[0]))),
+	}
+
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), bchIoctlSubvolumeCreate,
+		uintptr(unsafe.Pointer(&args)))
+	if errno != 0 {
+		return fmt.Errorf("failed to create bcachefs snapshot from %s to %s: %w", srcPath, dstPath, errno)
+	}
+	return nil
+}
+
+// subvolDelete recursively deletes a bcachefs subvolume and all nested child subvolumes.
+// The function walks the subvolume tree depth-first to ensure children are deleted before parents.
+func subvolDelete(dirpath, name string) error {
+	if name == "" {
+		return fmt.Errorf("subvolume name cannot be empty")
+	}
+
+	fullPath := filepath.Join(dirpath, name)
+
+	walkSubvolumes := func(p string, d fs.DirEntry, err error) error {
+		if err != nil {
+			if os.IsNotExist(err) && p != fullPath {
+				return nil
+			}
+			return fmt.Errorf("walking subvolumes: %w", err)
+		}
+		if d.IsDir() && p != fullPath {
+			isSub, err := isSubvolume(p)
+			if err != nil {
+				if os.IsNotExist(err) {
+					return nil
+				}
+				return fmt.Errorf("failed to check if %s is a subvolume: %w", p, err)
+			}
+			if isSub {
+				parentPath := filepath.Dir(p)
+				if err := subvolDelete(parentPath, d.Name()); err != nil {
+					return fmt.Errorf("failed to destroy bcachefs child subvolume (%s) of parent (%s): %w", p, parentPath, err)
+				}
+			}
+		}
+		return nil
+	}
+	if err := filepath.WalkDir(fullPath, walkSubvolumes); err != nil {
+		return fmt.Errorf("recursively walking subvolumes for %s failed: %w", fullPath, err)
+	}
+
+	fd, err := unix.Open(dirpath, unix.O_RDONLY|unix.O_DIRECTORY, 0)
+	if err != nil {
+		return fmt.Errorf("failed to open directory %s: %w", dirpath, err)
+	}
+	defer unix.Close(fd)
+
+	fullPathBytes := append([]byte(fullPath), 0)
+
+	args := bchIoctlSubvolume{
+		Flags:  0,
+		Dirfd:  unix.AT_FDCWD,
+		Mode:   subvolCreateMode,
+		DstPtr: uint64(uintptr(unsafe.Pointer(&fullPathBytes[0]))),
+		SrcPtr: 0,
+	}
+
+	_, _, errno := unix.Syscall(unix.SYS_IOCTL, uintptr(fd), bchIoctlSubvolumeDestroy,
+		uintptr(unsafe.Pointer(&args)))
+	if errno != 0 {
+		return fmt.Errorf("failed to destroy bcachefs subvolume %s: %w", fullPath, errno)
+	}
+	return nil
+}
+
+func (d *Driver) subvolumesDir() string {
+	return filepath.Join(d.home, "subvolumes")
+}
+
+func (d *Driver) subvolumesDirID(id string) string {
+	return filepath.Join(d.subvolumesDir(), id)
+}
+
+// String returns the driver name.
+func (d *Driver) String() string {
+	return "bcachefs"
+}
+
+// Status returns current driver information in a two dimensional string array.
+func (d *Driver) Status() [][2]string {
+	return [][2]string{}
+}
+
+// Metadata returns empty metadata for this driver.
+func (d *Driver) Metadata(id string) (map[string]string, error) {
+	return nil, nil
+}
+
+// Cleanup unmounts the home directory.
+func (d *Driver) Cleanup() error {
+	return mount.Unmount(d.home)
+}
+
+// CreateFromTemplate creates a layer with the same contents and parent as another layer.
+func (d *Driver) CreateFromTemplate(id, template string, templateIDMappings *idtools.IDMappings, parent string, parentIDMappings *idtools.IDMappings, opts *graphdriver.CreateOpts, readWrite bool) error {
+	return d.Create(id, template, opts)
+}
+
+// CreateReadWrite creates a layer that is writable for use as a container file system.
+func (d *Driver) CreateReadWrite(id, parent string, opts *graphdriver.CreateOpts) error {
+	return d.Create(id, parent, opts)
+}
+
+// Create creates a new layer with the given id, using parent as the parent layer.
+// If parent is empty, a new subvolume is created; otherwise a snapshot of parent is created.
+func (d *Driver) Create(id, parent string, opts *graphdriver.CreateOpts) error {
+	subvolumes := d.subvolumesDir()
+	if err := os.MkdirAll(subvolumes, 0o700); err != nil {
+		return err
+	}
+
+	if parent == "" {
+		if err := subvolCreate(filepath.Join(subvolumes, id)); err != nil {
+			return err
+		}
+		if err := os.Chmod(filepath.Join(subvolumes, id), defaultPerms); err != nil {
+			return err
+		}
+	} else {
+		parentDir := d.subvolumesDirID(parent)
+		st, err := os.Stat(parentDir)
+		if err != nil {
+			return err
+		}
+		if !st.IsDir() {
+			return fmt.Errorf("%s: not a directory", parentDir)
+		}
+		if err := subvolSnapshot(parentDir, filepath.Join(subvolumes, id)); err != nil {
+			return err
+		}
+	}
+
+	mountLabel := ""
+	if opts != nil {
+		mountLabel = opts.MountLabel
+	}
+
+	return label.Relabel(filepath.Join(subvolumes, id), mountLabel, false)
+}
+
+// Remove removes the layer with the given id.
+func (d *Driver) Remove(id string) error {
+	dir := d.subvolumesDirID(id)
+	if err := fileutils.Exists(dir); err != nil {
+		return err
+	}
+
+	if err := subvolDelete(d.subvolumesDir(), id); err != nil {
+		return err
+	}
+	// Cleanup any remaining files in case subvolDelete didn't remove everything
+	if err := system.EnsureRemoveAll(dir); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Get returns the mountpoint for the layered filesystem referred to by id.
+func (d *Driver) Get(id string, options graphdriver.MountOpts) (string, error) {
+	dir := d.subvolumesDirID(id)
+	st, err := os.Stat(dir)
+	if err != nil {
+		return "", err
+	}
+	for _, opt := range options.Options {
+		if opt == "ro" {
+			continue
+		}
+		return "", fmt.Errorf("bcachefs driver does not support mount options")
+	}
+	if !st.IsDir() {
+		return "", fmt.Errorf("%s: not a directory", dir)
+	}
+
+	return dir, nil
+}
+
+// Put releases the system resources for the specified id.
+func (d *Driver) Put(id string) error {
+	return nil
+}
+
+// ReadWriteDiskUsage returns the disk usage of the writable directory for the ID.
+func (d *Driver) ReadWriteDiskUsage(id string) (*directory.DiskUsage, error) {
+	return directory.Usage(d.subvolumesDirID(id))
+}
+
+// Exists checks if the id exists in the filesystem.
+func (d *Driver) Exists(id string) bool {
+	dir := d.subvolumesDirID(id)
+	err := fileutils.Exists(dir)
+	return err == nil
+}
+
+// ListLayers returns a list of all layer ids managed by this driver.
+func (d *Driver) ListLayers() ([]string, error) {
+	entries, err := os.ReadDir(d.subvolumesDir())
+	if err != nil {
+		return nil, err
+	}
+	results := make([]string, 0, len(entries))
+	for _, entry := range entries {
+		if !entry.IsDir() {
+			continue
+		}
+		results = append(results, entry.Name())
+	}
+	return results, nil
+}
+
+// AdditionalImageStores returns additional image stores supported by the driver.
+func (d *Driver) AdditionalImageStores() []string {
+	return nil
+}
+
+// Dedup performs deduplication of the driver's storage.
+func (d *Driver) Dedup(req graphdriver.DedupArgs) (graphdriver.DedupResult, error) {
+	return graphdriver.DedupResult{}, nil
+}
+
+// DeferredRemove removes the layer, deferring physical file deletion if needed.
+func (d *Driver) DeferredRemove(id string) (tempdir.CleanupTempDirFunc, error) {
+	return nil, d.Remove(id)
+}
+
+// GetTempDirRootDirs returns the root directories for temporary directories.
+func (d *Driver) GetTempDirRootDirs() []string {
+	return []string{}
+}

--- a/drivers/bcachefs/bcachefs_test.go
+++ b/drivers/bcachefs/bcachefs_test.go
@@ -1,0 +1,103 @@
+//go:build linux
+
+package bcachefs
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	graphdriver "github.com/containers/storage/drivers"
+)
+
+func TestBcachefsSubvolumeOperations(t *testing.T) {
+	testRoot := os.Getenv("BCACHEFS_TEST_ROOT")
+	if testRoot == "" {
+		t.Skip("BCACHEFS_TEST_ROOT not set, skipping bcachefs tests")
+	}
+
+	testDir := filepath.Join(testRoot, "test-subvol")
+
+	t.Run("CreateSubvolume", func(t *testing.T) {
+		err := subvolCreate(testDir)
+		if err != nil {
+			t.Fatalf("Failed to create subvolume: %v", err)
+		}
+
+		if _, err := os.Stat(testDir); os.IsNotExist(err) {
+			t.Fatal("Subvolume directory does not exist after creation")
+		}
+	})
+
+	t.Run("IsSubvolume", func(t *testing.T) {
+		isSub, err := isSubvolume(testDir)
+		if err != nil {
+			t.Fatalf("Failed to check isSubvolume: %v", err)
+		}
+		if !isSub {
+			t.Error("Expected testDir to be detected as a subvolume")
+		}
+
+		isSub, err = isSubvolume(testRoot)
+		if err != nil {
+			t.Fatalf("Failed to check isSubvolume for testRoot: %v", err)
+		}
+		if !isSub {
+			t.Error("Expected testRoot to be detected as a subvolume")
+		}
+	})
+
+	t.Run("CreateSnapshot", func(t *testing.T) {
+		snapshotDir := filepath.Join(testRoot, "test-snapshot")
+		err := subvolSnapshot(testDir, snapshotDir)
+		if err != nil {
+			t.Fatalf("Failed to create snapshot: %v", err)
+		}
+
+		if _, err := os.Stat(snapshotDir); os.IsNotExist(err) {
+			t.Fatal("Snapshot directory does not exist after creation")
+		}
+
+		err = subvolDelete(testRoot, "test-snapshot")
+		if err != nil {
+			t.Fatalf("Failed to delete snapshot: %v", err)
+		}
+	})
+
+	t.Run("DeleteSubvolume", func(t *testing.T) {
+		err := subvolDelete(testRoot, "test-subvol")
+		if err != nil {
+			t.Fatalf("Failed to delete subvolume: %v", err)
+		}
+
+		if _, err := os.Stat(testDir); !os.IsNotExist(err) {
+			t.Fatal("Subvolume directory still exists after deletion")
+		}
+	})
+}
+
+func TestBcachefsDriverInit(t *testing.T) {
+	testRoot := os.Getenv("BCACHEFS_TEST_ROOT")
+	if testRoot == "" {
+		t.Skip("BCACHEFS_TEST_ROOT not set, skipping bcachefs tests")
+	}
+
+	if os.Getuid() != 0 {
+		t.Skip("Driver init requires root (for mount.MakePrivate)")
+	}
+
+	driverHome := filepath.Join(testRoot, "driver-test")
+	if err := os.MkdirAll(driverHome, 0o755); err != nil {
+		t.Fatalf("Failed to create test directory: %v", err)
+	}
+	defer os.RemoveAll(driverHome)
+
+	driver, err := Init(driverHome, graphdriver.Options{})
+	if err != nil {
+		t.Fatalf("Failed to initialize driver: %v", err)
+	}
+
+	if driver.String() != "bcachefs" {
+		t.Errorf("Expected driver name 'bcachefs', got '%s'", driver.String())
+	}
+}

--- a/drivers/bcachefs/dummy_unsupported.go
+++ b/drivers/bcachefs/dummy_unsupported.go
@@ -1,0 +1,10 @@
+//go:build !linux
+
+package bcachefs
+
+import graphdriver "github.com/containers/storage/drivers"
+
+// Init returns an error on non-Linux platforms as bcachefs is Linux-only.
+func Init(home string, options graphdriver.Options) (graphdriver.Driver, error) {
+	return nil, graphdriver.ErrNotSupported
+}

--- a/drivers/driver_linux.go
+++ b/drivers/driver_linux.go
@@ -47,6 +47,8 @@ const (
 	FsMagicXfs = FsMagic(0x58465342)
 	// FsMagicZfs filesystem id for Zfs
 	FsMagicZfs = FsMagic(0x2fc12fc1)
+	// FsMagicBcachefs filesystem id for bcachefs
+	FsMagicBcachefs = FsMagic(0xca451a4e)
 	// FsMagicOverlay filesystem id for overlay
 	FsMagicOverlay = FsMagic(0x794C7630)
 	// FsMagicFUSE filesystem id for FUSE
@@ -95,6 +97,7 @@ var (
 		"overlay",
 		"aufs",
 		"btrfs",
+		"bcachefs",
 		"zfs",
 		"vfs",
 	}
@@ -102,6 +105,7 @@ var (
 	// FsNames maps filesystem id to name of the filesystem.
 	FsNames = map[FsMagic]string{
 		FsMagicAufs:        "aufs",
+		FsMagicBcachefs:    "bcachefs",
 		FsMagicBtrfs:       "btrfs",
 		FsMagicCramfs:      "cramfs",
 		FsMagicEcryptfs:    "ecryptfs",

--- a/drivers/register/register_bcachefs.go
+++ b/drivers/register/register_bcachefs.go
@@ -1,0 +1,7 @@
+//go:build !exclude_graphdriver_bcachefs && linux
+
+package register
+
+import (
+	_ "github.com/containers/storage/drivers/bcachefs"
+)


### PR DESCRIPTION
Implement a new storage driver for bcachefs filesystems that uses subvolumes and snapshots for container layer management, similar to the existing btrfs driver.

Features:
- Implementation using direct ioctl syscalls
- Subvolume creation via BCH_IOCTL_SUBVOLUME_CREATE
- Snapshot creation with BCH_SUBVOL_SNAPSHOT_CREATE flag
- Subvolume detection using statx() with STATX_SUBVOL
- Recursive nested subvolume deletion
- Support for both root and rootless operation

Tested on my system with multiple images:
```
❯ podman run --rm docker.io/library/nginx:latest nginx -v
Trying to pull docker.io/library/nginx:latest...
Getting image source signatures
Copying blob 53d743880af4 done   | 
Copying blob 0e4bc2bd6656 done   | 
Copying blob 108ab8292820 done   | 
Copying blob 192e2451f875 done   | 
Copying blob 77fa2eb06317 done   | 
Copying blob b5feb73171bf done   | 
Copying blob de57a609c9d5 done   | 
Copying config 60adc2e137 done   | 
Writing manifest to image destination
/docker-entrypoint.sh: /docker-entrypoint.d/ is not empty, will attempt to perform configuration
/docker-entrypoint.sh: Looking for shell scripts in /docker-entrypoint.d/
/docker-entrypoint.sh: Launching /docker-entrypoint.d/10-listen-on-ipv6-by-default.sh
10-listen-on-ipv6-by-default.sh: info: Getting the checksum of /etc/nginx/conf.d/default.conf
10-listen-on-ipv6-by-default.sh: info: Enabled listen on IPv6 in /etc/nginx/conf.d/default.conf
/docker-entrypoint.sh: Sourcing /docker-entrypoint.d/15-local-resolvers.envsh
/docker-entrypoint.sh: Launching /docker-entrypoint.d/20-envsubst-on-templates.sh
/docker-entrypoint.sh: Launching /docker-entrypoint.d/30-tune-worker-processes.sh
/docker-entrypoint.sh: Configuration complete; ready for start up
nginx version: nginx/1.29.3

❯ podman run --rm docker.io/library/python:3.12-slim python --version
Trying to pull docker.io/library/python:3.12-slim...
Getting image source signatures
Copying blob b7ba6d2a1fc7 done   | 
Copying blob 490b9a1c25e4 done   | 
Copying blob 0e4bc2bd6656 skipped: already exists  
Copying blob 0674d14a155c done   | 
Copying config 445121148b done   | 
Writing manifest to image destination
Python 3.12.12

❯ podman image mount ceph:v18 
/var/lib/containers/storage/bcachefs/subvolumes/7a295044d828c8a95725ef60009582c7a8a0c455ab9abd9ee9b350b0dd4c6d30

❯ ls /var/lib/containers/storage/bcachefs/subvolumes/7a295044d828c8a95725ef60009582c7a8a0c455ab9abd9ee9b350b0dd4c6d30
afs  bin  boot  dev  etc  home  lib  lib64  lost+found  media  mnt  opt  proc  root  run  sbin  srv  sys  tmp  usr  var

❯ podman run --rm --entrypoint=/bin/python3 -ti ceph:v18 
Python 3.9.21 (main, Feb 10 2025, 00:00:00) 
[GCC 11.5.0 20240719 (Red Hat 11.5.0-5)] on linux
Type "help", "copyright", "credits" or "license" for more information.
>>>

❯ podman image ls
REPOSITORY                TAG         IMAGE ID      CREATED       SIZE
docker.io/library/python  3.12-slim   445121148b18  13 days ago   123 MB
docker.io/library/nginx   latest      60adc2e137e7  13 days ago   155 MB
docker.io/library/alpine  latest      706db57fb206  7 weeks ago   8.62 MB
quay.io/ceph/ceph         v18         0f5473a1e726  6 months ago  1.27 GB

❯ podman image rm ceph:v18 
Error: image used by 085e9c2853013e627c41e8e1833655a7b73cf4ba45a19556102c3675dc840900: image is in use by a container: consider listing external containers and force-removing image

❯ podman rm -f ceph18 
ceph18

❯ podman image rm ceph:v18 
Untagged: quay.io/ceph/ceph:v18
Deleted: 0f5473a1e726b0feaff0f41f8de8341c0a94f60365d4584f4c10bd6b40d44bc1

❯ pwd && ls | wc -l
/var/lib/containers/storage/bcachefs/subvolumes
11

❯ podman image prune -a
WARNING! This command removes all images without at least one container associated with them.
Are you sure you want to continue? [y/N] y
706db57fb2063f39f69632c5b5c9c439633fda35110e65587c5d85553fd1cc38
60adc2e137e757418d4d771822fa3b3f5d3b4ad58ef2385d200c9ee78375b6d5
445121148b187db67e48799f002500623fa22d9f635e522f4e0f345414bd9107

❯ ls | wc -l
0
```