### PR TITLE
composefs: Properly add verity info to generated dump file

### DIFF
--- a/pkg/chunked/dump/dump.go
+++ b/pkg/chunked/dump/dump.go
@@ -190,7 +190,10 @@ func dumpNode(out io.Writer, added map[string]*minimal.FileMetadata, links map[s
 	if _, err := fmt.Fprint(out, " "); err != nil {
 		return err
 	}
-	digest := verityDigests[payload]
+	digest := ""
+	if entry.Type == minimal.TypeReg || entry.Type == minimal.TypeLink {
+		digest = verityDigests["/"+payload]
+	}
 	if _, err := fmt.Fprint(out, escapedOptional([]byte(digest), ESCAPE_LONE_DASH)); err != nil {
 		return err
 	}


### PR DESCRIPTION
The payloads in the dump files are relative, but the verityDigests map has absolute filenames.

Also, lets only look for verity digests for regular files, not fot e.g. symlinks (where the payload is the target of the link).