### PR TITLE
unshare: add CAP_NET_ADMIN helper

### DIFF
--- a/pkg/unshare/unshare_linux.go
+++ b/pkg/unshare/unshare_linux.go
@@ -411,6 +411,9 @@ var (
 	hasCapSysAdminOnce sync.Once
 	hasCapSysAdminRet  bool
 	hasCapSysAdminErr  error
+	hasCapNetAdminOnce sync.Once
+	hasCapNetAdminRet  bool
+	hasCapNetAdminErr  error
 )
 
 // IsRootless tells us if we are running in rootless mode
@@ -752,4 +755,21 @@ func HasCapSysAdmin() (bool, error) {
 		hasCapSysAdminRet = currentCaps.Get(capability.EFFECTIVE, capability.CAP_SYS_ADMIN)
 	})
 	return hasCapSysAdminRet, hasCapSysAdminErr
+}
+
+// HasCapNetAdmin returns whether the current process has CAP_NET_ADMIN.
+func HasCapNetAdmin() (bool, error) {
+	hasCapNetAdminOnce.Do(func() {
+		currentCaps, err := capability.NewPid2(0)
+		if err != nil {
+			hasCapNetAdminErr = err
+			return
+		}
+		if err = currentCaps.Load(); err != nil {
+			hasCapNetAdminErr = err
+			return
+		}
+		hasCapNetAdminRet = currentCaps.Get(capability.EFFECTIVE, capability.CAP_NET_ADMIN)
+	})
+	return hasCapNetAdminRet, hasCapNetAdminErr
 }

--- a/pkg/unshare/unshare_unsupported.go
+++ b/pkg/unshare/unshare_unsupported.go
@@ -53,3 +53,8 @@ func ParseIDMappings(uidmap, gidmap []string) ([]idtools.IDMap, []idtools.IDMap,
 func HasCapSysAdmin() (bool, error) {
 	return os.Geteuid() == 0, nil
 }
+
+// HasCapNetAdmin returns whether the current process has CAP_NET_ADMIN.
+func HasCapNetAdmin() (bool, error) {
+	return os.Geteuid() == 0, nil
+}


### PR DESCRIPTION
Dependency support for the main Podman fix: https://github.com/podman-container-tools/podman/pull/28995

Bug report: https://github.com/podman-container-tools/podman/issues/18783

Adds `unshare.HasCapNetAdmin()`, matching the existing cached `HasCapSysAdmin()` helper, so callers can check effective `CAP_NET_ADMIN` without duplicating capability-loading code.

Podman's rootful bridge-networking preflight needs to check `CAP_NET_ADMIN` separately from `CAP_SYS_ADMIN`. Once this is merged and vendored, the Podman PR can replace its temporary local helper with `unshare.HasCapNetAdmin()`.

## Tests

- `GOOS=linux go test -c -o /private/tmp/storage-unshare.test ./pkg/unshare`
